### PR TITLE
[AI] fix: config.mdx

### DIFF
--- a/ton/config.mdx
+++ b/ton/config.mdx
@@ -6,7 +6,7 @@ sidebarTitle: "Config"
 import { Aside } from '/snippets/aside.jsx';
 
 <Aside>
-View live values in [Tonviewer](https://tonviewer.com/config).
+  View live values in [Tonviewer](https://tonviewer.com/config).
 </Aside>
 
 This page provides a description of the configuration parameters used in the TON Blockchain.
@@ -20,7 +20,7 @@ This material should be read alongside the parameter list.
 You can view the parameter values in the [current configuration](https://tonviewer.com/config), and the method of writing them into [cells](/ton/cells/bag-of-cells) is outlined in the [block.tlb](https://github.com/ton-blockchain/ton/blob/master/crypto/block/block.tlb) file in Type Language Binary (TL‑B) format.
 
 <Aside>
-Configuration values are TL‑B typed cells serialized into bag of cells (BoC); see [canonical serialization](/ton/cells/boc) and [Bag of Cells](/ton/cells/bag-of-cells).
+  Configuration values are TL‑B typed cells serialized into bag of cells (BoC); see [canonical serialization](/ton/cells/boc) and [Bag of Cells](/ton/cells/bag-of-cells).
 </Aside>
 
 Use the right sidebar to navigate.
@@ -30,7 +30,7 @@ Use the right sidebar to navigate.
 This parameter is the address of a special smart contract that stores the blockchain's configuration. The configuration is stored in the contract to simplify its loading and modification during validator voting.
 
 <Aside>
-In the configuration parameter, only the hash portion of the address is recorded, as the contract always resides in the [masterchain](/ton/overview#masterchain) (workchain -1). Therefore, the full address of the contract is written as `-1:<value of the configuration parameter>`.
+  In the configuration parameter, only the hash portion of the address is recorded, as the contract always resides in the [masterchain](/ton/overview#masterchain) (workchain -1). Therefore, the full address of the contract is written as `-1:<value of the configuration parameter>`.
 </Aside>
 
 [Parameter #0 on mainnet](https://tonviewer.com/config#0)
@@ -46,7 +46,7 @@ This parameter is the address of the [elector smart contract](/ton/system-contra
 This parameter represents the address of the system, on behalf of which new Toncoins are minted and sent as rewards for validating the blockchain.
 
 <Aside>
-If parameter 2 is missing, parameter 0 is used instead (newly minted Toncoins come from the configuration smart contract).
+  If parameter 2 is missing, parameter 0 is used instead (newly minted Toncoins come from the configuration smart contract).
 </Aside>
 
 [Parameter #2 on mainnet](https://tonviewer.com/config#2)
@@ -56,7 +56,7 @@ If parameter 2 is missing, parameter 0 is used instead (newly minted Toncoins co
 This parameter is the address of the transaction fee collector.
 
 <Aside>
-If this parameter is missing, transaction fees are directed to the elector smart contract (parameter 1).
+  If this parameter is missing, transaction fees are directed to the elector smart contract (parameter 1).
 </Aside>
 
 [Parameter #3 on mainnet](https://tonviewer.com/config#3)
@@ -66,9 +66,9 @@ If this parameter is missing, transaction fees are directed to the elector smart
 This parameter is the address of the root Domain Name System (DNS) contract of the TON network.
 
 <Aside>
-For details, see [TON DNS & Domains](/services/dns) and the [original specification](https://github.com/ton-blockchain/TEPs/blob/master/text/0081-dns-standard.md).
+  For details, see [TON DNS & Domains](/services/dns) and the [original specification](https://github.com/ton-blockchain/TEPs/blob/master/text/0081-dns-standard.md).
 
-This contract is not responsible for selling **.ton** domains.
+  This contract is not responsible for selling **.ton** domains.
 </Aside>
 
 [Parameter #4 on mainnet](https://tonviewer.com/config#4)
@@ -78,7 +78,7 @@ This contract is not responsible for selling **.ton** domains.
 This parameter is responsible for minting fees for new currencies.
 
 <Aside>
-For background and process details, see the [Extra currency minter flow documentation](/techniques/tokens).
+  For background and process details, see the [Extra currency minter flow documentation](/techniques/tokens).
 </Aside>
 
 [Parameter #6 on mainnet](https://tonviewer.com/config#6)
@@ -94,7 +94,7 @@ This parameter stores the volume of each extra currency in circulation. The data
 This parameter indicates the network version and additional capabilities supported by the validators.
 
 <Aside>
-Validators are nodes in the TON Blockchain network that are responsible for creating new blocks and verifying transactions.
+  Validators are nodes in the TON Blockchain network that are responsible for creating new blocks and verifying transactions.
 </Aside>
 
 - `version`: This field specifies the version.
@@ -196,7 +196,7 @@ You can get the current `election_id` (if elections are ongoing) or the past one
 - `stake_held_for`: The period for which a validator's stake is held (for handling complaints) after the round expires.
 
 <Aside>
-Each value in the arguments is determined by the `uint32` data type.
+  Each value in the arguments is determined by the `uint32` data type.
 </Aside>
 
 ### Examples
@@ -302,7 +302,7 @@ This parameter represents the stake parameters configuration in the TON Blockcha
 - `max_stake_factor`: This parameter is a multiplier indicating how many times the maximum effective stake (pledge) can exceed the minimum stake sent by any other validator.
 
 <Aside>
-Each value in the arguments is determined by the `uint32` data type.
+  Each value in the arguments is determined by the `uint32` data type.
 </Aside>
 
 [Parameter #17 on mainnet](https://tonviewer.com/config#17)
@@ -320,9 +320,9 @@ This parameter represents the configuration for determining the prices for data 
 - `mc_bit_price_ps` and `mc_cell_price_ps`: These parameters represent the storage prices per bit and per cell in the TON masterchain for 65536 seconds.
 
 <Aside>
-`utime_since` accepts values in the `uint32` data type.
+  `utime_since` accepts values in the `uint32` data type.
 
-The rest accept values in the `uint64` data type.
+  The rest accept values in the `uint64` data type.
 </Aside>
 
 [Parameter #18 on mainnet](https://tonviewer.com/config#18)
@@ -348,7 +348,7 @@ These parameters define the cost of computations in the TON network. The complex
 - `freeze_due_limit` and `delete_due_limit`: Limits of accumulated storage fees (in nanotons) at which a contract is frozen and deleted, respectively.
 
 <Aside>
-You can find more about `gas_credit` and other parameters in the section of external messages [here](/ton/tblkch#2-1-3-external-messages-with-no-source-or-destination-address).
+  You can find more about `gas_credit` and other parameters in the section of external messages [here](/ton/tblkch#2-1-3-external-messages-with-no-source-or-destination-address).
 </Aside>
 
 [Parameter #20 on mainnet](https://tonviewer.com/config#20) | [Parameter #21 on mainnet](https://tonviewer.com/config#21)
@@ -372,7 +372,7 @@ These parameters set limits on the block, upon reaching which the block is final
 - `lt_delta`: This section sets the limits on the difference in logical time between the first and last transaction. Logical time is a concept used in the TON Blockchain for ordering events. The limits on underload, soft and hard limits, work the same as for size in bytes and gas.
 
 <Aside>
-If a shard has insufficient load and there is an intention to merge with a neighboring shard, the `soft_limit` indicates a threshold. When this threshold is exceeded, internal messages will stop being processed, while external messages will still be handled. External messages will continue to be processed until the total reaches a limit that is equal to half the sum of the `soft_limit` and `hard_limit`, or `(soft_limit + hard_limit) / 2`.
+  If a shard has insufficient load and there is an intention to merge with a neighboring shard, the `soft_limit` indicates a threshold. When this threshold is exceeded, internal messages will stop being processed, while external messages will still be handled. External messages will continue to be processed until the total reaches a limit that is equal to half the sum of the `soft_limit` and `hard_limit`, or `(soft_limit + hard_limit) / 2`.
 </Aside>
 
 [Parameter #22 on mainnet](https://tonviewer.com/config#22) | [Parameter #23 on mainnet](https://tonviewer.com/config#23)
@@ -394,7 +394,7 @@ Parameter 25 represents the configuration for the cost of sending messages in al
 - `ihr_price_factor`: This is a factor used to calculate the cost of immediate hypercube routing (IHR).
 
 <Aside>
-IHR is a method of message delivery in the TON Blockchain network, where messages are sent directly to the recipient's shardchain.
+  IHR is a method of message delivery in the TON Blockchain network, where messages are sent directly to the recipient's shardchain.
 </Aside>
 
 - `first_frac`: This parameter defines the fraction of the remaining amount that will be used for the first transition along the message route.
@@ -548,7 +548,7 @@ If absent, the default parameters are taken:
 - `max_acc_state_bits` = (1 \<\< 16) \* 1023
 
 <Aside>
-You can view more details about the standard parameters [here](https://github.com/ton-blockchain/ton/blob/fc9542f5e223140fcca833c189f77b1a5ae2e184/crypto/block/mc-config.h#L379) in the source code.
+  You can view more details about the standard parameters [here](https://github.com/ton-blockchain/ton/blob/fc9542f5e223140fcca833c189f77b1a5ae2e184/crypto/block/mc-config.h#L379) in the source code.
 </Aside>
 
 [Parameter #43 on mainnet](https://tonviewer.com/config#43)
@@ -558,7 +558,7 @@ You can view more details about the standard parameters [here](https://github.co
 This parameter defines the list of suspended addresses, which cannot be initialized until `suspended_until`. It only applies to yet uninitiated accounts. This is a measure for stabilizing the tokenomics (limiting early miners). If not set - there are no limitations. Each address is represented as an end node in this tree, and the tree-like structure allows efficient checking of whether an address is in the list.
 
 <Aside>
-The stabilization of the tokenomics is further described in the [official report](https://t.me/tonblockchain/178) of the **@tonblockchain** Telegram channel.
+  The stabilization of the tokenomics is further described in the [official report](https://t.me/tonblockchain/178) of the **@tonblockchain** Telegram channel.
 </Aside>
 
 [Parameter #44 on mainnet](https://tonviewer.com/config#44)
@@ -626,7 +626,7 @@ This parameter relates to bridges for wrapping tokens from other networks into t
 ## Negative parameters
 
 <Aside>
-Validators enforce TL‑B validity only for configuration parameters with non-negative indices. Values with negative indices are not validated against a specific `ConfigParam i` type. See the explanation in [Configuration parameters](/ton/config) section.
+  Validators enforce TL‑B validity only for configuration parameters with non-negative indices. Values with negative indices are not validated against a specific `ConfigParam i` type. See the explanation in [Configuration parameters](/ton/config) section.
 </Aside>
 
 ## Next steps


### PR DESCRIPTION
- [ ] **1. Plain wording: avoid “utilized”; use “used”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L14

Replace “some of which are utilized by the blockchain itself” with “some of which are used by the blockchain itself.” This follows the guidance to prefer common words over legalese.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **2. Throat‑clearing meta intro; make purpose direct**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L12-L15

The sentences “TON features a complex configuration… However, only a limited number of individuals fully understand… This article aims to offer users a straightforward explanation…” are throat‑clearing and verbose. Replace with a single, direct purpose sentence such as: “This page explains each TON configuration parameter and its purpose.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **3. Aside phrasing: “by using” → “in” (simpler wording)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L9

Change “You can view live values by using [Tonviewer]…” to “View live values in [Tonviewer]…”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **4. Remove filler/marketing tone about navigation**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L26

“All parameters are in place, and you won't get lost. For your convenience, please use the right sidebar for quick navigation.” Remove filler and “please”; keep a neutral, actionable sentence: “Use the right sidebar to navigate.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **5. Acronyms must be expanded on first mention (DNS, TVM, ADNL)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L64-L480

Add expansions and then use acronyms thereafter:
- “root DNS contract” → “root Domain Name System (DNS) contract”.
- “TON Virtual Machine” → “TON Virtual Machine (TVM)”.
- “ADNL address” → “Abstract Datagram Networking Layer (ADNL) address”. Optionally link to the network overview anchor.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **6. Terminology casing: use lower‑case chain types (masterchain, workchain, shardchain, basechain)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L33-L568

Replace “MasterChain/WorkChain/ShardChain/BaseChain” with “masterchain/workchain/shardchain/basechain” when used as common nouns. Keep proper names (for example, “TON Mainnet”) capitalized.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-terminology-and-naming

---

- [ ] **7. Unix casing: prefer “Unix time/timestamp,” not “UNIX”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L144-L316

Change “A UNIX timestamp…”, “UNIX-format time…”, and mixed “Unix” variants to consistently use “Unix time/timestamp”. This aligns with usage across the docs; when the guide is silent, prefer consistency with nearby pages.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-terminology-and-naming

---

- [ ] **8. Avoid time‑relative words (“currently”, “for the time being”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L59-L158

Remove time‑relative phrasing:
- “(for the time being)” → remove.
- “Currently this parameter is not used:” → “This parameter is not used:”.
- “(reserved, currently always 0)” → “(reserved; set to 0)”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17-2-timelessness

---

- [ ] **9. Code identifier styling: use code font for TickTock; avoid bold**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L462

Replace “**tick-tock** transactions” with “`TickTock` transactions” (exact case matches the TLB type).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-3-code-styling

---

- [ ] **10. Broken same‑page anchor: [Param 28](#param-28)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L408-L412

The link target `#param-28` does not match the generated heading anchor. Update to `#param-28-catchain-config`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format

---

- [ ] **11. Broken cross‑page anchor: /tvm/instructions#external-messages**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L351

The anchor `#external-messages` does not exist on `/tvm/instructions`. Link to an existing canonical anchor instead, for example `/ton/tblkch#2-1-3-external-messages-with-no-source-or-destination-address` or `/ton/ton#2-4-6-external-messages%2C-or-messages-from-nowhere`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format

---

- [ ] **12. Bare URL; use descriptive link text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L439

Replace “For up-to-date values, see https://tonviewer.com/config.” with “For up‑to‑date values, see [Tonviewer config](https://tonviewer.com/config).”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text

---

- [ ] **13. Oxford comma missing in three‑item list**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L466-L468

Use a serial comma: “Param 32, 34, and 36: validators lists” and “previous (32), current (34), and next (36) rounds.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **14. List punctuation consistency in Param 11**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L124-L134

Items are full sentences but lack terminal periods in places. Add periods to all items in this subsection for consistency.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **15. Bag of cells casing in prose**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L23

Use “bag of cells (BoC)” in prose; keep link text matching the page title if needed. Change “Bags of Cells (BoC)” → “bag of cells (BoC)”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-terminology-and-naming

---

- [ ] **16. Mainnet/Testnet headings: use proper names**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L206-L236

Change “#### Mainnet” → “#### TON Mainnet” and “#### Testnet” → “#### TON Testnet”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-terminology-and-naming

---

- [ ] **17. Inconsistent boolean casing**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L152-L414

Standardize casing for non‑code type mentions: use “boolean” consistently (for example, “A boolean flag …”).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-terminology-and-naming

---

- [ ] **18. Hyphenation in “get‑methods”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L186

Grammar fix: replace “get-methods” with “get methods”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **19. Self‑referential vague link; needs precise anchor**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L629-L632

“See the explanation in [Configuration parameters](/ton/config) section.” The link points to the top of the same page and does not name a specific anchor. Either link to a precise anchor (if one exists) or remove the link. This requires a domain decision to choose the correct target.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not

---

- [ ] **20. Prefer internal docs over external PDFs in Next steps**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L636-L644

Replace external PDFs with internal canonical pages where available:
- “The Open Network Whitepaper” → link to `/ton/ton`.
- “Telegram Open Network Blockchain” currently links to `/tblkch.pdf` (broken). Link to `/ton/tblkch` instead.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not

---

- [ ] **21. Descriptive link text in See also**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L646-L648

“On this [page](/ton/network), …” Use descriptive link text: “See [Network configurations](/ton/network) for active configurations.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text

---

- [ ] **22. Avoid synonym “nanograms” alongside “nanotons” (terminology discipline)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L176

To avoid dual terminology, remove the parenthetical “(also referred to as nanograms)” and use “nanotons” consistently.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-terminology-and-naming

---

- [ ] **23. Type name formatting: HashMap 256 should be code‑styled**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L462

Format the type name as code: change “(HashMap 256)” to “(`Hashmap 256`)” (or the exact identifier used) to follow code‑font rules for types.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-3-code-styling

---

- [ ] **24. Acronym not expanded on first use (TL‑B)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L20

First mention is “TL‑B” without expansion. Expand at first use and use the acronym thereafter. Minimal fix: “Type Language Binary (TL‑B)”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#53-acronyms-and-terms

---

- [ ] **25. Future tense where present tense is required**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L33-L124–134

Phrases like “will be written”, “will be rejected/accepted/chosen” must use present tense for general behavior. Minimal fixes: “is written”, “are rejected/accepted/chosen”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#51-voice-tense-and-person

---

- [ ] **26. Admonition written as inline “Note:”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L334–336

“Note: Param 20 defines …” should use the Aside component with a type. Minimal fix:

<Aside type="note">Param 20 defines gas settings for the masterchain; Param 21 defines gas settings for other workchains.</Aside>

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#a-admonition-levels-and-usage

---

- [ ] **27. Acronyms not expanded on first use (ADNL, IHR)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L394-L480–398

Expand acronyms on first mention, then use the acronym thereafter. For example: “Abstract Datagram Network Layer (ADNL) address …”; “Immediate Hypercube Routing (IHR) …”. Cross-doc precedent: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/overview.mdx?plain=1 defines ADNL. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **28. Duplicate H4 headings; make unique and imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L223-L253

Both sections are titled “How to calculate periods?”. Make them unique and imperative to avoid anchor collisions, e.g., “Calculate periods (mainnet)” and “Calculate periods (testnet)”. Keep sentence case. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-3-uniqueness-and-linkability

---

- [ ] **29. Heading grammar: “validators limits” → “validator limits”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L268

Use the singular noun as an adjective: “validator limits”. This is an obvious grammar fix based on general English usage. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **30. Heading grammar: “message price” → “message prices”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L380

The section covers multiple price components and two parameters; make the heading plural: “message prices”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **31. Scare quotes for emphasis — remove quotes**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L442

Remove quotes used for emphasis in “The number of "fast" attempts…”. Use plain wording: “The number of fast attempts…”. Quotes are reserved for literal UI/log strings. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **32. Non-descriptive link text “this page”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L576

Change “More details … are on [this page](/ton/precompiled).” to “More details … are on [Precompiled contracts](/ton/precompiled).” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text

---

- [ ] **33. Abbreviation “params” in headings — use “parameters”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L122-L150

Headings use the informal “params” (“mandatory params”, “critical params”). Use the canonical term “parameters” for clarity and consistency. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **34. Redundant phrasing in capabilities bullet**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L102–106

“a set of flags that are used to indicate the presence or absence of certain features or capabilities.” Simplify to “a set of flags indicating supported features.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references