### PR TITLE
[AI] fix: tact.mdx

### DIFF
--- a/language/tact.mdx
+++ b/language/tact.mdx
@@ -6,16 +6,16 @@ sidebarTitle: "Tact"
 import { Aside } from '/snippets/aside.jsx';
 
 <Aside>
-  The official language of TON Blockchain is [Tolk](/language/tolk), and all other languages are deemed **legacy**. They are not necessarily outdated or deprecated, so you can still use them and contribute to their development, tooling or documentation.
+  The official language of TON Blockchain is [Tolk](/language/tolk), and all other languages are deemed **legacy**. They are not necessarily outdated or deprecated, so you can still use them and contribute to their development, tooling, or documentation.
 </Aside>
 
-Tact is a fresh programming language for TON Blockchain, focused on efficiency and ease of development. It is a good fit for complex smart contracts, quick onboarding and rapid prototyping.
+Tact is a programming language for TON Blockchain, focused on efficiency and ease of development. It is a good fit for complex smart contracts, quick onboarding, and rapid prototyping.
 
-Developed by [TON Studio](https://tonstudio.io), powered by the community — at the start of 2025, the number of _unique code_[^1] contracts deployed on the mainnet reached almost 28 thousand, of which about 33% were written in Tact. You can view some selected projects here: [Tact in production](#tact-in-production).
+Developed by [TON Studio](https://tonstudio.io), powered by the community — at the start of 2025, the number of _unique code_[^1] contracts deployed on the [Mainnet](/ton/glossary#mainnet) reached approximately 28,000, of which about 33% were written in Tact. You can view some selected projects here: [Tact in production](#tact-in-production).
 
-[^1]: The "unique code" means that each contract in the data sample has at least one TVM instruction that differs from the other contracts, excluding many preprocessed wallets with everything inlined — even seqno and a public key for signature verification!
+[^1]: The unique code means that each contract in the data sample has at least one TON Virtual Machine (TVM) instruction that differs from the other contracts, excluding many preprocessed wallets with everything inlined — even `seqno` and a public key for signature verification!
 
-Tact has undergone a comprehensive security audit by [Trail of Bits](https://www.trailofbits.com), a leading Web3 security firm.
+Tact has undergone a comprehensive security audit by [Trail of Bits](https://www.trailofbits.com).
 
 <Columns cols={3}>
   <Card
@@ -41,26 +41,25 @@ Tact has undergone a comprehensive security audit by [Trail of Bits](https://www
 
 The most prominent and distinctive features of Tact are:
 
-- Familiar and user-friendly TypeScript-like syntax.
-- Strong static type system with built-in [Structs], [Messages], and [maps], among others.
-- First-class [maps] support, with many methods and a convenient [`foreach` statement][foreach] for traversing.
-- Automatic (de)serialization of incoming messages and data structures.
-- Automatic routing of [internal, external, and bounced messages][recvfun].
-- Automatic handling of message types, including [binary, text, and fallback slices][recv].
-- No boilerplate functions for [sending messages] and deploying child contracts.
-- Reusable behaviors through [traits].
-- Support for low-level programming with [`asm` functions][asmfun].
+- Familiar and user-friendly TypeScript-like syntax
+- Strong static type system with built-in [structs], [messages], and [maps], among others
+- First-class [maps] support, with many methods and a convenient [`foreach` statement][foreach] for traversing
+- Automatic (de)serialization of incoming messages and data structures
+- Automatic routing of [internal, external, and bounced messages][recvfun]
+- Automatic handling of message types, including [binary, text, and fallback slices][recv]
+- No boilerplate functions for [sending messages] and deploying child contracts
+- Reusable behaviors through [traits]
+- Support for low-level programming with [`asm` functions][asmfun]
 - Generation of [single-file TypeScript wrappers] for convenient interactions with compiled contracts, which include:
-  - Type definitions for [Structs] and [Messages] observable in the [compilation report].
-  - Corresponding `storeStructureName()` and `loadStructureName()` functions for (de)serialization.
-  - All global and contract-level constants.
-  - Bi-directional records of exit codes: from their names to numbers and vice versa.
-  - Opcodes of all [Messages].
-  - A contract wrapper class with various helper functions for initialization, deployment, and message exchange.
-- Rich [standard library][stdlib].
-- Extensive [documentation].
-- Robust [tooling](#tooling).
-- ...and there's much more to come!
+  - Type definitions for [structs] and [messages] observable in the [compilation report]
+  - Corresponding `storeStructureName()` and `loadStructureName()` functions for (de)serialization
+  - All global and contract-level constants
+  - Bidirectional records of exit codes: from their names to numbers and vice versa
+  - Opcodes of all [messages]
+  - A contract wrapper class with various helper functions for initialization, deployment, and message exchange
+- Rich [standard library][stdlib]
+- [Documentation]
+- [Tooling](#tooling)
 
 [Structs]: https://docs.tact-lang.org/book/structs-and-messages#structs
 
@@ -90,8 +89,8 @@ The most prominent and distinctive features of Tact are:
 
 ## Security
 
-- [Security audit of Tact by the Trail of Bits (2025, PDF)](https://github.com/trailofbits/publications/blob/master/reviews/2025-01-ton-studio-tact-compiler-securityreview.pdf)
-  - Backup link: [PDF Report](https://github.com/tact-lang/website/blob/416073ed4056034639de257cb1e2815227f497cb/pdfs/2025-01-ton-studio-tact-compiler-securityreview.pdf)
+- [Security audit of Tact by Trail of Bits (2025, PDF)](https://github.com/tact-lang/website/blob/416073ed4056034639de257cb1e2815227f497cb/pdfs/2025-01-ton-studio-tact-compiler-securityreview.pdf)
+  - Backup link: [PDF Report](https://github.com/trailofbits/publications/blob/master/reviews/2025-01-ton-studio-tact-compiler-securityreview.pdf)
 
 ## Tact in production
 
@@ -104,9 +103,9 @@ Some selected software and applications based on contracts written in Tact, depl
 
 ###### Closed source
 
-- [Tradoor](https://tradoor.io) - Fast and social DEX on TON.
+- [Tradoor](https://tradoor.io) - Fast and social decentralized exchange (DEX) on TON.
   - See the [security audit report](https://www.tonbit.xyz/reports/Tradoor-Smart-Contract-Audit-Report-Summary.pdf) by TonBit.
-- [PixelSwap](https://www.pixelswap.io) - First modular and upgradeable DEX on TON.
+- [PixelSwap](https://www.pixelswap.io) - First modular and upgradeable decentralized exchange (DEX) on TON.
   - See the [security audit report](https://github.com/trailofbits/publications/blob/master/reviews/2024-12-pixelswap-dex-securityreview.pdf) by Trail of Bits.
 - [GasPump](https://gaspump.tg) - TON memecoin launchpad and trading platform.
 
@@ -136,27 +135,27 @@ pnpm add @tact-lang/compiler
 bun add @tact-lang/compiler
 ```
 
-Alternatively, you can install it globally as such:
+Alternatively, install it globally:
 
 ```bash
 npm i -g @tact-lang/compiler
 ```
 
-It will make the `tact` compiler available on your PATH, as well as:
+It makes the `tact` compiler available on your `PATH` and also provides:
 
-- a convenient `unboc` disassembler of a contract's code compiled into a [bag of cells](/ton/cells/boc) `.boc` format.
-- a formatter `tact-fmt`, which can format or check the formatting of individual Tact files and directories.
+- a convenient `unboc` disassembler of a contract's code compiled into a [Bag of Cells](/ton/cells/boc) (BoC) `.boc` format
+- a formatter `tact-fmt`, which can format or check the formatting of individual Tact files and directories
 
 ### Tooling
 
 ###### Extensions and plugins
 
-- [VS Code extension](https://marketplace.visualstudio.com/items?itemName=tonstudio.vscode-tact) - powerful and feature-rich extension for Visual Studio Code (VSCode) and VSCode-based editors like VSCodium, Cursor, Windsurf, and others.
+- [Visual Studio Code (VSCode) extension](https://marketplace.visualstudio.com/items?itemName=tonstudio.vscode-tact) - supports VSCode-based editors such as VSCodium, Cursor, and Windsurf
   - Get it on the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=tonstudio.vscode-tact).
   - Get it on the [Open VSX Registry](https://open-vsx.org/extension/tonstudio/vscode-tact).
   - Or install from the [`.vsix` files in nightly releases](https://github.com/tact-lang/tact-language-server/releases).
-- [JetBrains IDEs plugin](https://plugins.jetbrains.com/plugin/27290-tact#) - provides syntax highlighting, code navigation, and more.
-- [Language Server (LSP Server)](https://github.com/tact-lang/tact-language-server) - supports Sublime Text, (Neo)Vim, Helix, and other editors with LSP support.
+- [JetBrains IDEs plugin](https://plugins.jetbrains.com/plugin/27290-tact#) - provides syntax highlighting and code navigation
+- [Language Server (LSP)](https://github.com/tact-lang/tact-language-server) - supports Sublime Text, (Neo)Vim, Helix, and other editors with LSP support
 - [tact.vim](https://github.com/tact-lang/tact.vim) - Vim 8+ plugin.
 - [tact-sublime](https://github.com/tact-lang/tact-sublime) - Sublime Text 4 package.
   - Get it on the [Package Control](https://packagecontrol.io/packages/Tact).
@@ -168,26 +167,26 @@ It will make the `tact` compiler available on your PATH, as well as:
 
 ###### Utility
 
-- Formatter (`tact-fmt`) — The official formatter. It ships with the Tact Language Server, VS Code extension, and as a standalone binary with the compiler. You can invoke it by running `npx tact-fmt` in your Tact projects.
-- BoC Disassembler (`unboc`) — Disassembler for [`.boc`](/ton/cells/boc) files. Ships as a standalone binary with the compiler. You can invoke it by running `npx unboc` in your Tact projects.
+- Formatter (`tact-fmt`) — the official formatter. It ships with the Tact Language Server, VSCode extension, and as a standalone binary with the compiler. You can invoke it by running `npx tact-fmt` in your Tact projects.
+- BoC disassembler (`unboc`) — disassembler for [`.boc`](/ton/cells/boc) files. Ships as a standalone binary with the compiler. You can invoke it by running `npx unboc` in your Tact projects.
 
 ### Getting started
 
-For a quick start, read the ["Let's start!"](https://docs.tact-lang.org/#start) mini-guide in the Tact documentation. It uses the [Blueprint](https://github.com/ton-community/blueprint) development environment for writing, testing, and deploying smart contracts on TON Blockchain.
+For a quick start, read the [Let's start!](https://docs.tact-lang.org/#start) mini-guide in the Tact documentation. It uses the [Blueprint](https://github.com/ton-community/blueprint) development environment for writing, testing, and deploying smart contracts on TON Blockchain.
 
-If you want more manual control, use [tact-template](https://github.com/tact-lang/tact-template). It's a ready-to-use template with the development environment set up, including the Tact compiler with TypeScript + Jest, a local TON emulator, AI-based editor support, and examples of how to run tests.
+If you want more manual control, use [tact-template](https://github.com/tact-lang/tact-template). It's a ready-to-use template with the development environment set up, including the Tact compiler with TypeScript + Jest, a local TON emulator, artificial intelligence (AI)-based editor support, and examples of how to run tests.
 
-```shell
+```bash
 git clone --depth 1 https://github.com/tact-lang/tact-template
 ```
 
 ## Community
 
-If you can’t find the answer in the [docs](https://docs.tact-lang.org), or you’ve tried to do some local testing and it still didn’t help — don’t hesitate to reach out to Tact’s flourishing community:
+If you can’t find the answer in the [Tact documentation](https://docs.tact-lang.org), or you’ve tried to do some local testing and it still didn’t help — reach out to Tact’s community:
 
-- [`@tactlang` on Telegram](https://t.me/tactlang) - Main community chat and discussion group.
+- [`@tactlang` on Telegram](https://t.me/tactlang) - Main community chat and discussion group
 - [`@tactlang_ru` on Telegram](https://t.me/tactlang_ru) _(Russian)_
-- [`@tact_kitchen` on Telegram](https://t.me/tact_kitchen) - Channel with updates from the team.
+- [`@tact_kitchen` on Telegram](https://t.me/tact_kitchen) - Channel with updates from the team
 - [`@tact_language` on X/Twitter](https://x.com/tact_language)
 - [`tact-lang` organization on GitHub](https://github.com/tact-lang)
 - [`@ton_studio` on Telegram](https://t.me/ton_studio)


### PR DESCRIPTION
- [ ] **1. Missing Oxford comma in Aside list**

[language/tact.mdx:9](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L9)

The list "development, tooling or documentation" omits the serial comma for three items. Minimal fix: change to "development, tooling, or documentation". Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#61-commas-colons-semicolons

---

- [ ] **2. Missing Oxford comma in features sentence**

[language/tact.mdx:12](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L12)

The series "complex smart contracts, quick onboarding and rapid prototyping" lacks the serial comma. Minimal fix: change to "complex smart contracts, quick onboarding, and rapid prototyping." Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#61-commas-colons-semicolons

---

- [ ] **3. Use numerals with thousands separator**

[language/tact.mdx:14](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L14)

The phrase "almost 28 thousand" should use numerals with a thousands separator. Minimal fix: "almost 28,000". Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#141-numerals-and-separators

---

- [ ] **4. Quotation marks used for emphasis on a term**

[language/tact.mdx:16](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L16)

The term is presented as ""unique code"" for emphasis, not as a literal string. Quotes should be reserved for quotations or literal UI/log text. Minimal fix: remove quotes and keep the existing emphasis style, e.g., "Unique code means …" (or keep italics if needed for first mention). Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#62-quotation-marks-and-emphasis

---

- [ ] **5. Acronym not expanded on first mention (TVM)**

[language/tact.mdx:16](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L16)

"TVM instruction" appears before defining TVM. Minimal fix: expand on first mention: "TON Virtual Machine (TVM) instruction". Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#53-acronyms-and-terms

---

- [ ] **6. Marketing tone in security sentence**

[language/tact.mdx:18](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L18)

"a leading Web3 security firm" is promotional in a technical context. Minimal fix: remove the qualifier: "Tact has undergone a comprehensive security audit by Trail of Bits." Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#1-goals-and-principles-reader-first-answer-first

---

- [ ] **7. Forward‑looking filler in features list**

[language/tact.mdx:63](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L63)

"...and there's much more to come!" is non‑actionable and time‑relative. Minimal fix: remove this bullet. Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#172-timelessness

---

- [ ] **8. Incomplete clause before a colon**

[language/tact.mdx:145](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L145)

"It will make the `tact` compiler available on your PATH, as well as:" is not a complete clause before a colon. Minimal fix: "It makes the `tact` compiler available on your `PATH` and also provides:" Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#61-commas-colons-semicolons

---

- [ ] **9. Format environment variable as code**

[language/tact.mdx:145](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L145)

`PATH` appears as plain text; environment variables/tokens should be formatted as code. Minimal fix: wrap PATH with backticks: `PATH`. Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#62-quotation-marks-and-emphasis

---

- [ ] **10. Capitalization of glossary term (Bag of Cells)**

[language/tact.mdx:147](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L147)

Link text uses "bag of cells" in lower case; the glossary term is "Bag of Cells (BoC)". Minimal fix: capitalize the term in link text: "[Bag of Cells]". Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#53-acronyms-and-terms

---

- [ ] **11. Redundant phrasing “Language Server (LSP Server)”**

[language/tact.mdx:159](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L159)

The parenthetical repeats "Server". Minimal fix: "Language Server (LSP)". Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#57-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **12. Unnecessary quotation marks around link text**

[language/tact.mdx:176](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L176)

The link text ["Let's start!"] uses quotes for a title, which are not required and can hinder localization. Minimal fix: remove quotes: [Let's start!]. Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#62-quotation-marks-and-emphasis

---

- [ ] **13. Wordy boilerplate phrasing**

[language/tact.mdx:139](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L139)

"Alternatively, you can install it globally as such:" is wordy. Minimal fix: "Alternatively, install it globally:". Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#57-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **14. Acronym not expanded on first mention (DEX)**

[language/tact.mdx:107, language](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L107)/tact.mdx:109

"DEX" is used without first defining it. Minimal fix: expand on first mention in each item or once before the list: "decentralized exchange (DEX)". Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#53-acronyms-and-terms

---

- [ ] **15. Marketing adjectives in features list**

[language/tact.mdx:61, language](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L61)/tact.mdx:62

"Extensive [documentation]" and "Robust [tooling]" are promotional. Minimal fix: use neutral labels, e.g., "[Documentation]" and "[Tooling]". Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#1-goals-and-principles-reader-first-answer-first

---

- [ ] **16. Marketing adjective in opening sentence**

[language/tact.mdx:12](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L12)

"a fresh programming language" is promotional. Minimal fix: "a programming language" (remove "fresh"). Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#1-goals-and-principles-reader-first-answer-first

---

- [ ] **17. Marketing phrasing in VS Code extension bullet**

[language/tact.mdx:154](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L154)

"powerful and feature-rich" is promotional. Minimal fix: "Visual Studio Code (VS Code) extension" or list concrete capabilities only (syntax highlighting, code navigation). Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#1-goals-and-principles-reader-first-answer-first

---

- [ ] **18. Capitalized generic concepts mid-sentence in link text**

[language/tact.mdx:45, 54, 58](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L45-L58)

Generic concepts should be lowercase mid‑sentence. Change link text to lowercase: "[structs]", "[messages]" in bullets and sub-bullets. Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#13-2-general-casing-rules

---

- [ ] **19. Acronym introduction/usage inconsistency (VSCode)**

[language/tact.mdx:154, 171](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L154-L171)

Spell out at first mention, then use the acronym thereafter. Update the first link label to "Visual Studio Code (VSCode) extension" (instead of "VS Code extension"). In later mentions, prefer the acronym: change "VS Code extension" to "VSCode extension". Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#5-3-acronyms-and-terms

---

- [ ] **20. Acronym not expanded on first use (AI)**

[language/tact.mdx:178](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L178)

Expand AI on first mention: "artificial intelligence (AI)‑based editor support". Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#5-3-acronyms-and-terms

---

- [ ] **21. Marketing tone in community section**

[language/tact.mdx:186](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L186)

"flourishing community" is promotional. Use a neutral phrasing: "community". Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#1-goals-and-principles-reader-first-answer-first

---

- [ ] **22. Inconsistent code fence language tags for shell commands**

[language/tact.mdx:180 vs. 125](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L125-L180)

Both code blocks are shell commands; earlier uses ```bash while later uses ```shell. For consistency within the page, change the latter to ```bash. The guide requires specifying a language; when silent about which, prefer consistency with nearby examples. Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#10-1-general-rules

---

- [ ] **23. Hyphenation/spelling: “Bi-directional” → “Bidirectional”**

[language/tact.mdx:57](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L57)

Use the standard American English spelling without a hyphen. Replace “Bi-directional records of exit codes” with “Bidirectional records of exit codes”.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#5-6-spelling-and-contractions

---

- [ ] **24. List punctuation consistency (non-sentence fragments end without periods)**

[language/tact.mdx:147-148](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L147-L148)

The two list items under the PATH sentence are sentence fragments but end with periods. Remove terminal periods for consistency with §6.4 when items are not full sentences.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#6-4-lists

---

- [ ] **25. Generic link text (“docs”) should be descriptive**

[language/tact.mdx:186](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L186)

Link text “[docs]” is not descriptive. Use “[Tact documentation]” or similar: If you can’t find the answer in the [Tact documentation]…
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#12-1-link-text

---

- [ ] **26. Community list: inconsistent terminal punctuation**

[language/tact.mdx:188, language](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L188)/tact.mdx:190

Some items end with periods while others do not. For list items that are fragments, omit terminal periods consistently. Remove the final periods from lines 188 and 190.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#6-4-lists

---

- [ ] **27. Prefer precise, non-promotional wording (“and others”, “and more”)**

[language/tact.mdx:154, language](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L154)/tact.mdx:158

Avoid filler like “and others” / “and more”. Tighten to concrete examples or remove the filler: “VSCode-based editors such as VSCodium, Cursor, and Windsurf.” and “provides syntax highlighting and code navigation.”
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#5-2-plain-precise-wording

---

- [ ] **28. Use a stable permalink for the audit PDF**

[language/tact.mdx:93-94](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L93-L94)

The primary link points to a moving target on GitHub “master”. Use a versioned or permanent URL as primary (the existing backup permalink can be primary), and keep the other as a secondary link if needed.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#12-5-external-references

---

- [ ] **29. Link core term to Glossary on first useful mention (“mainnet”)**

[language/tact.mdx:14](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L14)

On first useful mention of a core TON term, link to the Glossary. Link “mainnet” to the Glossary entry: [Mainnet](/ton/glossary#mainnet). This follows the project-wide convention when the page does not define the term.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#12-2-what-to-link-and-what-not

---

- [ ] **30. Code identifier formatting in footnote (“seqno”)**

[language/tact.mdx:16](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L16)

Identifiers must use code font. Wrap seqno in backticks: “even `seqno` and a public key…”. “Public key” is a general concept and does not need code font. This is a basic code styling rule.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#6-3-code-styling

---

- [ ] **31. Acronym used before being defined (BoC)**

[language/tact.mdx:147, 171](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L147-L171)

“BoC” appears in “BoC Disassembler” before the acronym is introduced. Introduce the acronym at first mention of the concept. Minimal fix at the earlier mention: “compiled into a bag of cells (BoC)  format.” This aligns the later “BoC Disassembler” usage.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#5.3-acronyms-and-terms; [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#13.4-ton-specific-examples

---

- [ ] **32. Unnecessary article before proper noun (“the Trail of Bits”)**

[language/tact.mdx:93](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L93)

Use precise wording for proper names. Minimal fix: “Security audit of Tact by Trail of Bits (2025, PDF)”.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#5.2-plain-precise-wording

---

- [ ] **33. Hedgey approximation; prefer precise value or standard form**

[language/tact.mdx:14](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L14)

Phrase “almost 28 thousand” is a hedge and uses colloquial number style. Prefer a precise value or a clear approximation (for example, “approximately 28,000”). General knowledge: English technical prose uses digits with thousands separators for readability. If an exact value is required, this needs confirmation from the domain owner. Minimal fix: “approximately 28,000”.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **34. Fragment list items end with periods**

[language/tact.mdx:44](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L44)

In “Features,” list items are fragments but end with periods. For unordered lists, if items aren’t full sentences, omit terminal punctuation consistently. Minimal fix: remove trailing periods across the Features bullets (lines 44–63) and their sub-bullets (lines 54–59).
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#6-4-lists

---

- [ ] **35. Filler phrase in Community call-to-action**

[language/tact.mdx:186](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L186)

“don’t hesitate to reach out” is filler/instructional throat‑clearing. Prefer direct, concise phrasing. Minimal fix: “reach out to Tact’s community:”.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **36. Capitalization of generic nouns in utility bullets**

[language/tact.mdx:171, 172](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/tact.mdx#L171-L172)

Generic nouns mid‑sentence should be lowercase. Minimal fix: “Formatter (`tact-fmt`) — the official formatter.” and “BoC disassembler (`unboc`) — …”. Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#13-2-general-casing-rules