### PR TITLE
[AI] fix: libraries.mdx

### DIFF
--- a/language/func/libraries.mdx
+++ b/language/func/libraries.mdx
@@ -6,16 +6,16 @@ noindex: true
 
 ## Standard libraries
 
- - [stdlib.fc](/language/func/stdlib): the FunC standard library
- - [mathlib](https://github.com/ton-blockchain/ton): the FunC fixed-point math library
+- [stdlib.fc](/language/func/stdlib): the FunC standard library
+- [mathlib](https://github.com/ton-blockchain/ton): the FunC fixed-point math library
 
 ## Libraries from the community
 
- - [continuation-team/openlib.func](https://github.com/continuation-team/openlib.func/): reduces transaction fees in common scenarios
- - [open-contracts/utils](https://github.com/TonoxDeFi/open-contracts): utility library
- - [open-contracts/strings](https://github.com/TonoxDeFi/open-contracts): provides string manipulation functions
- - [open-contracts/math](https://github.com/TonoxDeFi/open-contracts): extends FunC arithmetic operations with additional math functions
- - [open-contracts/tuples](https://github.com/TonoxDeFi/open-contracts): collection of tuple-related functions for FunC
- - [open-contracts/crypto](https://github.com/TonoxDeFi/open-contracts): provides cryptographic operations for secp256k1 curves
- - [toncli/test-libs](https://github.com/disintar/toncli): supports TL‑B operations, including message and type parsing and generation
- - [ston-fi/funcbox](https://github.com/ston-fi/funcbox/): collection of FunC snippets and utilities
+- [continuation-team/openlib.func](https://github.com/continuation-team/openlib.func/): reduces transaction fees in common scenarios
+- [open-contracts/utils](https://github.com/TonoxDeFi/open-contracts): utility library
+- [open-contracts/strings](https://github.com/TonoxDeFi/open-contracts): provides string manipulation functions
+- [open-contracts/math](https://github.com/TonoxDeFi/open-contracts): extends FunC arithmetic operations with additional math functions
+- [open-contracts/tuples](https://github.com/TonoxDeFi/open-contracts): collection of tuple-related functions for FunC
+- [open-contracts/crypto](https://github.com/TonoxDeFi/open-contracts): provides cryptographic operations for secp256k1 curves
+- [toncli/test-libs](https://github.com/disintar/toncli): supports TL‑B operations, including message and type parsing and generation
+- [ston-fi/funcbox](https://github.com/ston-fi/funcbox/): collection of FunC snippets and utilities


### PR DESCRIPTION
- [ ] **1. Frontmatter `noindex` should be boolean**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/libraries.mdx?plain=1#L4

`noindex` is set to a quoted string instead of a boolean. Use a boolean per frontmatter guidance. Minimal fix: change `noindex: "true"` to `noindex: true`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-2-navigation-labels

---

- [ ] **2. Fix unintended nested bullet indentation**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/libraries.mdx?plain=1#L15

This list item has two leading spaces before the hyphen, rendering it as a nested sub-item unintentionally. Align with other top-level bullets. Minimal fix: remove one leading space so the line starts with `- [open-contracts/utils](...)`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **3. Align list punctuation across sections**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/libraries.mdx?plain=1#L14–21

List items under “Libraries from community” end with periods, but they are sentence fragments (not full sentences). Per the guide, fragments should omit terminal punctuation, and punctuation style must be consistent. Minimal fix: remove the trailing period from each item in lines 14–21.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **4. Add “the” in heading**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/libraries.mdx?plain=1#L12

Use plain, international English in headings; the definite article is missing. Minimal fix: change `## Libraries from community` to `## Libraries from the community`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#15-1-language

---

- [ ] **5. Use stable permalinks for deep GitHub links**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/libraries.mdx?plain=1#L9–10, 15–20

Deep links point to moving branches (`master`/`main`), which are not stable. Prefer a tag/commit permalink for precise code paths, or link the repo root when versioning adds no value. Minimal fix: update these URLs to versioned permalinks or to repository roots.
Occurrences:
- L9–10: `ton-blockchain/ton/blob/master/...`
- L15–19: `TonoxDeFi/open-contracts/tree/main/...`
- L20: `disintar/toncli/tree/master/...`
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references

---

- [ ] **6. Use “TL‑B” consistently (not “TLB”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/libraries.mdx?plain=1#L20

Terminology should be consistent across docs. This page uses “TLB”, while core pages and paths use “TL‑B” (e.g., `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/overview.mdx?plain=1`). Minimal fix: replace “TLB operations” with “TL‑B operations”. If a domain decision is required, confirm the canonical form in the term bank/glossary.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-1-term-bank

---

- [ ] **7. Align list punctuation across sections**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/libraries.mdx?plain=1#L9/func/libraries.mdx:10

List items under “Standard libraries” omit terminal periods, while items under “Libraries from the community” use periods. Keep list punctuation consistent: since most items end with periods, add periods to these two lines. Minimal fix: append a period at the end of lines 9 and 10.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#lists

---

- [ ] **8. Prefer internal link for stdlib**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/libraries.mdx?plain=1#L9

The entry links externally to GitHub for the standard library even though an internal canonical page exists. Minimal fix: link to the internal reference instead: [stdlib.fc](/language/func/stdlib): the FunC standard library. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not

---

- [ ] **9. Link text should be descriptive (stdlib)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/libraries.mdx?plain=1#L9

Link text "stdlib" is terse; the guide prefers descriptive link text. Minimal fix: change to "stdlib.fc" to clearly indicate the file being referenced: [stdlib.fc](/language/func/stdlib). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text

---

- [ ] **10. Acronym not expanded on first mention (TLB)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/libraries.mdx?plain=1#L20

"TLB" appears without its expansion. The guide requires spelling out the term on first mention, followed by the acronym. Minimal fix: expand the term on first use (e.g., “<Full term> (TLB)”) — needs domain owner confirmation for the exact expansion used in TON docs. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **11. Trailing slash in GitHub file URL (stdlib)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/libraries.mdx?plain=1#L9

The GitHub file URL ends with a trailing slash (`.../stdlib.fc/`), which is not valid for file paths and can 404. Minimal fix if retaining external link: remove the trailing slash (`.../stdlib.fc`). This relies on general URL semantics for GitHub file paths.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references

---

- [ ] **12. Trailing slash in GitHub file URL (mathlib)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/libraries.mdx?plain=1#L10

The GitHub file URL ends with a trailing slash (`.../mathlib.fc/`), which is not valid for file paths and can 404. Minimal fix: remove the trailing slash (`.../mathlib.fc`). This relies on general URL semantics for GitHub file paths.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references