### PR TITLE
[AI] fix: comments.mdx

### DIFF
--- a/language/func/comments.mdx
+++ b/language/func/comments.mdx
@@ -8,6 +8,7 @@ FunC supports both single-line and multi-line comments.
 
 Single-line comments start with `;;` (double semicolon), for example:
 Not runnable
+
 ```func
 int x = 1; ;; assigns 1 to x
 ```
@@ -16,15 +17,16 @@ Multi-line comments begin with `{-` and end with `-}`.
 Unlike other languages, FunC allows nested multi-line comments.
 Example:
 Not runnable
+
 ```func
 {- This is a multi-line comment
     {- This is a comment inside a comment -}
 -}
 ```
 
-
 Additionally, single-line comments `;;` can appear inside multi-line comments, and they take precedence over multi-line comments `{-` … `-}`. In the following example:
 Not runnable
+
 ```func
 {-
   Start of the comment


### PR DESCRIPTION
- [ ] **1. Frontmatter title uses title case; sentence case required**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/comments.mdx?plain=1#L2

The page title is in title case ("FunC Comments"). Headings must use sentence case; the frontmatter `title` renders as the page H1, so follow the same rule. Minimal fix: change to `title: "FunC comments"` (preserve proper noun casing for "FunC").
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form

---

- [ ] **2. Frontmatter noindex uses string; boolean required**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/comments.mdx?plain=1#L4

Frontmatter shows `noindex: "true"`. Use a boolean, not a quoted string. Minimal fix: change to `noindex: true`. This relies on basic YAML typing: booleans must be unquoted to be parsed as booleans.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-2-navigation-labels

---

- [ ] **3. Partial code examples missing "Not runnable" labels**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/comments.mdx?plain=1

The three code fences illustrate syntax only and are not runnable on their own. Partial snippets must be labeled clearly above the block. Minimal fix: insert a standalone line `Not runnable` immediately above each code fence at lines 11, 19, and 28.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **4. Standalone “Example:” label should follow a complete clause**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/comments.mdx?plain=1#L9

The line ends with "Example:" as a fragment. Colons should introduce lists or explanations after a complete clause. Minimal fix: fold the label into the preceding sentence, e.g., "Single-line comments start with `;;` (double semicolon), for example:" followed by the code block.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **5. Ambiguous multi-line delimiter formatting (`{- -}`)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/comments.mdx?plain=1#L26

The phrase “multi-line comments `{- -}`” places both delimiters inside one code span, which can imply a single token. Code literals must be represented precisely. Minimal fix: rewrite as “multi-line comments `{-` … `-}`” or “begin with `{-` and end with `-}`” to show the two exact tokens.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#code-styling

---

- [ ] **6. Unnecessary bold emphasis for routine labels**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/comments.mdx?plain=1#L9

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/comments.mdx?plain=1#L15

The words “Single-line” and “Multi-line” are bolded in running text. Emphasis should be used sparingly; prefer plain text when not adding clarifying value. Minimal fix: remove bold formatting so the sentences read “Single-line comments start …” and “Multi-line comments begin …”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.2-quotation-marks-and-emphasis