### PR TITLE
[AI] fix: statuses.mdx

### DIFF
--- a/ton/statuses.mdx
+++ b/ton/statuses.mdx
@@ -7,23 +7,24 @@ Understanding these states is crucial for accurately predicting transaction outc
 
 ## What is the account status?
 
-The account status is a formal indicator of what actions can occur with an account, what it can store, whether it contains a contract code or not. In other words, it is one of the main factors determining the behavior of a given account during a transaction. The account status at the beginning and end of a transaction is recorded in [the corresponding TL-B block](/ton/tblkch#4-2-12-serialization-of-a-general-transaction) in the fields `orig_status` and `end_status`. Thus, it allows developers to always view the current status of an account before sending it a message and restore the history of its status changes.  
+The account status is a formal indicator of what actions can occur with an account, what it can store, whether it contains a contract code or not. In other words, it is one of the main factors determining the behavior of a given account during a transaction. The account status at the beginning and end of a transaction is recorded in [the corresponding TL-B block](/ton/tblkch#4-2-12-serialization-of-a-general-transaction) in the fields `orig_status` and `end_status`. Thus, it allows developers to always view the current status of an account before sending it a message and restore the history of its status changes.
 
 ## Status variety
 
 Each account exists in one of the following statuses:
 
--   `nonexist`: the default status for accounts with no transaction history or that were deleted. Contains no code, data, or balance. All 2<sup>256</sup> accounts start in this status.
--   `uninit`: holds a balance and metadata, but no code and persistent data. It cannot execute logic but retains funds (and accumulates storage fees) until the contract code is deployed.
--   `active`: contains code, data, and a balance. Fully deployed and operational, capable of processing messages. 
--   `frozen`: occurs when the storage debt of an active account exceeds 0.1 TON. Only the hashes of the previous code and data cells are preserved. While frozen, the contract cannot execute. To unfreeze, send a message with a valid `state_init` and sufficient funds for storage fees. Recovery is complex; avoid reaching this state. A project to unfreeze accounts is available at the [Unfreezer project](https://unfreezer.ton.org/).
+- `nonexist`: the default status for accounts with no transaction history or that were deleted. Contains no code, data, or balance. All 2<sup>256</sup> accounts start in this status.
+- `uninit`: holds a balance and metadata, but no code and persistent data. It cannot execute logic but retains funds (and accumulates storage fees) until the contract code is deployed.
+- `active`: contains code, data, and a balance. Fully deployed and operational, capable of processing messages.
+- `frozen`: occurs when the storage debt of an active account exceeds 0.1 TON. Only the hashes of the previous code and data cells are preserved. While frozen, the contract cannot execute. To unfreeze, send a message with a valid `state_init` and sufficient funds for storage fees. Recovery is complex; avoid reaching this state. A project to unfreeze accounts is available at the [Unfreezer project](https://unfreezer.ton.org/).
 
 ### Rationale for the four statuses
+
 Although the need for the `active` and `nonexist` statuses is obvious, the purpose of the `uninit` and `frozen` statuses is not immediately clear.
 
 **`nonexist` vs `uninit`**:
 
-Each account starts in the `nonexist` status. Besides code and persistent data, in this status an account also has no [metadata](/ton/tblkch#4-1-6-account-description), so it does not accumulate storage fees. At the same time, the `uninit` status of an account indicates that some actions were performed with it and, possibly, it is prepared for the deployment. So, the `uninit` account always has a [positive balance and some additional information](https://github.com/ton-blockchain/ton/blob/cac968f77dfa5a14e63db40190bda549f0eaf746/crypto/block/block.tlb#L259-L260) for which it must pay storage fees. 
+Each account starts in the `nonexist` status. Besides code and persistent data, in this status an account also has no [metadata](/ton/tblkch#4-1-6-account-description), so it does not accumulate storage fees. At the same time, the `uninit` status of an account indicates that some actions were performed with it and, possibly, it is prepared for the deployment. So, the `uninit` account always has a [positive balance and some additional information](https://github.com/ton-blockchain/ton/blob/cac968f77dfa5a14e63db40190bda549f0eaf746/crypto/block/block.tlb#L259-L260) for which it must pay storage fees.
 
 Sending an internal message with valid `state_init` and proper `value` to a `nonexist` account results in its deployment and the status changes to `active`. The key point is that the deployment occurs during the compute phase, which requires a suitable number of nanotons to run. But often you want to be able to deploy an account through an **external message**, to which you can also attach `state_init`, but it is impossible to attach `value`. This is also the purpose for which `uninit` exists. You can initially transfer the balance to the account via an internal message, notifying the rest of the blockchain participants of your intention to deploy an account in the future. Then deploy it, including via an external message.
 
@@ -38,85 +39,89 @@ The main difference between the `uninit` and `frozen` statuses is that in additi
 The diagram below describes all potential changes in the account status during the receipt of internal or external messages.
 
 ### Diagram
-In the diagram below, there are four nodes representing the four different account statuses. Each arrow and loop corresponds to a change in the account status at the end of a given transaction. The parameters in the blocks above the arrows (and loops) briefly describe what caused the transaction and also contain some fields that affect the change in the account status.
 
+In the diagram below, there are four nodes representing the four different account statuses. Each arrow and loop corresponds to a change in the account status at the end of a given transaction. The parameters in the blocks above the arrows (and loops) briefly describe what caused the transaction and also contain some fields that affect the change in the account status.
 
 ![Account status transition diagram](/resources/images/status-changes-diagram.svg)
 
-
 The following cases show how a `nonexist` account changes based on incoming messages.
-   - **Receiving external messages**: no changes.
-   - **Receiving internal messages**:
-      - **With valid `state_init` and sufficient value**: the contract is deployed on its address that becomes `active` before processing the message.
-      - **Without/with invalid `state_init` or with insufficient value**: if the message is **bounceable**, then it returns to the sender, and the account status isn't changed. Otherwise, with no `value` in the message, the account status isn't changed. Finally, it becomes `uninit` if it received a valid `state_init` but insufficient nanotons, or if `state_init` is absent or invalid.
+
+- **Receiving external messages**: no changes.
+- **Receiving internal messages**:
+  - **With valid `state_init` and sufficient value**: the contract is deployed on its address that becomes `active` before processing the message.
+  - **Without/with invalid `state_init` or with insufficient value**: if the message is **bounceable**, then it returns to the sender, and the account status isn't changed. Otherwise, with no `value` in the message, the account status isn't changed. Finally, it becomes `uninit` if it received a valid `state_init` but insufficient nanotons, or if `state_init` is absent or invalid.
 
 With the diagram Legend below, you can inspect all possible changes in the account status when receiving messages with different parameters.
 
 ### Legend
- - `type`: message type.
-   - any
-   - internal
-   - external
- - `bounce`: `bounce` flag of an internal message.
-   - any
-   - true
-   - false
- - `value`: an amount of nanotons in a message.
-   - any
-   - 0
-   -  \> 0
- - `StateInit`: StateInit structure.
-   - any
-   - none
-   - invalid: the address computed from a given `state_init` does not match the recipient address
-   - valid: the computed address matches the recipient address
-   - valid last state: must be `state_init` of the last successful transaction before the account change to frozen
- - `balance`: The account balance in nanotons after **Storage phase** of the transaction.
-   - 0
-   - \> 0
-   - \< 40,000
-   - \>= 40,000
-   - (0, 40,000)
- - `storage_fees_due`: the number of storage fees that were charged but could not be conducted. In the diagram this field indicates `storage_fees_due` after **Storage phase**.
-   - 0
-   - < 0.1 TON
-   - < 1 TON
-   - \>= 0.1 TON
-   - \>= 1 TON
- - `send_dest_if_zero`: is there any outgoing message with flag 32 in the **Action phase**?
-   - any
-   - false
-   - true
-   - invalid: there was no **Action phase**
- - `zero_bal_after_dest_act`: did the account balance become zero when sending some messages with the flag 32? This field is meaningful only if there's at least one such message during the **Action phase**.
-   - any
-   - false
-   - true
- - `action_phase_is_successful`: was the **Action phase** successful?
-   - false
-   - true
- - `account_state_changed`: has the account's state changed during its lifetime?
-   - false
-   - true
+
+- `type`: message type.
+  - any
+  - internal
+  - external
+- `bounce`: `bounce` flag of an internal message.
+  - any
+  - true
+  - false
+- `value`: an amount of nanotons in a message.
+  - any
+  - 0
+  - \> 0
+- `StateInit`: StateInit structure.
+  - any
+  - none
+  - invalid: the address computed from a given `state_init` does not match the recipient address
+  - valid: the computed address matches the recipient address
+  - valid last state: must be `state_init` of the last successful transaction before the account change to frozen
+- `balance`: The account balance in nanotons after **Storage phase** of the transaction.
+  - 0
+  - \> 0
+  - \< 40,000
+  - \>= 40,000
+  - (0, 40,000)
+- `storage_fees_due`: the number of storage fees that were charged but could not be conducted. In the diagram this field indicates `storage_fees_due` after **Storage phase**.
+  - 0
+  - \< 0.1 TON
+  - \< 1 TON
+  - \>= 0.1 TON
+  - \>= 1 TON
+- `send_dest_if_zero`: is there any outgoing message with flag 32 in the **Action phase**?
+  - any
+  - false
+  - true
+  - invalid: there was no **Action phase**
+- `zero_bal_after_dest_act`: did the account balance become zero when sending some messages with the flag 32? This field is meaningful only if there's at least one such message during the **Action phase**.
+  - any
+  - false
+  - true
+- `action_phase_is_successful`: was the **Action phase** successful?
+  - false
+  - true
+- `account_state_changed`: has the account's state changed during its lifetime?
+  - false
+  - true
 
 ### Key points
 
- Key points for statuses other than `nonexist`:
+Key points for statuses other than `nonexist`:
 
 **Sending to `uninit` account**:
-   - **Messages of any type without `state_init`**: changes to `nonexist` if its balance becomes zero.
-   - **Messages of any type with valid `state_init`**: changes to `active` if the balance is at least 40,000 nanotons.
+
+- **Messages of any type without `state_init`**: changes to `nonexist` if its balance becomes zero.
+- **Messages of any type with valid `state_init`**: changes to `active` if the balance is at least 40,000 nanotons.
 
 **Sending to `frozen` account**:
-   - **Messages of any type**: Changes to `nonexist` if its `storage_fees_due` exceeds 1 TON and the balance is zero.
-   - **Internal message with valid `state_init` (non-bounceable)**: changes to `active` if its `storage_fees_due` becomes zero.
-   - **Internal message with valid `state_init` (bounceable)**: changes to `active` with the same debt and the account balance equals the message's balance minus compute and action fees.
+
+- **Messages of any type**: Changes to `nonexist` if its `storage_fees_due` exceeds 1 TON and the balance is zero.
+- **Internal message with valid `state_init` (non-bounceable)**: changes to `active` if its `storage_fees_due` becomes zero.
+- **Internal message with valid `state_init` (bounceable)**: changes to `active` with the same debt and the account balance equals the message's balance minus compute and action fees.
 
 **Sending to `active` account**:
-   - **Messages of any type**: changes to `frozen` if its `storage_fees_due` exceeds 0.1 TON and the account's state has ever changed.
-   - **Messages of any type**: changes to `uninit` if its `storage_fees_due` exceeds 0.1 TON and the account's state has never changed.
-   - **Messages of any type**: if in the action list there is an outgoing message with the flag 32 but **Action phase** was unsuccessful or the balance after this action is positive, the account status doesn't change.
-   - **Messages of any type with any `state_init`**: A new `state_init` will be ignored and therefore doesn't change the account status.
+
+- **Messages of any type**: changes to `frozen` if its `storage_fees_due` exceeds 0.1 TON and the account's state has ever changed.
+- **Messages of any type**: changes to `uninit` if its `storage_fees_due` exceeds 0.1 TON and the account's state has never changed.
+- **Messages of any type**: if in the action list there is an outgoing message with the flag 32 but **Action phase** was unsuccessful or the balance after this action is positive, the account status doesn't change.
+- **Messages of any type with any `state_init`**: A new `state_init` will be ignored and therefore doesn't change the account status.
 
 **Deployment strategy**: the standard practice for deploying a wallet is to first send a non-bounceable message with Toncoin to its address. This transitions the account to the `uninit` status. The wallet owner can then deploy the contract in a subsequent transaction, using the pre-funded balance.
 
@@ -126,5 +131,5 @@ With the diagram Legend below, you can inspect all possible changes in the accou
 
 - The account statuses (`nonexist`, `uninit`, `active`, `frozen`) define behavior.
 - Correct handling of `state_init` and the `bounce` flag is crucial for successful deployment and avoiding unintended fund transfers.
-- There are many cases when the account status can become `nonexist` or `frozen`. Keep track of the amount of TON in the account balance.  
+- There are many cases when the account status can become `nonexist` or `frozen`. Keep track of the amount of TON in the account balance.
 - Each new `state_init` is ignored when the account status is active.


### PR DESCRIPTION
- [ ] **1. Throat-clearing opening sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L5

The page opens with “This article describes…”, which is a meta-introduction. Replace with a direct, purpose-first sentence. For example: “Understand the four account states on TON and how they affect transactions and deployment.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **2. Non-descriptive link text (“here”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L19

Link text “here” is non-descriptive. Replace with meaningful text, e.g., “A project to unfreeze accounts is available at the Unfreezer project.” Use: “[Unfreezer project](https://unfreezer.ton.org/)”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text

---

- [ ] **3. Avoid “as mentioned above” reference**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L23

“As was mentioned above,” is a relative reference. Remove the phrase or link to a precise anchor if needed. Minimal fix: delete the clause and start the sentence with “Each account starts in the `nonexist` status.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **4. Spelling and grammar in `uninit` paragraph**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L25

Correct typos and articles for clarity and American English spelling: change “addtional” → “additional”; “the positive balance” → “a positive balance”; “pay storage fee” → “pay storage fees”. Minimal edit: “So, the `uninit` account always has a positive balance and some additional information … for which it must pay storage fees.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-6-spelling-and-contractions. Also relied on general English grammar norms for article use.

---

- [ ] **5. Wrong identifier `state_nint` (typo)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L37

Inline code shows `state_nint`, which appears to be a typo for `state_init`. Fix the token to keep examples precise and copy‑pasteable. Minimal fix: `state_init`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-full-runnable-examples; also see https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-3-code-styling

---

- [ ] **6. Prefer internal references over external GitHub source links**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L11-L35

Replace external GitHub line links with internal canonical docs:
- `block.tlb#L285` (orig_status/end_status) → `/ton/tblkch#4-2-12-serialization-of-a-general-transaction`.
- `block.tlb#L258` (metadata) → `/ton/tblkch#4-1-6-account-description`.
- `block.tlb#L268` (last account state hash) → `/ton/tblkch#4-1-6-account-description`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format

---

- [ ] **7. List item punctuation in “Legend” (use no terminal punctuation)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L55–92

In unordered lists that are not full sentences, terminal punctuation should be omitted. Items end with semicolons and periods (e.g., “any;”, “0.”). Remove terminal punctuation consistently across the Legend sublists. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **8. Spelling: “out-going” → “outgoing”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L74

Use standard American English spelling without the hyphen: “outgoing message”. Minimal fix: “is there any outgoing message …”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-6-spelling-and-contractions

---

- [ ] **9. Grammar: “some of messages” → “any messages”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L78

Fix article/quantifier usage for clarity: change “when sending some of messages” to “when sending any messages”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording (basic grammar/clarity)

---

- [ ] **10. Article usage: “to `nonexist` account” → “to a `nonexist` account”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L28

Add the indefinite article for grammatical correctness. Minimal fix: “to a `nonexist` account”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording (basic grammar/clarity)

---

- [ ] **11. Article usage: “with the valid `state_init`” → “with a valid `state_init`”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L19

Use the correct article with a countable noun. Minimal fix: “with a valid `state_init`”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording (basic grammar/clarity)

---

- [ ] **12. Subject‑verb agreement in Summary**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L121

“The account statuses (…) defines behavior.” should use the plural verb. Minimal fix: “The account statuses (…) define behavior.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording (basic grammar/clarity)

---

- [ ] **13. Verb agreement earlier: “and accumulate the storage fee”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L15

Fix agreement and noun number: change to “and accumulates storage fees”. Minimal fix: “… It cannot execute logic but retains funds (and accumulates storage fees) until the contract code is deployed.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording (basic grammar/clarity)

---

- [ ] **14. Ambiguous “we” and throat‑clearing in Diagram intro**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L41

“We present here a diagram …” uses ambiguous “we” and throat‑clearing. Rewrite in active, descriptive voice: “The diagram below describes all potential changes …”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#4-voice-and-tone and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **15. Conversational “So, let’s look …”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L50

Avoid conversational “let’s”. Use direct descriptive phrasing. Minimal fix: “The following cases show how a `nonexist` account changes based on incoming messages.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#4-voice-and-tone

---

- [ ] **16. Preposition: “Beside code and persistent data” → “Besides code and persistent data”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L25

Use correct preposition and grammar for clarity: “Besides code and persistent data, in this status an account also has no metadata …”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **17. Missing subject: “if received a valid `state_init`” → “if it received”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L58

Add the subject for grammatical correctness: “Finally, it becomes `uninit` if it received a valid `state_init` but insufficient nanotons, or if `state_init` is absent or invalid.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **18. Articles for “Action phase” references**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L70–81

Add the definite article when referring to a named phase: “in the **Action phase**”, “during the **Action phase**”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **19. Image alt text is generic (“alt text”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L45

Alt text must describe the figure. Replace `![alt text](/resources/images/status-changes-diagram.svg)` with a short descriptive alt, e.g., `![Account status transition diagram](/resources/images/status-changes-diagram.svg)`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#15-2-structure-and-tables

---

- [ ] **20. Thousand separators missing for ≥10,000**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L76-L108

Use thousands separators: `40000` → `40,000` (nanotons).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#14-1-numerals-and-separators

---

- [ ] **21. Grammar: “some of messages”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L91

Fix to “some messages” for correct English: “did the account balance become zero when sending some messages with the flag 32?”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **22. Missing article and stylistic exclamation**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L28

Missing article and unnecessary exclamation: “to `nonexist` account…” → “to a `nonexist` account…”, and remove the exclamation after “it is impossible to attach `value`”. Minimal fix: “…to a `nonexist` account results…”, “…but it is impossible to attach `value`.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **23. Ambiguous “We additionally review …” sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L104

Avoid “we” and throat-clearing. Minimal fix: remove the sentence entirely or rephrase to neutral: “Key points for statuses other than `nonexist`:”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **24. Article usage in bullets**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L116

“equals message’s balance” is missing an article. Minimal fix: “equals the message’s balance”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **25. Article usage for sentence clarity**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L125

“new `state_init` will be ignored” is missing an article. Minimal fix: “A new `state_init` will be ignored…”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **26. Tone: remove emphatic exclamation in summary**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L129

Avoid emphatic punctuation and tighten phrasing. Minimal fix: “There are many cases when the account status can become `nonexist` or `frozen`. Keep track of the amount of TON in the account balance.” (remove the exclamation and use “in the account balance”).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **27. Concept heading style (noun phrase preferred)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L21

“Why exactly these four statuses?” is a question form. For concept sections, noun phrases are preferred. Minimal fix: change to “Rationale for the four statuses”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles

---

- [ ] **28. Spelling and article usage in contrast section**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L26

Issues: “Beside” → “Besides”; “addtional” → “additional”; add article “the” before “account’s history” where applicable later; and use plural “storage fees.” Minimal fix: “As mentioned above, each account starts in the `nonexist` status. Besides code and persistent data, an account in this status also has no metadata, so it does not accumulate storage fees. … the `uninit` account always has a positive balance and some additional information … for which it must pay storage fees.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-6-spelling-and-contractions; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **29. Token styling: use code font, not bold, for status literals**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L16-L19

Status values are tokens/literals and should use code font, not bold. Minimal fix: replace “**nonexist**”, “**uninit**”, “**active**”, “**frozen**” with “`nonexist`”, “`uninit`”, “`active`”, “`frozen`”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-3-code-styling

---

- [ ] **30. Awkward fragment; tighten wording**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L28

The sentence fragment “And only then, including through an external message, to deploy.” is awkward. Minimal fix: “Then deploy it, including via an external message.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#8-1-paragraphs-and-sentences

---

- [ ] **31. Article usage: “contains hash of the last account state” → “contains the hash of the last account state”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L34

Add the definite article before “hash”. Minimal fix as shown.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#8-1-paragraphs-and-sentences

---

- [ ] **32. Unnecessary bolding of “Legend”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L53

Avoid bold for common nouns; use plain text or link to the “Legend” heading. Minimal fix: remove bold from “Legend”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **33. Units missing for currency thresholds**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L82-L85

Quantities must include units. Minimal fix: add “TON” to each value: “< 0.1 TON”, “< 1 TON”, “>= 0.1 TON”, “>= 1 TON”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#14-2-units-and-conventions

---

- [ ] **34. Article usage: “the computed address matches a recipient address” → “the computed address matches the recipient address”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#L72

Use the definite article for specificity. Minimal fix as shown.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#8-1-paragraphs-and-sentences