### PR TITLE
[AI] fix: wallet.mdx

### DIFF
--- a/guidebook/wallet.mdx
+++ b/guidebook/wallet.mdx
@@ -29,6 +29,7 @@ Explore demo wallets:
     arrow="true"
     href="https://walletkit-demo-wallet.vercel.app"
   />
+
   <Card
     title="Demo wallet, GitHub repository"
     icon="link"
@@ -44,8 +45,13 @@ Explore demo wallets:
 Once the wallet is [integrated](#integrate), follow one of these common usage recipes:
 
 <Tabs>
-  <Tab title="Web" icon="globe">
-    <Columns cols={3}>
+  <Tab
+    title="Web"
+    icon="globe"
+  >
+    <Columns
+      cols={3}
+    >
       <Card
         title="Initialize the kit"
         href="/ecosystem/ton-connect/walletkit/web/init"
@@ -63,6 +69,7 @@ Read more about TON Connect and WalletKit:
     title="TON Connect overview"
     href="/ecosystem/ton-connect"
   />
+
   <Card
     title="WalletKit overview"
     href="/ecosystem/ton-connect/walletkit"
@@ -76,14 +83,17 @@ Skim the reference pages with more in-depth information:
     title="TON Connect manifests"
     href="/ecosystem/ton-connect/manifest"
   />
+
   <Card
     title="WalletKit integration quality assurance (QA) guide"
     href="/ecosystem/ton-connect/walletkit/qa-guide"
   />
+
   <Card
     title="Native and web wallets"
     href="/ecosystem/ton-connect/walletkit/native-web"
   />
+
   <Card
     title="Browser extensions and in-wallet browsers"
     href="/ecosystem/ton-connect/walletkit/browser-extension"
@@ -97,6 +107,7 @@ Discover app integration guides or explore complete examples:
     title="Integrate a dApp"
     href="/guidebook/dapp"
   />
+
   <Card
     title="Centralized exchange (CEX)"
     href="/guidebook/cex"


### PR DESCRIPTION
- [ ] **1. Frontmatter title is generic; use descriptive title**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/wallet.mdx?plain=1#L2

The frontmatter `title: "Wallet"` is a one-word generic title that is not a top-level page or a proper name. Use a descriptive, self-contained title. Minimal fix: change to `title: "Wallet commands"` (optionally set `sidebarTitle: "Wallet"` if needed elsewhere).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-1-files-and-titles

---

- [ ] **2. Missing safety callout for fund transfers (`mg`, `mgtp`)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/wallet.mdx?plain=1#L161

Sections that move funds must include a Warning callout with risk, scope, rollback/mitigation, and an explicit testnet/mainnet label. Minimal fix: insert an `<Aside type="danger" title="Funds at risk">` before the `## Fund transfers` section (or individually before `mg`/`mgtp`) that explains irreversible transfers, scope (source and destination wallets), suggests testing on testnet first, and states there is no rollback on mainnet.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-1-when-a-safety-callout-is-required; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout

---

- [ ] **3. Missing safety callout and placeholder for secrets in `iw`/`ew`**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/wallet.mdx?plain=1#L98

Pages that expose or transmit private keys must include a Warning callout and must not show secrets in examples. The `iw` example shows truncated, key‑like arguments. Minimal fix: add an `<Aside type="danger" title="Secrets at risk">` to `iw` and `ew` describing risk/scope/mitigation and testnet‑first guidance; in the `iw` example, replace both arguments with placeholders (`iw <WALLET_ADDR> <WALLET_SECRET_KEY_BASE64>`) and define them on first use.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-3-safety-and-secrets-in-code; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-1-when-a-safety-callout-is-required; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-5-placeholder-names

---

- [ ] **4. Placeholders not in `<ANGLE_CASE>` and undefined**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/wallet.mdx?plain=1#L21-L193

Syntax blocks use lowercase/hyphenated placeholders (for example, `<workchain-id>`, `<wallet-name>`, `<account-addr|bookmark>`) and do not define them at first use. Minimal fix: convert to `<ANGLE_CASE>` with descriptive names and define each on first use, e.g., `nw [<WORKCHAIN_ID> <WALLET_NAME> [<VERSION> <SUBWALLET>]]`; `aw [<WALLET_NAME>|all]`; `iw <WALLET_ADDR> <WALLET_SECRET_KEY_BASE64>`; `swv <WALLET_ADDR> <WALLET_VERSION>`; `mg <WALLET_NAME> <ACCOUNT_ADDR_OR_BOOKMARK> <AMOUNT_TON> [<ADDITIONAL_FLAGS>...]`; `mgtp <WALLET_NAME> <ACCOUNT_ADDR_OR_BOOKMARK> <AMOUNT_TON>`. Add 1–2 short definition lines immediately after each first use.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-5-placeholder-names

---

- [ ] **5. Partial “Syntax” snippets lack the required “Not runnable” label**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/wallet.mdx?plain=1#L19–23,42–46,79–83,102–106,123–127,144–148,167–171,190–194

Syntax blocks are not intended to run as-is and must be labeled. Minimal fix: add a plain line `Not runnable` immediately above each `Syntax` fenced block.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **6. UI prompt quoted with code font instead of quotation marks**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/wallet.mdx?plain=1#L87

UI/log strings must be in double quotation marks, not code font. Minimal fix: change to: Prompts “Are you sure you want to delete this wallet (yes/no):” and only proceeds on `yes`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **7. Log message string uses code font; should be in quotes**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/wallet.mdx?plain=1#L177

Literal UI/log strings must appear in quotes. Minimal fix: replace backticks with quotation marks: prints “MoveCoins - OK” on success.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **8. Silent truncation of addresses in examples without disclaimer**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/wallet.mdx?plain=1#L181–184,204–206

Address values are truncated (e.g., `EQDv...Qw`, `EQC6...rA`) without stating truncation, which is disallowed for copy/pasteable identifiers. Minimal fix: add a brief note before the first example stating that addresses are truncated for readability and show the pattern (e.g., first 3 / last 2 with an ellipsis), or switch to placeholders in examples where appropriate.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#14-2-units-and-conventions

---

- [ ] **9. Code fence language should be `bash` for CLI commands**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/wallet.mdx?plain=1#L21-L204

The page uses nonstandard code fence language `mytonctrl` for shell commands. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules. Minimal fix: change all CLI command fences from ```mytonctrl to ```bash. General knowledge: `bash` is the conventional tag for shell commands and is supported by highlighters; `mytonctrl` is not.

---

- [ ] **10. Add required safety callouts for destructive and funds‑risk operations**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/wallet.mdx?plain=1#L75–94,161–206

Deleting local wallets (`dw`) risks data loss; transfers (`mg`, `mgtp`) risk funds. Required safety callouts are missing. Rules: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-safety-critical-content-blockchain-specific and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#19-appendices-a-admonition-levels-and-usage. Minimal fix: add `<Aside>` callouts:
- Before `dw`: `<Aside type="caution" title="Caution">Removes local wallet files. Back up the wallets directory and .pk files before running.</Aside>`
- Before `mg`/`mgtp`: `<Aside type="danger" title="Warning">Transfers on mainnet are final. Test on testnet first and verify the destination.</Aside>`

---

- [ ] **11. Replace informal phrasing “Handy” with precise wording**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/wallet.mdx?plain=1#L200

“Handy when the destination cannot accept a direct bounceable transfer.” uses informal tone. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording. Minimal fix: “Useful when the destination cannot accept a direct bounceable transfer.”

---

- [ ] **12. Missing Glossary link on first useful mention of a core term**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/wallet.mdx?plain=1#L27

The first useful mention of “workchain” is not linked to the Glossary. Minimal fix: link the first mention to `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860//ton/glossary.mdx?plain=1#workchain` (retain plain text thereafter).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not

---

- [ ] **13. Add safety callouts for transfers, key handling, and deletion**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/wallet.mdx?plain=1#L161

This page moves funds (`mg`, `mgtp`), exposes/handles keys (`iw`, `ew`), and deletes local data (`dw`) without required safety callouts. Minimal fix: insert `<Aside>` callouts:
- Before “Fund transfers”: `<Aside type="danger" title="Funds at risk">` (risk, scope, rollback/mitigation, and testnet/mainnet label).
- Near `iw`/`ew`: `<Aside type="danger" title="Secrets at risk">` warning not to expose real keys and that leaks are irreversible.
- Near `dw`: `<Aside type="caution" title="Data loss">` noting local file removal and advising verified backups.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-1-when-a-safety-callout-is-required; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#rendering-component-high

---

- [ ] **14. Expand BoC on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/wallet.mdx?plain=1#L40

“BoCs” appears without expansion on first mention. Minimal fix: “unsigned deployment Bags of Cells (BoCs)”; keep later uses as “BoC/BoCs”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **15. Add thousands separators to large numeral in prose**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/wallet.mdx?plain=1#L27

The number “698983191” appears in prose. Minimal fix: write “698,983,191”. Do not add separators inside identifiers or code tokens.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#14-1-numerals-and-separators

---

- [ ] **16. Avoid `[]` placeholder notation in command forms**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/wallet.mdx?plain=1#L22

The “Syntax” lines use square brackets to indicate optional parts (e.g., `nw [<workchain-id> <wallet-name> [<version> <subwallet>]]`, `aw [<wallet-name>|all]`, `mg ... [additional-flags...]`). Minimal fix: remove square brackets from command forms and describe optionality in prose; for variadic flags, use a placeholder such as `<ADDITIONAL_FLAGS>`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-5-placeholder-names; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#severity-model-release‑blocking