### PR TITLE
[AI] fix: analytics.mdx

### DIFF
--- a/ecosystem/analytics.mdx
+++ b/ecosystem/analytics.mdx
@@ -19,7 +19,7 @@ Creating such pipelines from scratch can be resource-consuming, so we recommend 
 
 Dune Analytics consumes data from the public [TON Data Lake](#public-data-lake) and comes with a variety of raw and decoded tables.
 
-The [raw tables](https://dune.com/queries?category=canonical&namespace=ton) include:
+The [raw tables](https://dune.com/queries?category=canonical\&namespace=ton) include:
 
 - [Blocks](https://docs.dune.com/data-catalog/ton/blocks)
 - [Transactions](https://docs.dune.com/data-catalog/ton/transactions)
@@ -33,16 +33,16 @@ The [raw tables](https://dune.com/queries?category=canonical&namespace=ton) incl
 
 Apart from raw tables, there are decoded tables that allow you to work with high-level structures in a unified manner:
 
-- [NFT events](https://dune.com/queries?category=canonical&namespace=ton&id=ton.nft_events) — comprehensive source of NFT-related data including
-sales, transfers, and mints.
+- [NFT events](https://dune.com/queries?category=canonical\&namespace=ton\&id=ton.nft_events) — comprehensive source of NFT-related data including
+  sales, transfers, and mints.
 - [DEX trades](https://docs.dune.com/data-catalog/ton/dex_trades) — includes a unified data model for decentralized exchange (DEX) trades. The full list of
-supported DEXs is available in the [DEX trades section of the TON-ETL README](https://github.com/ton-studio/ton-etl/blob/main/datalake/README.md#dex-trades).
+  supported DEXs is available in the [DEX trades section of the TON-ETL README](https://github.com/ton-studio/ton-etl/blob/main/datalake/README.md#dex-trades).
 - [DEX pools](https://docs.dune.com/data-catalog/ton/dex_pools) — comes with the full history of DEX pool balances and total value locked (TVL) estimations
 
 Finally, two tables with off-chain metadata are available:
 
 - [Jetton metadata](https://docs.dune.com/data-catalog/ton/jetton_metadata)
-- [NFT metadata](https://dune.com/queries?category=canonical&namespace=ton&id=ton.nft_metadata)
+- [NFT metadata](https://dune.com/queries?category=canonical\&namespace=ton\&id=ton.nft_metadata)
 
 ### Bespoke data marts
 
@@ -54,18 +54,18 @@ Since TON handles complex [data structures](tvm/serialization/cells/) and doesn'
 
 The following protocols are decoded using this framework and serve as examples:
 
-- [EVAA](https://dune.com/queries?category=abstraction&namespace=evaa) ([implementation](https://github.com/duneanalytics/spellbook/tree/main/dbt_subprojects/daily_spellbook/models/evaa/ton))
-- [Affluent](https://dune.com/queries?category=abstraction&namespace=affluent) ([implementation](https://github.com/duneanalytics/spellbook/tree/main/dbt_subprojects/daily_spellbook/models/affluent/ton))
-- [StormTrade](https://dune.com/queries?category=abstraction&namespace=stormtrade) ([implementation](https://github.com/duneanalytics/spellbook/tree/main/dbt_subprojects/daily_spellbook/models/stormtrade/ton))
-- [TON DNS](https://dune.com/queries?category=abstraction&namespace=dns_ton) ([implementation](https://github.com/duneanalytics/spellbook/tree/main/dbt_subprojects/daily_spellbook/models/ton/dns))
+- [EVAA](https://dune.com/queries?category=abstraction\&namespace=evaa) ([implementation](https://github.com/duneanalytics/spellbook/tree/main/dbt_subprojects/daily_spellbook/models/evaa/ton))
+- [Affluent](https://dune.com/queries?category=abstraction\&namespace=affluent) ([implementation](https://github.com/duneanalytics/spellbook/tree/main/dbt_subprojects/daily_spellbook/models/affluent/ton))
+- [StormTrade](https://dune.com/queries?category=abstraction\&namespace=stormtrade) ([implementation](https://github.com/duneanalytics/spellbook/tree/main/dbt_subprojects/daily_spellbook/models/stormtrade/ton))
+- [TON DNS](https://dune.com/queries?category=abstraction\&namespace=dns_ton) ([implementation](https://github.com/duneanalytics/spellbook/tree/main/dbt_subprojects/daily_spellbook/models/ton/dns))
 
 #### Custom views
 
 In addition to decoding raw data, the Spellbook allows building custom materialized views. Some of them are widely used and maintained to be up to date:
 
-- [`ton.prices_daily`](https://dune.com/queries?category=abstraction&namespace=ton&id=ton.prices_daily) — prices calculated based on all other tables. The prices include jettons traded on DEXs, liquidity provider (LP) tokens for DEXs and perpetuals, tsUSDe, and other core assets. It is recommended to use this table if you need to build an estimation of assets denominated in TON or USD.
-- [`ton.accounts`](https://dune.com/queries?category=abstraction&namespace=ton&id=ton.accounts) — materialized view with information about all accounts. It comes with the latest TON balance, interface (if any), funding information, and other fields.
-- [`ton.latest_balances`](https://dune.com/queries?category=abstraction&namespace=ton&id=ton.latest_balances) — helper table to get the latest balances for TON and jettons.
+- [`ton.prices_daily`](https://dune.com/queries?category=abstraction\&namespace=ton\&id=ton.prices_daily) — prices calculated based on all other tables. The prices include jettons traded on DEXs, liquidity provider (LP) tokens for DEXs and perpetuals, tsUSDe, and other core assets. It is recommended to use this table if you need to build an estimation of assets denominated in TON or USD.
+- [`ton.accounts`](https://dune.com/queries?category=abstraction\&namespace=ton\&id=ton.accounts) — materialized view with information about all accounts. It comes with the latest TON balance, interface (if any), funding information, and other fields.
+- [`ton.latest_balances`](https://dune.com/queries?category=abstraction\&namespace=ton\&id=ton.latest_balances) — helper table to get the latest balances for TON and jettons.
 
 <Aside>All tables mentioned above are updated daily.</Aside>
 
@@ -79,11 +79,13 @@ If you're just starting to explore TON data on Dune, we recommend checking these
     arrow
     href="https://dune.com/ton_foundation/ton-quick-start"
   />
+
   <Card
     title="TON on-chain data analysis: quickstart on Dune"
     arrow
     href="https://blog.ton.org/ton-on-chain-data-analysis-dune"
   />
+
   <Card
     title="How to Analyze TON Users and Token Flows on Dune: A Practical Guide"
     arrow
@@ -99,11 +101,13 @@ For inspiration to build your own dashboards, check out these examples:
     arrow
     href="https://dune.com/ton_foundation/application-activity"
   />
+
   <Card
     title="TON & Ethena Boost Rewards Campaign"
     arrow
     href="https://dune.com/ton_foundation/tonandethena-staking-rewards-campaign"
   />
+
   <Card
     title="Telegram Gifts Dashboard"
     arrow
@@ -126,6 +130,7 @@ Dune integration runs on the public data lake from the [TON-ETL](https://github.
 The TON-ETL extracts raw data and performs decoding to create a unified view of high-level on-chain activity. The most important part is decoding DEX activity.
 
 The decoding implementation must solve the following tasks:
+
 - Decoding of swap events. The code must check the authenticity of the swap. For example, you cannot rely on the opcode alone since anyone can generate messages with your opcode
 - Extracting all swap-related fields: tokens sold and bought, amounts, query IDs, trader, router (if any), and pool
 - Fetching pool reserves and LP token supply, if applicable
@@ -148,7 +153,7 @@ While data availability and integrations are essential, building insightful dash
 
 The [TON Labels](https://github.com/ton-studio/ton-labels) project simplifies this process by providing a comprehensive taxonomy of addresses in the TON ecosystem. It covers active addresses across various categories including centralized exchanges (CEXs), decentralized applications (dApps), and DeFi protocols.
 
-You can access the latest labels either directly from [the build branch](https://github.com/ton-studio/ton-labels/blob/build/assets.json) or through Dune Analytics using the [`dune.ton_foundation.dataset_labels`](https://dune.com/queries?category=uploaded_data&id=dune.ton_foundation.dataset_labels) table.
+You can access the latest labels either directly from [the build branch](https://github.com/ton-studio/ton-labels/blob/build/assets.json) or through Dune Analytics using the [`dune.ton_foundation.dataset_labels`](https://dune.com/queries?category=uploaded_data\&id=dune.ton_foundation.dataset_labels) table.
 
 ## Other platforms
 


### PR DESCRIPTION
- [ ] **1. Hedge and pleonasm in Dune intro**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/analytics.mdx?plain=1#L16

The sentence uses the hedge “Basically,” and the pleonasm “SQL language.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#57-avoid-tautology-pleonasm-throat-clearing-and-circular-references
Minimal fix: remove “Basically,” and use “SQL” alone. For example: “One needs to be familiar with SQL to write queries, but the Dune AI prompt engine allows users to start working with data even without SQL knowledge.”

---

- [ ] **2. Missing Oxford comma in “Jetton events” bullet**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/analytics.mdx?plain=1#L28

List of three items omits the serial comma.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#61-commas-colons-semicolons
Minimal fix: “— comes with transfers, burns, and mints.”

---

- [ ] **3. Inconsistent punctuation in “Raw tables” list**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/analytics.mdx?plain=1#L24–28

Some list items end with periods while others don’t; items are not full sentences.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#64-lists
Minimal fix: remove terminal periods from lines 26–28 so all bullets are fragments without periods.

---

- [ ] **4. Missing Oxford comma in “NFT events” description**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/analytics.mdx?plain=1#L36–37

The phrase “sales, transfers and mints” lacks the serial comma.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#61-commas-colons-semicolons
Minimal fix: “sales, transfers, and mints.”

---

- [ ] **5. Non‑descriptive link text “here”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/analytics.mdx?plain=1#L38–39

Link text must be descriptive; “here” is not.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#121-link-text
Minimal fix: replace “available [here]” with descriptive text, e.g., “the DEX trades section in the TON‑ETL README,” linking to the same URL/anchor.

---

- [ ] **6. Unexpanded acronym “TVL” on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/analytics.mdx?plain=1#L40

Acronyms must be spelled out on first use.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#53-acronyms-and-terms
Minimal fix: “TVL” → “total value locked (TVL)”.

---

- [ ] **7. Unexpanded acronyms “EVMs” and “ABIs” on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/analytics.mdx?plain=1#L49-L53

Acronyms must be expanded on first use.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#53-acronyms-and-terms
Minimal fix: “EVMs” → “Ethereum Virtual Machines (EVMs)”; “ABIs” → “Application Binary Interfaces (ABIs)”.

---

- [ ] **8. Heading not in sentence case**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/analytics.mdx?plain=1#L114

Headings must use sentence case.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#71-case-and-form
Minimal fix: “## Public Data Lake” → “## Public data lake”.

---

- [ ] **9. Ordered list numbering style**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/analytics.mdx?plain=1#L141–143

Ordered lists must use `1.` for every item (auto‑numbered).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#64-lists
Minimal fix: change `1., 2., 3.` to `1.` for each step.

---

- [ ] **10. Improper casing: “TON Node” mid‑sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/analytics.mdx?plain=1#L118

Common nouns must not be capitalized mid‑sentence; use “TON node” for consistency.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#53-acronyms-and-terms
Minimal fix: “TON Node” → “TON node”. If needed, align with usage in https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/overview.mdx?plain=1.

---

- [ ] **11. Non‑descriptive link text “this article”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/analytics.mdx?plain=1#L122–124

Link text must describe the target; “this article” is vague.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#121-link-text
Minimal fix: change the anchor text to the article’s title (for example, “New dataset added to the AWS Public Blockchain Data: TON (The Open Network)”) while linking to the same URL.

---

- [ ] **12. Capitalization inconsistency: “Jettons” mid‑sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/analytics.mdx?plain=1#L68

Use lowercase “jettons” mid‑sentence to match terminology usage.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#53-acronyms-and-terms
Minimal fix: “Jettons” → “jettons”.

---

- [ ] **13. Fragment bullets ending with periods**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/analytics.mdx?plain=1#L129–131

These bullets are fragments but end with periods.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#64-lists
Minimal fix: remove terminal periods on lines 129–131.

---

- [ ] **14. Possible typo in external anchor: “pulic”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/analytics.mdx?plain=1#L137

The URL fragment contains “pulic,” which likely should be “public.” Broken/missing anchors are high severity.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#severity-model-release-blocking
Minimal fix: correct the fragment to “#near-real-time--data-streaming-via-public-kafka-topics” (verify the exact anchor in the target repo and update accordingly).

---

- [ ] **15. Proper noun not capitalized in H2 heading**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/analytics.mdx?plain=1#L14

“Dune analytics” appears as an H2, but “Dune Analytics” is a proper product name and the heading must be sentence case with proper nouns preserved. Minimal fix: change “## Dune analytics” to “## Dune Analytics”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **16. Proper noun not capitalized in prose**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/analytics.mdx?plain=1#L16-L49

Occurrences of “Dune analytics” in sentences should capitalize the product name. Minimal fix: change “Dune analytics …” to “Dune Analytics …” in these lines. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **17. Inconsistent punctuation across two‑item list**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/analytics.mdx?plain=1#L44-L45

Under “Finally, two tables…”, the second bullet (“NFT metadata”) ends with a period while the first (“Jetton metadata”) does not. Minimal fix: remove the period from the second item to keep list punctuation consistent. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **18. Acronyms not expanded on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/analytics.mdx?plain=1#L16-L131

Per first‑mention rule, several acronyms are used without expansion: SQL (16), DEX/DEXs (38–39), TVL (40), EVMs and ABIs (49), dbt (53), LP (66/131), MPP (118), AWS (121). Minimal fix: expand at first use, for example: “Structured Query Language (SQL)”, “decentralized exchange (DEX)”, “total value locked (TVL)”, “Ethereum Virtual Machine (EVM)”, “application binary interface (ABI)”, “data build tool (dbt)”, “liquidity provider (LP)”, “massively parallel processing (MPP)”, “Amazon Web Services (AWS)”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **19. Capitalization of common‑noun service name**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/analytics.mdx?plain=1#L156

“Analytics Service” is capitalized; unless this is the exact proper product name, capitalize only proper nouns. Minimal fix: “analytics service”. If capitalization is official branding, confirm and keep. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **20. Gerund in section heading (prefer imperative for procedures)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/analytics.mdx?plain=1#L72

Heading “Getting started with Dune” uses a gerund. Prefer an imperative form for task‑like sections. Minimal fix: “Get started with Dune”. If this section is intended as a concept rather than a procedure, a concise noun phrase is also acceptable. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-2-gerunds-and-labels

---

- [ ] **21. Inconsistent casing of project name “TON‑ETL” in link text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/analytics.mdx?plain=1#L142

Earlier the page uses “TON‑ETL”, but this line uses “ton‑etl”. Use consistent casing for names in prose; keep repository slug lowercase only in URLs. Minimal fix: change link text to “TON‑ETL”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **22. Capitalization of “TON ecosystem” in running text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/analytics.mdx?plain=1#L149-L157

“TON Ecosystem” capitalizes “Ecosystem” mid‑sentence; elsewhere the docs use “TON ecosystem” in running text (e.g., https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/index.mdx?plain=1#L28). Minimal fix: “TON ecosystem”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **23. Missing Oxford comma in three-item lists**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/analytics.mdx?plain=1#L28-L36–37, 66

Several three-item lists omit the serial comma. Examples: "transfers, burns and mints" and "sales, transfers and mints"; also add a comma after "tsUSDe" to separate the final item in "LP tokens for DEXs and perpetuals, tsUSDe and other core assets". Minimal fix: "transfers, burns, and mints"; "sales, transfers, and mints"; and "LP tokens for DEXs and perpetuals, tsUSDe, and other core assets". Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **24. Reversed acronym order and “etc.” in example list**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/analytics.mdx?plain=1#L118

Per first-use rules, spell out then give the acronym; also avoid open-ended "etc." in lists. Current: "MPP (Massively Parallel Processing) engines: Presto, Apache Spark, etc." Minimal fix: "massively parallel processing (MPP) engines such as Presto and Apache Spark." This expansion relies on general knowledge. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **25. “see below” phrasing after an anchor link**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/analytics.mdx?plain=1#L20

Avoid relative references like "see below"; link to the exact anchor instead (already present). Minimal fix: delete the parenthetical "(see below)". Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **26. Code styling missing for dataset/table identifiers in link text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/analytics.mdx?plain=1#L66–68

Identifiers must use code font. Dataset/table names like "ton.prices_daily", "ton.accounts", and "ton.latest_balances" appear as plain-text link labels, while later "dune.ton_foundation.dataset_labels" is correctly code-formatted. Minimal fix: wrap these link labels in backticks (e.g., [`ton.prices_daily`](…)). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-3-code-styling

---

- [ ] **27. Capitalization consistency for “TON Data Lake” vs. common “data lake”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/analytics.mdx?plain=1#L20-L114

If "TON Data Lake" is not an official proper name, use sentence case for the common noun ("TON data lake") and align with the section heading. If it is a proper name, keep capitalization and ensure consistent use across the page. Minimal fix requires domain confirmation. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules

---

- [ ] **28. Prefer relative internal links instead of absolute site paths**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/analytics.mdx?plain=1#L53-L141

Internal links use absolute paths (e.g., “/tvm/serialization/cells/”, “/ecosystem/node/overview”). Convert to relative paths (e.g., “tvm/serialization/cells/”, “ecosystem/node/overview”) for stability across domains.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format

---

- [ ] **29. Inconsistent punctuation in “Decoded tables” list**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/analytics.mdx?plain=1#L36–40

Bullets are fragments; one item ends with a period. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#64-lists. Minimal fix: remove the terminal period at line 40 to keep list-item punctuation consistent.