### PR TITLE
[AI] fix: overview.mdx

### DIFF
--- a/ecosystem/interoperability/oracles/overview.mdx
+++ b/ecosystem/interoperability/oracles/overview.mdx
@@ -89,10 +89,7 @@ This model works well with pull oracles, since you can always guarantee the lowe
 
 1. The user contract receives the response from the oracle contract, checks that the sender is the oracle, and then can use the provided data.
 
-
 ![Oracle flow diagram](/resources/images/oracles/oracle-flow.svg)
-
-
 
 ## List of oracles in TON
 


### PR DESCRIPTION
- [ ] **1. Generic page title violates title vs sidebar rule**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/overview.mdx?plain=1#L2

Frontmatter uses a generic `title: "Overview"`, which MUST NOT be used except on top‑level pages. Use a descriptive title and, if needed, keep a concise sidebar label. Minimal fix:

---

- [ ] **2. Throat‑clearing sentence; rewrite to direct summary**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/overview.mdx?plain=1#L13

Sentence starts with “This section covers …”, which is prohibited throat‑clearing. Rewrite to a direct, reader‑focused summary and fix minor grammar/casing within it. Minimal fix:

Replace:
“This section covers development, testing, smart contracts deployment and interaction, performance benchmarks, and blueprint configuration and reference.”

With:
“Develop, test, deploy, and interact with smart contracts; run performance benchmarks; configure Blueprint.”

Notes: “smart contracts deployment” → “smart contract deployment” (basic grammar) and “blueprint” → “Blueprint” (proper noun per term bank). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **3. Code fence language should be `bash` for shell command**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/overview.mdx?plain=1#L19

The Quick start command is fenced as `console`. The guide requires language‑tagged fences and nearby pages use `bash` for shell commands; align for consistency and tooling/highlighting. Minimal fix:

Change ```console → ```bash for the `npm create ton@latest` block.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules. The guide is silent on `console` specifically; this change prefers consistency with nearby pages.

---

- [ ] **4. Mainnet/Testnet casing inconsistent with term bank**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/overview.mdx?plain=1#L27-L48

Use lowercase for generic network types or the full proper names when referring to TON networks. Minimal fix options (choose one consistently):
- Generic: “mainnet and testnet”
- Proper: “TON Mainnet and TON Testnet”

Current text: “Mainnet and Testnet”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-3-hyphenation-and-abbreviations

---

- [ ] **5. External link used where internal exists (internal‑first)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/overview.mdx?plain=1#L8

The “Blueprint” bullet links to the GitHub README. Prefer an internal docs page when available. Minimal fix: link to the in‑repo page instead, e.g., `[Blueprint](/ecosystem/blueprint/develop)`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not

---

- [ ] **6. Acronym not expanded on first use**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/overview.mdx?plain=1#L35

Heading “IDE plugins” uses the acronym IDE without expansion. Expand on first mention, then use the acronym thereafter. Minimal fix: change heading to “Integrated development environment (IDE) plugins”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **7. Ordered list numbering should use auto-numbering**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/overview.mdx?plain=1#L42-L43

The ordered list uses `1.` then `2.`. The guide requires using `1.` for every item and letting the renderer auto-number. Minimal fix: change line 43 from `2.` to `1.`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.4-lists

---

- [ ] **8. Product name casing: lowercase “blueprint” in prose**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/overview.mdx?plain=1#L13

“blueprint configuration and reference” uses a lowercase product name. Proper nouns and official product names must use correct casing. Minimal fix: “Blueprint configuration and reference”. Cross-check: page titles use proper casing (https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/reference.mdx?plain=1#L2/blueprint/config.mdx:2).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13.2-general-casing-rules

---

- [ ] **9. Trailing periods on non-sentence list items**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/overview.mdx?plain=1#L8-L11/blueprint/overview.mdx:25-28, ecosystem/blueprint/overview.mdx:47-50, ecosystem/blueprint/overview.mdx:52-54

Several bulleted items are sentence fragments but end with periods. For non-sentence list items, omit terminal punctuation consistently. Minimal fix: remove trailing periods from these bullets (including nested fragments at lines 52–53); keep the period on line 51 because it is a full sentence.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.4-lists

---

- [ ] **10. Compound noun modifier: “smart contracts deployment”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/overview.mdx?plain=1#L13

Use the singular noun as a modifier: “smart contract deployment” (not “smart contracts deployment”). Minimal fix: change only the compound to “smart contract deployment” in this sentence. This relies on general English grammar for compound modifiers; change improves clarity and concision (basic grammar).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording

---

- [ ] **11. Product naming inconsistent with corpus (“Testing utils”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/overview.mdx?plain=1#L11

Link text uses “Testing utils”, while other pages refer to the package as “Test utils” (e.g., https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/testing/reference.mdx?plain=1#L1810). Minimal fix: change the link label to “Test utils” (URL unchanged). The style guide is silent on this label; align with corpus usage for consistency.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-terminology-and-naming

---

- [ ] **12. Overemphasis: bold used for emphasis in body text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/overview.mdx?plain=1#L50

“except Tact” is bolded for emphasis. Bold should be used sparingly in body text; prefer plain wording. Minimal fix: remove bold from “except Tact”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **13. Wordy/marketing phrasing in the opening sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/overview.mdx?plain=1#L5

Phrase “designed to enhance the process of creating, testing, and deploying” is wordy and reads like marketing. Minimal fix: “Blueprint is an all-in-one development environment for creating, testing, and deploying smart contracts on the TON Blockchain.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles-reader-first-answer-first; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **14. Undefined acronym on first mention (TON)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/overview.mdx?plain=1#L5

“TON Blockchain” appears before defining the acronym. Minimal fix: spell out on first mention as “The Open Network (TON) Blockchain”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **15. Unnecessary bold emphasis on product name**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/overview.mdx?plain=1#L5

“**Blueprint**” is bolded in running prose without a functional reason. Minimal fix: remove bold and use plain “Blueprint”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **16. Marketing adverb in feature bullet**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/overview.mdx?plain=1#L26

“Streamlined workflow — build, test, and deploy smart contracts efficiently.” The adverb “efficiently” adds marketing tone. Minimal fix: remove “efficiently.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles-reader-first-answer-first

---

- [ ] **17. Marketing adjective in feature label (“Simple deployment”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/overview.mdx?plain=1#L27

“Simple deployment” is value-laden. Minimal fix: use a neutral label like “Deployment — publish contracts to Mainnet and Testnet directly from your wallet.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles-reader-first-answer-first

---

- [ ] **18. Marketing adjective in feature label (“Fast local testing”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/overview.mdx?plain=1#L28

“Fast local testing” is value-laden. Minimal fix: use a neutral label like “Local testing — run multiple contracts in an isolated in-process blockchain.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles-reader-first-answer-first

---

- [ ] **19. Package/identifier should use code font in link text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/overview.mdx?plain=1#L11

Link text “Testing utils” is informal and does not use code formatting for the package identifier. Minimal fix: use the package name in code font as the link text, for example: ``[`@ton/test-utils`](https://github.com/ton-org/test-utils) — testing helpers and unit test matchers.``

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-3-code-styling

---

- [ ] **20. Trailing periods on non-sentence list items**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/overview.mdx?plain=1#L8-L11/blueprint/overview.mdx:25-28, ecosystem/blueprint/overview.mdx:47-50, ecosystem/blueprint/overview.mdx:54

Several bulleted items are sentence fragments but end with periods. For non-sentence list items, omit terminal punctuation consistently. Minimal fix: remove trailing periods from these bullets only (keep periods on nested full-sentence sub-bullets at lines 51–53).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.4-lists