### PR TITLE
crosslink Tvm PDF 

### DIFF
--- a/ton/tvm.mdx
+++ b/ton/tvm.mdx
@@ -16,7 +16,7 @@ The aim of this text is to provide a description of the Telegram Open Network Vi
 
 <Aside type="caution" title="Reference Update Notice">
  The original PDF referred to an earlier version of the [Telegram Open Network](https://www.editionmultimedia.fr/wp-content/uploads/2019/10/Telegram-Open-Network-2017.pdf).  
- We have redirected links **[1.x.x]** to the updated documents — [The Open Network](/ton/ton) and the [TON Blockchain](/ton/tblkch).
+ We have redirected links **[1.x.x]** to the updated [The Open Network](/ton/ton) and the [TON Blockchain](/ton/tblkch) documents.
 </Aside>
 
 ## 1 Introduction


### PR DESCRIPTION
This whitepaper has only one reference cited:
**[1]: N. Durov, “Telegram Open Network,” 2017**

This reference is linked in only three sections:
* **Section 1.1.3** – [1, 2.5.14]
* **Section 3.1.10** – [1, 2.5.14]
* **Section 4.1.10** – [1, 5]

I have attached the following external link to the reference entry *N. Durov, “Telegram Open Network,” 2017* for easier access:
[https://www.editionmultimedia.fr/wp-content/uploads/2019/10/Telegram-Open-Network-2017.pdf](https://www.editionmultimedia.fr/wp-content/uploads/2019/10/Telegram-Open-Network-2017.pdf)

The 2017 PDF is not hosted on Mintlify (only the 2020 version is) hence the need for the external link. Also, this pdf does not crosslink with other whitepapers currently available on Mintlify.

Closes issue: [https://github.com/tact-lang/mintlify-ton-docs/issues/560](https://github.com/tact-lang/mintlify-ton-docs/issues/560)
