### PR TITLE
[AI] fix: fift-and-tvm-assembly.mdx

### DIFF
--- a/language/fift/fift-and-tvm-assembly.mdx
+++ b/language/fift/fift-and-tvm-assembly.mdx
@@ -12,6 +12,7 @@ Fift executes at **compile-time** - when your compiler builds the smart contract
 - TVM opcode definitions in `Asm.fif`:
 
   Not runnable
+
   ```fift
   // Tuple primitives
   x{6F0} @Defop(4u) TUPLE
@@ -23,6 +24,7 @@ Fift executes at **compile-time** - when your compiler builds the smart contract
 - `wallet_v3_r2.fif`:
 
   Not runnable
+
   ```fift
   "Asm.fif" include
   <{ SETCP0 DUP IFNOTRET // Return if recv_internal
@@ -66,26 +68,28 @@ When using `toncli`, you can include large BoCs by:
 
 1. Editing `project.yaml` to include `fift/blob.fif`:
 
-  ```yaml
-  contract:
-    fift:
-      - fift/blob.fif
-    func:
-      - func/code.fc
-  ```
+```yaml
+contract:
+  fift:
+    - fift/blob.fif
+  func:
+    - func/code.fc
+```
 
 1. Adding the BoC to `fift/blob.boc`
 
 1. Including this code in `fift/blob.fif`:
 
-  Not runnable
-  ```fift
-  <b 8 4 u, 8 4 u, "fift/blob.boc" file>B B>boc ref, b> <s @Defop LDBLOB
-  ```
+Not runnable
+
+```fift
+<b 8 4 u, 8 4 u, "fift/blob.boc" file>B B>boc ref, b> <s @Defop LDBLOB
+```
 
 Now you can access the blob in your contract:
 
 Not runnable
+
 ```func
 cell load_blob() asm "LDBLOB";
 
@@ -99,6 +103,7 @@ cell load_blob() asm "LDBLOB";
 Fift primitives can't convert integers to strings at runtime because Fift operates at compile-time. For runtime conversion, use TVM assembly like this solution from TON Smart Challenge 3:
 
 Not runnable
+
 ```func
 tuple digitize_number(int value)
   asm "NIL WHILE:<{ OVER }>DO<{ SWAP TEN DIVMOD s1 s2 XCHG TPUSH }> NIP";
@@ -122,6 +127,7 @@ builder store_signed(builder msg, int v) inline_ref {
 Compare these implementations:
 
 Not runnable
+
 ```func
 int mul_mod(int a, int b, int m) inline_ref {               ;; 1232 gas units
   (_, int r) = muldivmod(a % m, b % m, m);


### PR DESCRIPTION
- [ ] **1. Incorrect BoC casing ('BOC' → 'BoC')**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/fift-and-tvm-assembly.mdx?plain=1#L10

“BoC” is the required abbreviation; the page uses “BOC”. Minimal fix: change “code BOC” to “code BoC”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-4-ton-specific-examples

---

- [ ] **2. Acronyms not expanded on first use (TON, TVM, BoC)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/fift-and-tvm-assembly.mdx?plain=1#L6

On first mention, spell out acronyms, then use the short form. Minimal fixes: “designed for The Open Network (TON)” and “TON Virtual Machine (TVM) assembly” in the opening paragraph; at first mention of BoC, write “bag of cells (BoC)”. Optionally link the first useful mentions to the Glossary per §12.2. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **3. Ordered list numbering should use 1. for every item**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/fift-and-tvm-assembly.mdx?plain=1#L65

The procedure under “Including large BoCs in contracts” numbers items as 1., 2., 3. Per the guide, each item should be written as “1.” and auto-numbered by the renderer. Minimal fix: change items 2. and 3. to start with “1.”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **4. Procedural headings use gerunds; use imperative form**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/fift-and-tvm-assembly.mdx?plain=1#L61-L93

Task/procedure headings should start with an imperative verb, not a gerund. Minimal fixes: “(Fift) Include large BoCs in contracts” (was “Including …”); “(TVM assembly) Convert integers to strings” (was “Converting …”). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-2-gerunds-and-labels

---

- [ ] **5. Link text not descriptive/mismatched with target heading**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/fift-and-tvm-assembly.mdx?plain=1#L131

The link text “section 5.2 Division” does not match the target anchor (`/tvm/instructions#A988`) and is not descriptive in-page. Minimal fix: change link text to “MULMOD (`A988`)” while keeping the same anchor. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text

---

- [ ] **6. Partial snippets missing required “Not runnable” labels**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/fift-and-tvm-assembly.mdx?plain=1#L14-L119

Several code blocks are focused excerpts that are not runnable by themselves (opcode excerpts, contract fragments, and function-only examples). Partial snippets must be labeled. Minimal fix: insert a plain “Not runnable” line immediately above each affected code fence. Example:
Not runnable
```fift
...
```
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **7. Filename should use code font**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/fift-and-tvm-assembly.mdx?plain=1#L55

Filenames and paths must be in code formatting. Minimal fix: wrap “Asm[Tests].fif” in backticks. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-3-code-styling

---

- [ ] **8. Intensifier in prose; prefer neutral phrasing**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/fift-and-tvm-assembly.mdx?plain=1#L55

“…demonstrates this perfectly…” uses an intensifier. Prefer neutral, factual language. Minimal fix: remove “perfectly” → “…demonstrates this — it’s essentially a collection…” (or simply “…demonstrates this; it’s essentially a collection…”).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **9. Missing Glossary link on first useful mention of TVM**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/fift-and-tvm-assembly.mdx?plain=1#L6

First mention of TVM should link to the Glossary. Minimal fix: link “TVM” the first time it appears to `/ton/glossary#ton-virtual-machine-tvm`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not

---

- [ ] **10. Link anchor and text for instruction A988 are not precise**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/fift-and-tvm-assembly.mdx?plain=1#L131

The link uses “/tvm/instructions#A988” and labels it “section 5.2 Division,” which does not match the target page’s anchor structure. Use a stable, specific anchor and accurate link text. Minimal fix: change the link to “/tvm/instructions#a988-mulmod” and the text to “instruction A988 (MULMOD)”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-3-links-and-anchors

---

- [ ] **11. Procedural section should use imperative heading**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/fift-and-tvm-assembly.mdx?plain=1#L115

“(TVM assembly) Efficient modulo multiplication” is a noun phrase in a procedure-like section. Use an imperative heading. Minimal fix: change to “Use efficient modulo multiplication (TVM assembly)”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form

---

- [ ] **12. Metaphorical “trainee” analogy; prefer plain wording**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/fift-and-tvm-assembly.mdx?plain=1#L53-L57

The extended “trainee/teaching language” analogy is an idiomatic metaphor and adds narrative instead of precise facts. Prefer neutral, direct explanation. Minimal fix: replace the analogy with a concise factual comparison (e.g., “Fift defines custom commands/macros at compile time; Asm[Tests].fif contains opcode definitions. TVM assembly executes contract code on-chain with fewer built-ins.”).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-5-global-and-inclusive-language; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **13. Frontmatter `noindex` should be boolean**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/fift-and-tvm-assembly.mdx?plain=1#L1-L4

Frontmatter sets `noindex: "true"` as a string. Use the supported boolean form. Minimal fix: change to `noindex: true`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-2-navigation-labels