### PR TITLE
chore: increase maximum width of the content area from 42 to 48rem

### DIFF
--- a/extra.css
+++ b/extra.css
@@ -30,3 +30,9 @@ td>a>code {
   border-bottom-right-radius: 0;
   text-decoration: none;
 }
+
+/* Make content area be a bit wider when there is enough place */
+
+#content-area {
+  max-width: 48rem;
+}


### PR DESCRIPTION
This is a rather safe change because:

1. We're changing `max-width`
2. It's changed by 6rem units, which aligns with other width constraints Maple theme has
3. We're not pushing the limits of `max-width` and not overlapping navigation nor table of contents (yet)