### PR TITLE
[AI] fix: syntax-and-semantics.mdx

### DIFF
--- a/language/TL-B/syntax-and-semantics.mdx
+++ b/language/TL-B/syntax-and-semantics.mdx
@@ -1,3 +1,4 @@
+---
 title: "Syntax and semantics"
 ---
 


### PR DESCRIPTION
- [ ] **1. Title not in sentence case**

[language/TL-B/syntax-and-semantics.mdx:2](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/TL-B/syntax-and-semantics.mdx#L2)

The frontmatter title uses Title Case (“Syntax and Semantics”). Per the style guide, all titles and headings must use sentence case. Minimal fix: change to “Syntax and semantics”.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#7.1-case-and-form

---

- [ ] **2. Heading contains code formatting**

[language/TL-B/syntax-and-semantics.mdx:393, 427](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/TL-B/syntax-and-semantics.mdx#L393-L427)

The headings “Implicit fields and the negate operator (`~`)” and “Negate operator (`~`) in type definition” include code formatting in headings, which is disallowed except for reference pages. Minimal fix: remove code spans from headings (e.g., “Implicit fields and the negate operator” and “Negate operator in type definition”) and mention `~` in the first sentence of the section.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#7.4-formatting-restrictions

---

- [ ] **3. Bold used for full-sentence emphasis**

[language/TL-B/syntax-and-semantics.mdx:178](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/TL-B/syntax-and-semantics.mdx#L178)

“Note: the total size of all fields …” is fully bolded. The guide forbids bolding entire sentences; use structure or plain text instead. Minimal fix: remove bold styling from the sentence (keep “Note:” as plain text) or convert to an `<Aside type="note">` callout if emphasis is needed.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#6.2-quotation-marks-and-emphasis

---

- [ ] **4. Tokens styled with bold instead of code font**

[language/TL-B/syntax-and-semantics.mdx:189](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/TL-B/syntax-and-semantics.mdx#L189)

The token-like names “Tick” and “Tock” are bolded in prose. Identifiers and tokens must use code font; bold must not be used for token styling. Minimal fix: replace “**Tick** and **Tock**” with “`Tick` and `Tock`”.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#6.2-quotation-marks-and-emphasis

---

- [ ] **5. Unlabeled code fences (missing language tags)**

[language/TL-B/syntax-and-semantics.mdx:66](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/TL-B/syntax-and-semantics.mdx#L66)–74,93–100,165–167,291–293

Several fenced code blocks don’t specify a language, which the guide requires. Minimal fixes:
- L66–74 (comments example): label as “tlb”.
- L93–100 (directory tree): label as “text”.
- L165–167 (bitstring transformation): label as “text”.
- L291–293 (A 32 example): label as “tlb”.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#10.1-general-rules

---

- [ ] **6. Image uses placeholder alt text**

[language/TL-B/syntax-and-semantics.mdx:12](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/TL-B/syntax-and-semantics.mdx#L12)

Alt text is “alt text”, which harms accessibility. Provide a descriptive alternative. Minimal fix: change to something like “TL‑B scheme examples diagram”.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#15.2-structure-and-tables

---

- [ ] **7. Terminology inconsistency: “schema” vs “scheme”**

[language/TL-B/syntax-and-semantics.mdx:157](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/TL-B/syntax-and-semantics.mdx#L157)

This page otherwise uses “scheme” for TL‑B; here it says “schema”. Minimal fix: replace “schema” with “scheme” for intra‑page consistency. When the guide is silent, prefer consistency with nearby pages per the workflow instructions.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#5.3-acronyms-and-terms

---

- [ ] **8. Grammar: “Fields definitions … is consist of”**

[language/TL-B/syntax-and-semantics.mdx:28](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/TL-B/syntax-and-semantics.mdx#L28)–30

“Fields definitions, each of which is consist of” is ungrammatical. Minimal fix: “Field definitions, each of which consists of:”.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#5.2-plain-precise-wording (basic grammar; general English)

---

- [ ] **9. Grammar: “Parameters declarations”**

[language/TL-B/syntax-and-semantics.mdx:46](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/TL-B/syntax-and-semantics.mdx#L46)

Use the singular noun phrase. Minimal fix: change “Parameters declarations” to “Parameter declarations”.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#5.2-plain-precise-wording

---

- [ ] **10. Awkward phrasing and agreement in combinator description**

[language/TL-B/syntax-and-semantics.mdx:54](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/TL-B/syntax-and-semantics.mdx#L54)–55

“a right side … that represented name … Could be parameterized.” has agreement and sentence‑fragment issues. Minimal fix: “the right side of a TL‑B scheme that represents the name of the defined combinator. It can be parameterized.”
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#5.2-plain-precise-wording

---

- [ ] **11. First‑mention acronym not expanded**

[language/TL-B/syntax-and-semantics.mdx:116](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/TL-B/syntax-and-semantics.mdx#L116)–118

“CRC32” appears without first‑mention expansion. Minimal fix: “cyclic redundancy check (CRC32)”.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#5.3-acronyms-and-terms

---

- [ ] **12. Grammar: “must computes”**

[language/TL-B/syntax-and-semantics.mdx:116](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/TL-B/syntax-and-semantics.mdx#L116)

Subject‑verb agreement error. Minimal fix: “TL‑B parser must compute a default 32‑bit constructor tag …”.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#5.2-plain-precise-wording

---

- [ ] **13. Non‑descriptive link text**

[language/TL-B/syntax-and-semantics.mdx:128](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/TL-B/syntax-and-semantics.mdx#L128)

Link text “general info page” is non‑descriptive. Minimal fix: change link text to “addresses — general information” (or similar descriptive text) while pointing to the same target.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#12.1-link-text

---

- [ ] **14. Prefer relative internal links**

[language/TL-B/syntax-and-semantics.mdx:128, 467](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/TL-B/syntax-and-semantics.mdx#L128-L467)

Internal links use absolute site‑root paths. The guide prefers relative, stable links. Minimal fixes:
- L128: change `/ton/addresses/addresses-general-info` → `../../ton/addresses/addresses-general-info`.
- L467: change `/language/TL-B/complex-and-non-trivial-examples` → `./complex-and-non-trivial-examples`.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#12.3-link-targets-and-format

---

- [ ] **15. Typo in identifier: `add_std` vs `addr_std`**

[language/TL-B/syntax-and-semantics.mdx:143](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/TL-B/syntax-and-semantics.mdx#L143)

The prose says “add_std”; the constructor is `addr_std`. Minimal fix: correct to “`addr_std`”.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#5.2-plain-precise-wording (clarity and correctness of tokens)

---

- [ ] **16. American spelling consistency: “parametrized” → “parameterized”**

[language/TL-B/syntax-and-semantics.mdx:104, 395](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/TL-B/syntax-and-semantics.mdx#L104-L395)

The page mixes “parametrized/parameterized”. Use American English spelling consistently. Minimal fix: replace “parametrized” with “parameterized”.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#5.6-spelling-and-contractions

---

- [ ] **17. Heading wording: “Libraries import”**

[language/TL-B/syntax-and-semantics.mdx:76](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/TL-B/syntax-and-semantics.mdx#L76)

Awkward noun phrase. Minimal fix: change the heading to “Library imports” (sentence case). This improves clarity and matches common heading patterns.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#7.1-case-and-form; [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#5.2-plain-precise-wording

---

- [ ] **18. Code identifiers not in code font**

[language/TL-B/syntax-and-semantics.mdx:372](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/TL-B/syntax-and-semantics.mdx#L372)–376

The list of cell types (Ordinary, PrunedBranch, Library, MerkleProof, MerkleUpdate) are identifiers but are not formatted in code font. Minimal fix: wrap each item in backticks.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#6.2-quotation-marks-and-emphasis (identifiers must use code formatting)

---

- [ ] **19. Time‑relative wording: “Currently”**

[language/TL-B/syntax-and-semantics.mdx:370](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/TL-B/syntax-and-semantics.mdx#L370)

“Currently, TVM allows …” uses time‑relative phrasing, which the guide discourages. Minimal fix: drop “Currently,” → “TVM allows …”.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#17.2-timelessness

---

- [ ] **20. Punctuation after “i.e.”**

[language/TL-B/syntax-and-semantics.mdx:7](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/TL-B/syntax-and-semantics.mdx#L7)

American English typically uses a comma after “i.e.” Minimal fix: change “i.e. type declaration” to “i.e., type declaration.” This relies on general American English punctuation conventions.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#5.2-plain-precise-wording (basic mechanics; general English)

---

- [ ] **21. Casing of TON chain names**

[language/TL-B/syntax-and-semantics.mdx:190](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/TL-B/syntax-and-semantics.mdx#L190)

“MasterChain” is used mid‑sentence; per TON‑specific casing rules, use lowercase “masterchain” mid‑sentence. Minimal fix: change to “masterchain”.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#b.-banned-and-preferred-terms (TON‑specific casing)

---

- [ ] **22. Non‑parallel wording: internal/external addresses**

[language/TL-B/syntax-and-semantics.mdx:128](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/TL-B/syntax-and-semantics.mdx#L128)–143

Sentence reads “either an internal message or an external,” which is not parallel and mismatches linked terminology (“internal/external addresses”). Minimal fix: “either an internal or an external address” (aligns with the linked page title). This is a style/grammar correction; no domain decision is introduced.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#5.2-plain-precise-wording
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#5.2-plain-precise-wording; [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#12.2-what-to-link (keep terminology aligned with the linked canonical page)

---

- [ ] **23. Heading uses Title Case (should be sentence case)**

[language/TL-B/syntax-and-semantics.mdx:9](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/TL-B/syntax-and-semantics.mdx#L9)

The H3 "TL-B Scheme" uses Title Case. Headings must use sentence case. Minimal fix: "TL‑B scheme".
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#7.1-case-and-form

---

- [ ] **24. Wordiness: “For the real‑world example, one may consider…”**

[language/TL-B/syntax-and-semantics.mdx:262](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/TL-B/syntax-and-semantics.mdx#L262)

Prefer plain, direct phrasing. Minimal fix: "For a real‑world example, consider the following `McStateExtra` combinator…" (General English style guidance used.)
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#5.2-plain-precise-wording

---

- [ ] **25. Grammar: “that parameterized by”**

[language/TL-B/syntax-and-semantics.mdx:283](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/TL-B/syntax-and-semantics.mdx#L283)

Current: "definition of a type A that parameterized by a natural number x". Minimal fix: "definition of a type A that is parameterized by a natural number x".
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#5.2-plain-precise-wording

---

- [ ] **26. Grammar: “as combinator's field”**

[language/TL-B/syntax-and-semantics.mdx:281](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/TL-B/syntax-and-semantics.mdx#L281)

Current: "as combinator's field." Minimal fix: "as a field of the combinator." (Clearer and grammatically correct.)
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#5.2-plain-precise-wording

---

- [ ] **27. Article usage: “The good real‑world example …”**

[language/TL-B/syntax-and-semantics.mdx:355](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/TL-B/syntax-and-semantics.mdx#L355)

Current: "The good real‑world example…" Minimal fix: "A good real‑world example…".
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#5.2-plain-precise-wording

---

- [ ] **28. Moving‑target link to GitHub `master` (use a stable permalink)**

[language/TL-B/syntax-and-semantics.mdx:472](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/TL-B/syntax-and-semantics.mdx#L472)

The reference links to `.../blob/master/crypto/block/block.tlb`, which is a moving target. Use a versioned/commit permalink for precision‑critical references. Minimal fix: replace with a Git commit/tag permalink to the exact file version. Domain owner must select the specific commit/tag.
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#12.5-external-references

---

- [ ] **29. Latinism “i.e.” in prose**

[language/TL-B/syntax-and-semantics.mdx:7](https://github.com/tact-lang/mintlify-ton-docs/blob/main/language/TL-B/syntax-and-semantics.mdx#L7)

Prefer plain wording over Latinisms. Minimal fix: replace "(i.e. type declaration)" with "(that is, type declaration)".
Rule: [contribute/style-guide-extended.mdx](https://github.com/tact-lang/mintlify-ton-docs/blob/main/contribute/style-guide-extended.mdx)#5.2-plain-precise-wording