### PR TITLE
[AI] fix: browser-extension.mdx

### DIFF
--- a/ecosystem/ton-connect/walletkit/browser-extension.mdx
+++ b/ecosystem/ton-connect/walletkit/browser-extension.mdx
@@ -1,11 +1,11 @@
 ---
 title: Custodian integration for in-wallet browsers and browser extensions
-sidebarTitle: Browser extensions and in-wallet browsers
-documentation: >-
+sidebarTitle: Wallet browsers and extensions
+description: >-
   TON Connect integration for custodians in browser extensions and in-wallet browsers
 ---
 
-This document provides instructions for integrating [TON Connect](/ecosystem/ton-connect/index) into wallets and other custodian services in browser extensions and in-wallet browsers.
+Integrate [TON Connect](/ecosystem/ton-connect/index) into wallets and other custodian services in browser extensions and in-wallet browsers.
 
 TON Connect is the standard wallet connection protocol for The Open Network (TON) blockchain, similar to WalletConnect on Ethereum. It enables secure communication between wallets and decentralized applications, allowing users to authorize transactions while maintaining control of their private keys.
 
@@ -66,10 +66,11 @@ TON Connect is the standard wallet connection protocol for The Open Network (TON
 
 A TON Connect bridge acts as a communication layer between decentralized applications (dApps) and wallets.
 
-The wallet extension should expose the bridge using the `window.[custodian].tonconnect` property.
+The wallet extension should expose the bridge using the `window.<CUSTODIAN>.tonconnect` property. Here, <CUSTODIAN> is your wallet namespace.
 
 This bridge must implement a defined interface, allowing dApps to call its methods and receive appropriate responses from the wallet.
 
+Not runnable
 ```ts
 interface TonConnectBridge {
     deviceInfo: DeviceInfo; // see Requests/Responses spec
@@ -83,7 +84,7 @@ interface TonConnectBridge {
 }
 ```
 
-To read more about the bridge protocol, please refer to the [TON Connect Bridge documentation](https://github.com/ton-blockchain/ton-connect/blob/main/bridge.md).
+See the [TON Connect Bridge documentation](https://github.com/ton-blockchain/ton-connect/blob/main/bridge.md).
 
 ## TON Connect protocol
 
@@ -92,7 +93,7 @@ TON Connect enables communication between wallets and dApps. For custodian walle
 1. Listening for messages from connected dApps
 1. Disconnecting from dApps
 
-### Setting up the protocol
+### Set up the protocol
 
 We recommend using the `@tonconnect/protocol` package to handle the TON Connect protocol. But you can also implement the protocol manually.
 
@@ -102,11 +103,11 @@ npm install @tonconnect/protocol
 
 Refer to the [`@tonconnect/protocol` documentation](https://github.com/ton-connect/sdk/tree/main/packages/protocol) for more details.
 
-### Interacting with the dApp
+### Interact with the dApp
 
-To interact with dApp wallet implement `TonConnectBridge` interface and inject it to `window.[custodian].tonconnect` property. Below is the sample implementation of protocol:
+To interact with a dApp wallet, implement the `TonConnectBridge` interface and inject it into `window.<CUSTODIAN>.tonconnect`. Below is a sample implementation of the protocol:
 
-```ts expandable
+```ts not runnable expandable
 import {
     AppRequest,
     CHAIN,
@@ -484,7 +485,7 @@ async function handleTransactionRequest(request: SendTransactionRpcRequest) {
 
 ## TON Connect signing
 
-The signing process is a critical component when integrating TON Connect with custodians. Two key cryptographic operations are required: **Transaction Signing** and **TON Proof Signing**.
+The signing process is a critical component when integrating TON Connect with custodians. Two key cryptographic operations are required: transaction signing and TON proof signing.
 
 ### Transaction signing
 
@@ -495,7 +496,7 @@ For transaction signing implementation, you can refer to the [`@ton/ton` library
 
 This library provides examples and utilities for TON blockchain operations, but custodians will need to adapt these patterns to work with their specific signing infrastructure and APIs.
 
-### TON Proof implementation
+### TON proof implementation
 
 For implementing the necessary functionality, two key resources are available:
 1. [TON Proof specification](https://github.com/ton-blockchain/ton-connect/blob/main/requests-responses.md#address-proof-signature-ton_proof)
@@ -516,21 +517,21 @@ These implementations demonstrate how different wallets handle TON Connect signi
 ## Support and assistance
 
 For questions or clarifications during your integration process:
-- Add comments directly in this document for specific technical clarifications
-- Engage with the TON Foundation team through our technical chat channels
-- Contact the TON Foundation business development team to provide access to technical team for consultations
+- Add comments directly in this document for specific technical clarifications.
+- Engage with the TON Foundation team through our technical chat channels.
+- Contact the TON Foundation business development team to provide access to the technical team for consultations.
 
 To schedule a consultation call with our technical team:
-- Request a meeting through our technical chat channels
-- Contact the TON Foundation business development team to arrange technical discussions
+- Request a meeting through our technical chat channels.
+- Contact the TON Foundation business development team to arrange technical discussions.
 
-The TON Foundation is fully committed to supporting custodians throughout this integration process. This support includes:
+TON Foundation supports custodians throughout this integration. Support includes:
 - Providing technical documentation and specifications
 - Sharing reference implementations and code examples
 - Offering consulting and troubleshooting assistance
 - Helping with testing and verification
 
-The TON Foundation is committed to supporting custodians throughout their TON Connect integration journey. Our team is available to address technical implementation questions, provide guidance on best practices, and facilitate business discussions to ensure successful integration outcomes.
+
 
 ## FAQ
 


### PR DESCRIPTION
- [ ] **1. Sidebar title exceeds 30-character cap**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/browser-extension.mdx?plain=1#L3

`sidebarTitle` is 41 characters ("Browser extensions and in-wallet browsers"), exceeding the ≤30 limit when `title` > 30. Minimal fix: shorten to ≤30 while preserving meaning, e.g., `sidebarTitle: "Wallet browsers and extensions"` (exactly 30).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16.2-navigation-labels

---

- [ ] **2. Unsupported frontmatter key `documentation`**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/browser-extension.mdx?plain=1#L4-L5

Custom frontmatter keys for internal taxonomy are not allowed. Minimal fix: replace `documentation:` with the supported `description:` and keep the same text content.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16.2-navigation-labels

---

- [ ] **3. Throat-clearing opener instead of action-first lead**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/browser-extension.mdx?plain=1#L8

Starts with “This document provides instructions…”. Minimal fix: rewrite to an action-first sentence, e.g., “Integrate TON Connect into wallets and other custodian services in browser extensions and in-wallet browsers.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **4. Wordy “please refer to” phrasing**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/browser-extension.mdx?plain=1#L86

Use concise verbs. Minimal fix: “See the TON Connect Bridge documentation.” (keep the link unchanged).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording

---

- [ ] **5. Grammar and clarity in “Interacting with the dApp” intro**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/browser-extension.mdx?plain=1#L107

Current: “To interact with dApp wallet implement … and inject it to … Below is the sample implementation of protocol:”. Minimal fix: “To interact with a dApp wallet, implement the `TonConnectBridge` interface and inject it into `window.[custodian].tonconnect`. Below is a sample implementation of the protocol:”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#15.1-language-and-reading

---

- [ ] **6. Placeholder style for `window.[custodian].tonconnect`**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/browser-extension.mdx?plain=1#L69-L162

Placeholder uses square brackets in inline code. Placeholders MUST use `<ANGLE_CASE>` in prose/inline code. Minimal fix: change to `window.<CUSTODIAN>.tonconnect` and define `<CUSTODIAN>` once at first mention.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10.1-general-rules

---

- [ ] **7. Partial code snippet is not labeled as non-runnable**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/browser-extension.mdx?plain=1#L109

The large `ts` snippet contains undefined variables/functions and cannot run as-is. Minimal fix: mark the fence as a partial snippet: change ` ```ts expandable` to ` ```ts not runnable expandable`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10.2-partial-snippets

---

- [ ] **8. Placeholder formatting in code comment**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/browser-extension.mdx?plain=1#L157

Uses `<png image url>` with spaces and lowercase. Minimal fix: use angle-case placeholder formatting, e.g., `<PNG_IMAGE_URL>`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10.1-general-rules

---

- [ ] **9. Time-relative wording (“currently”) in example comment**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/browser-extension.mdx?plain=1#L168

Comment: “TON Connect protocol version, currently 2”. Minimal fix: remove the time-relative term: “TON Connect protocol version (2)” or just “TON Connect protocol version”. The numeric value remains in code.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17.2-timelessness

---

- [ ] **10. TON-specific casing for BoC not followed**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/browser-extension.mdx?plain=1#L401-L432

Strings and comments use “boc”; preferred casing is “BoC”. Minimal fix: change “boc” → “BoC” in the user-facing error messages and adjacent comments (e.g., “Payload is not valid BoC”, “StateInit is not valid BoC”).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#b-banned-and-preferred-terms

---

- [ ] **11. Silent truncation of identifiers in examples**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/browser-extension.mdx?plain=1#L214-L276

Example values like `walletAddress = '0:9C60B85...57805AC'` are truncated without an explicit note. Minimal fix: add a clear note per line, e.g., `// truncated for readability; replace with the full value`, or replace with angle-case placeholders (e.g., `<WALLET_ADDRESS>`, `<WALLET_PUBLIC_KEY>`, `<WALLET_STATE_INIT>`) and define them once in the surrounding text.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#14.2-units-and-conventions

---

- [ ] **12. Marketing tone and duplication in Support section**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/browser-extension.mdx?plain=1#L527-L534

Phrases like “fully committed” and the repeated commitment paragraph add marketing tone and redundancy. Minimal fix: merge and rephrase into one neutral sentence, e.g., “TON Foundation supports custodians throughout this integration. Support includes: …” and remove the duplicated paragraph.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles-reader-first-answer-first

---

- [ ] **13. Partial snippet missing “Not runnable” label (interface block)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/browser-extension.mdx?plain=1#L73

The `ts` block shows an interface and is not runnable by itself. Partial snippets must be labeled to prevent execution attempts. Minimal fix: add a line “Not runnable” immediately above the fence.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **14. Heading capitalization not in sentence case**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/browser-extension.mdx?plain=1#L498

Heading “### TON Proof implementation” capitalizes “Proof”. Headings must use sentence case. Minimal fix: “### TON proof implementation”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form

---

- [ ] **15. Multiple bold spans in one paragraph**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/browser-extension.mdx?plain=1#L487

Paragraph contains two bold phrases (“Transaction Signing” and “TON Proof Signing”), exceeding the guideline of one short bold span per paragraph and using title case. Minimal fix: remove bold on both and use sentence case: “transaction signing and TON proof signing”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **16. Procedural list items missing terminal periods**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/browser-extension.mdx?plain=1#L518-L525

Bulleted imperatives under “Support and assistance” are full sentences but lack periods. Minimal fix: add periods at the end of each of these bullets.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **17. Task heading uses gerund form**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/browser-extension.mdx?plain=1#L95

“Setting up the protocol” uses a gerund. For procedure headings, use imperative mood. Change to “Set up the protocol”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles

---

- [ ] **18. Task heading uses gerund (“Interacting with the dApp”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/browser-extension.mdx?plain=1#L105

Task/procedure headings should use imperative verbs, not gerunds. Change “Interacting with the dApp” to “Interact with the dApp”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles

---

- [ ] **19. Improper casing of “TON Connect” in code comments**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/browser-extension.mdx?plain=1#L77-L135

Comments use “Ton Connect” instead of the correct “TON Connect”. Fix casing in comments. Example: “max supported TON Connect version (e.g., 2)”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules

---

- [ ] **20. Invalid TypeScript: await in non‑async function**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/browser-extension.mdx?plain=1#L305

Function `send<T extends RpcMethod>(request: AppRequest<T>): Promise<WalletResponse<T>> { ... }` uses `await` but is not declared `async`, which is a syntax error (general JavaScript/TypeScript rule). Minimal fix: change the signature to `async send<T extends RpcMethod>(request: AppRequest<T>): Promise<WalletResponse<T>> { ... }`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules