### PR TITLE
[AI] fix: getting-started.mdx

### DIFF
--- a/ecosystem/tma/telegram-ui/getting-started.mdx
+++ b/ecosystem/tma/telegram-ui/getting-started.mdx
@@ -12,7 +12,6 @@ Install the package with npm:
 npm install @telegram-apps/telegram-ui
 ```
 
-
 ## Import styles
 
 Import the styles:
@@ -39,6 +38,7 @@ ReactDOM.render(
 ## See an example
 
 Not runnable
+
 ```jsx
 // Import the necessary styles globally
 import '@telegram-apps/telegram-ui/dist/styles.css';
@@ -70,4 +70,5 @@ export const App = () => (
 You can now use the library.
 
 ### More UI components
+
 Find more demo components in the [Playground and Storybook](https://tgui.xelene.me/?path=/docs/getting-started--documentation).


### PR DESCRIPTION
- [ ] **1. First visible heading level is H3, must be H2**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/getting-started.mdx?plain=1#L26

The first visible in-body heading is `### Installing @telegram-apps/mate`, but per the template the page title comes from frontmatter and the first visible heading in content must be an H2. Minimal fix: change `### Installing @telegram-apps/mate` to `## Install @telegram-apps/mate` (also switches to imperative; see item 2).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form

---

- [ ] **2. Procedural headings use gerunds; prefer imperative sentence case**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/getting-started.mdx?plain=1#L26-L139

Task/procedure headings should start with an imperative verb and use sentence case. Minimal fixes:
- `### Installing @telegram-apps/mate` → `## Install @telegram-apps/mate` (also fixes H2 level)
- `## Retrieving project deployment info` → `## Retrieve project deployment info`
- `## Deploying` → `## Deploy`
- `## Using Config` → `## Use a config file`
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-2-gerunds-and-labels; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form

---

- [ ] **3. UI labels incorrectly styled as code; use quotation marks**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/getting-started.mdx?plain=1#L10-L23

UI button/label strings must appear in quotation marks, not code font. Minimal fixes:
- ``press the `Start` button`` → `press the “Start” button`
- ``press the `Create a Project` button`` → `press the “Create a Project” button`
- ``a `Deploy Token``` → `a “Deploy Token”` (if this matches the literal UI string)
Use the house quoting style with punctuation outside the closing quotes unless part of the string.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **4. Curly‑brace placeholders in commands; must use <ANGLE_CASE>**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/getting-started.mdx?plain=1#L63-L136

Copy‑pasteable commands must not use `{}` placeholders. Minimal fixes:
- `mate deploy info --token {TOKEN} --project {PROJECT}` → `mate deploy info --token <TOKEN> --project <PROJECT>`
- `--token {SPECIFY TOKEN HERE}` → `--token <TOKEN>`
- `--token {TOKEN} --project {PROJECT} --tag test` → `--token <TOKEN> --project <PROJECT> --tag test`
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-5-placeholder-names; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#severity-model-release‑blocking

---

- [ ] **5. Blockquote used for callout; must use <Aside> component**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/getting-started.mdx?plain=1#L120-L124

Admonitions must use the `<Aside>` component, not Markdown blockquotes. Minimal fix (MDX):

````mdx
import { Aside } from '/snippets/aside.jsx';

<Aside type="note" title="Important">
  Your directory must include only regular files and directories. Symlinks and other file types are forbidden; the CLI tool reports them.
</Aside>
````

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-6-blockquotes; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#19-appendices (Implementation)

---

- [ ] **6. Banned filler word “simply” in prose**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/getting-started.mdx?plain=1#L128-L129

Avoid filler/hedging. Minimal fix: `A tag is simply a marker for your deployment version.` → `A tag is a marker for your deployment version.`
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#b-banned-and-preferred-terms

---

- [ ] **7. Wordy/awkward phrasing with redundancy**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/getting-started.mdx?plain=1#L47

“Not to install the package, you can also use the package using …” is unidiomatic and repeats “use”. Minimal fix: `To avoid installing the package, use "pnpm" or "npx":`
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **8. Mentions `pnpm` without a corresponding example command**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/getting-started.mdx?plain=1#L47-L51

The text suggests using `pnpm` or `npx` but only provides an `npx` example. This harms reproducibility. Minimal fix (one of): add a `pnpm` example (if supported) or remove `pnpm` from the sentence. Domain decision required to avoid inventing tool syntax.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles-reader-first-answer-first (Example‑first and precise); https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-language-and-labels

---

- [ ] **9. Typo: “CLI toll” → “CLI tool”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/getting-started.mdx?plain=1#L123

Correct the typo in the Important note text. Minimal fix: `the CLI toll` → `the CLI tool`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17-4-proofread

---

- [ ] **10. Acronym casing: use “ID” (not “id”) in prose**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/getting-started.mdx?plain=1#L97

Use standard acronym casing in prose. Minimal fix: `project with id \`48\`` → `project with ID \`48\``. Keep UI/log strings as-is inside quoted output blocks.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **11. Prefer internal docs link over external when available**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/getting-started.mdx?plain=1#L28-L29

Linking directly to npm is acceptable, but when an internal page exists it should be the primary link. Minimal fix: link `@telegram-apps/mate` to `/ecosystem/tma/mate/telegram-apps-mate` (the internal page), and optionally keep the npm link later in the paragraph if needed.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not (Internal first)

---

- [ ] **12. Images lack alt text; add concise alt attributes**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/getting-started.mdx?plain=1#L13-L20

Images should include text alternatives for accessibility. Minimal fix: add `alt` attributes, e.g., `alt="tma_mate_bot start screen"` and `alt="Create a Project dialog"`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#15-2-tables-and-figures (Provide text alternatives)

---

- [ ] **13. Marketing tone in opening sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/getting-started.mdx?plain=1#L5

Avoid marketing language in technical docs. Minimal fix: replace `Your companion for managing Telegram Mini Apps.` with a neutral, task‑focused line such as `Manage Telegram Mini Apps.`
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles-reader-first-answer-first

---

- [ ] **14. Output code blocks missing language tag**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/getting-started.mdx?plain=1#L68-L107

Fenced blocks must specify a language. Tag CLI output blocks as `text`:
- Change ``` at line 68 to ```text
- Change ``` at line 107 to ```text
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **15. Typo and comma splice in Important note text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/getting-started.mdx?plain=1#L122–124

Fix the typo “CLI toll” → “CLI tool” and split the comma splice. Also remove filler “Note that”. Minimal text:
- `Your directory must include only regular files and directories. Other types (for example, symlinks) are forbidden; the CLI tool will warn you.`
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **16. Acronyms not defined on first mention (URL, CDN)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/getting-started.mdx?plain=1#L55–56,98

Spell out acronyms on first mention, then use the acronym thereafter. Examples:
- `Uniform Resource Locator (URL)` on first use of URL
- `content delivery network (CDN)` on first use of CDN
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **17. Mixed casing for the same term (“mini app” vs “Mini App”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/getting-started.mdx?plain=1#L7

Use consistent casing for the term per this section’s usage. Elsewhere in TMA docs, “Mini App(s)” is capitalized (see https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/overview.mdx?plain=1#L5-L11). Change “mini app distribution files” → “Mini App distribution files”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-1-term-bank; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules

---

- [ ] **18. Curly‑brace placeholders in YAML; prefer neutral placeholders**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/getting-started.mdx?plain=1#L144–149

Avoid `{PROJECT}`/`{TOKEN}` in code examples. In language code blocks, prefer neutral UPPER_SNAKE placeholders. Example:
```yml
deploy:
  projectId: PROJECT_ID
  directory: DIST_DIR
  token: TOKEN
```
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **19. Prefer imperative/present over “should”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/getting-started.mdx?plain=1#L89

Use present tense for general instructions. Minimal fix: “Use `https://35f105bd6b.tapps.global/latest` as the base URL in your bundler.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-1-voice-and-tense

---

- [ ] **20. Procedural headings use gerunds; use imperative verbs**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/getting-started.mdx?plain=1#L26-L139

Task/procedure headings should start with an imperative verb and avoid gerunds. Minimal fixes:
- `### Installing @telegram-apps/mate` → `## Install @telegram-apps/mate` (also resolves item 1)
- `## Retrieving project deployment info` → `## Retrieve project deployment info`
- `## Deploying` → `## Deploy`
- `## Tagging` → `## Use tags`
- `## Using Config` → `## Use config` (also see item 3)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#task-procedure-headings