### PR TITLE
add decoder endpoint and decoded fields across schemas

### DIFF
--- a/ecosystem/rpc/toncenter/v3.yaml
+++ b/ecosystem/rpc/toncenter/v3.yaml
@@ -449,7 +449,7 @@ paths:
                 $ref: '#/components/schemas/RequestError'
   /api/v3/decode:
     get:
-      tags: 
+      tags:
       - Utils
       summary: Decode opcodes and bodies
       description: Decode opcodes (hex or decimal) and message bodies (base64 or hex).
@@ -488,7 +488,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/RequestError'
     post:
-      tags: 
+      tags:
       - Utils
       summary: Decode opcodes and bodies
       description: >


### PR DESCRIPTION
Closes https://github.com/tact-lang/mintlify-ton-docs/issues/730

This PR updates the API specification to reflect the new message decoder functionality in Toncenter API

- Added `/api/v3/decode` endpoint (GET + POST) 
- Added `DecodeRequest` and `DecodeResponse` schemas
- Added decoded payload helper fields
