### PR TITLE
add getLibraries endpoint to v2 schema

### DIFF
--- a/ecosystem/rpc/ton-center-http-api-v-2.json
+++ b/ecosystem/rpc/ton-center-http-api-v-2.json
@@ -1630,6 +1630,116 @@
         "security": []
       }
     },
+    "/getLibraries": {
+      "get": {
+        "tags": [
+          "blocks"
+        ],
+        "summary": "Get Libraries",
+        "description": "Get libraries codes.",
+        "operationId": "get_libraries_getLibraries_get",
+        "parameters": [
+          {
+            "description": "List of base64 encoded libraries hashes",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "title": "Libraries",
+              "description": "List of base64 encoded libraries hashes"
+            },
+            "name": "libraries",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "result": {
+                      "type": "object",
+                      "properties": {
+                        "@type": {
+                          "type": "string",
+                          "example": "smc.libraryResult"
+                        },
+                        "result": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "@type": {
+                                "type": "string",
+                                "example": "smc.libraryEntry"
+                              },
+                              "hash": {
+                                "type": "string",
+                                "example": "RZuqu83SGYHpN7D/5z+dUoN/hO08EXrRJg1TXsFigAo="
+                              },
+                              "data": {
+                                "type": "string",
+                                "description": "Base64-encoded library data"
+                              }
+                            }
+                          }
+                        },
+                        "@extra": {
+                          "type": "string",
+                          "example": "1758735556.956807:1:0.731451399868406"
+                        }
+                      }
+                    }
+                  },
+                  "required": ["ok", "result"]
+                },
+                "examples": {
+                  "sample": {
+                    "summary": "Example response",
+                    "value": {
+                      "ok": true,
+                      "result": {
+                        "@type": "smc.libraryResult",
+                        "result": [
+                          {
+                            "@type": "smc.libraryEntry",
+                            "hash": "RZuqu83SGYHpN7D/5z+dUoN/hO08EXrRJg1TXsFigAo=",
+                            "data": "te6ccgECDQEAA4kAART/APSkE/..."
+                          }
+                        ],
+                        "@extra": "1758735556.956807:1:0.731451399868406"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error"
+          },
+          "504": {
+            "description": "Lite Server Timeout"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "APIKeyQuery": []
+          }
+        ]
+      }
+    },
     "/getOutMsgQueueSizes": {
       "get": {
         "tags": [


### PR DESCRIPTION
it adds this endpoint in our rpc ref for TON Center: https://toncenter.com/api/v2/#/blocks/get_libraries_getLibraries_get

Closes issue: https://github.com/tact-lang/mintlify-ton-docs/issues/401