### PR TITLE
[AI] fix: from-ethereum.mdx

### DIFF
--- a/guidebook/from-ethereum.mdx
+++ b/guidebook/from-ethereum.mdx
@@ -21,10 +21,10 @@ So compared to Ethereum, where you can have multiple processed messages and stat
 
 Here is a table for comparison:
 
-| Action description                                                                             | Ethereum                          | TON                       |
-| :--------------------------------------------------------------------------------------------- | --------------------------------- | ------------------------- |
-| Single message processing with state change on one contract                                    | Message call or internal transaction | Transaction               |
-| Number of state changes and messages on different accounts produced from initial contract call | Transaction                       | Chain of transactions (trace) |
+| Action description                                                                             | Ethereum                             | TON                           |
+| :--------------------------------------------------------------------------------------------- | ------------------------------------ | ----------------------------- |
+| Single message processing with state change on one contract                                    | Message call or internal transaction | Transaction                   |
+| Number of state changes and messages on different accounts produced from initial contract call | Transaction                          | Chain of transactions (trace) |
 
 Example: liquidity withdrawal on a decentralized exchange (DEX).
 
@@ -80,12 +80,12 @@ The recommended programming language for smart contract development in TON is [T
 
 Ecosystem overview.
 
-| Use case                              | Popular Ethereum tool | TON counterpart                                                                                              |
-| :------------------------------------ | --------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Use case                              | Popular Ethereum tool | TON counterpart                                                                                                   |
+| :------------------------------------ | --------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | Blockchain interaction                | Ethers, Web3.js, Viem | [`@ton/ton`](https://www.npmjs.com/package/@ton/ton), [`assets-sdk`](https://github.com/ton-community/assets-sdk) |
-| Wallet connection protocol            | WalletConnect, Wagmi  | [TonConnect](https://github.com/ton-connect)                                                                 |
-| Dev environment framework / scripting | Hardhat, Truffle      | [Blueprint](https://github.com/ton-org/blueprint)                                                            |
-| Simulation engine                     | Revm & Reth           | [Sandbox](https://github.com/ton-org/sandbox)                                                                |
+| Wallet connection protocol            | WalletConnect, Wagmi  | [TonConnect](https://github.com/ton-connect)                                                                      |
+| Dev environment framework / scripting | Hardhat, Truffle      | [Blueprint](https://github.com/ton-org/blueprint)                                                                 |
+| Simulation engine                     | Revm & Reth           | [Sandbox](https://github.com/ton-org/sandbox)                                                                     |
 
 Another important library to know about is [`@ton/core`](https://www.npmjs.com/package/@ton/core). This library handles low-level blockchain primitives (de-)serialization; you will probably need it together with any RPC client or contract interaction library.
 


### PR DESCRIPTION
- [ ] **1. Acronyms not expanded on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L7

 "TON" and "EVM" appear without expansion. Expand on first use to define terms for all readers. Minimal fix: “Learn how to develop on The Open Network (TON) coming from the Ethereum Virtual Machine (EVM) ecosystem.”
 Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms

---

- [ ] **2. Tautology in lead sentence (“develop and build”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L7

 Avoid redundant pairs. Minimal fix: change “develop and build” to “develop”.
 Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **3. Article and casing in Aside link text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L10-L11

 Grammar and proper noun casing: add the article and fix “Ton” → “TON”. Minimal fix: “If you want a more practical example, see Tokens on TON.”
 Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.6-spelling-and-contractions; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13.2-general-casing-rules; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording

---

- [ ] **4. Comma splice and unnecessary quotation marks around terms**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L20

 The sentence joins independent clauses with a comma and uses quotes for emphasis on the word transaction. Minimal fix: split into two sentences and remove quotes. For example: “... on TON, a transaction represents a state change only for one account and a single message processing. A signed, included‑in‑block unit is called a transaction on both chains; however, due to different execution models, the impact differs.”
 Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.1-commas-colons-semicolons; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.2-quotation-marks-and-emphasis

---

- [ ] **5. Quotation marks used for terms in comparison table**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L26-L27

 Quotation marks are used for “internal transaction” and “trace” for emphasis. Use plain text (no quotes) for generic terms. Minimal fix: remove quotation marks in the table cells.
 Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.2-quotation-marks-and-emphasis

---

- [ ] **6. Throat-clearing phrasing (“Let’s explore …”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L29

 Avoid throat‑clearing and first‑person plural; prefer direct, descriptive phrasing. Minimal fix: “Example: liquidity withdrawal on a DEX.”
 Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.7-avoid-tautology-pleonasm-throat-clearing-and-circular-references; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.1-voice-tense-and-person

---

- [ ] **7. Non-descriptive image alt text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L33-L37

 Alt text should describe the figure for accessibility. Minimal fix: replace “eth-burn” with “Ethereum DEX liquidity withdrawal shown as one atomic transaction” and “tvm-burn” with “TON DEX liquidity withdrawal shown as a chain of transactions (trace)”.
 Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#15.2-structure-and-tables

---

- [ ] **8. Intensifier and italics (“really big”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L39

 Remove hedge/intensifier and avoid decorative italics. Minimal fix: “If you want to execute a large transaction on Ethereum …”.
 Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **9. Missing article and awkward phrasing (“With TON asynchronous execution model”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L39

 Add the article to improve readability. Minimal fix: “With the TON asynchronous execution model, you can have a trace …”.
 Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording

---

- [ ] **10. On‑chain get methods: missing article and plural**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L43-L45

 Fix grammar for clarity. Minimal fix: “you can’t call a get method … during a transaction” and “with these limitations”.
 Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording

---

- [ ] **11. Acronym style and plurality for EOA**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L49

 Introduce the acronym once and use correct plurality. Minimal fix: “externally owned account (EOA) and contract accounts. EOAs are …”.
 Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms

---

- [ ] **12. Quotation marks around generic term (wallets)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L49-L51

 Do not quote generic terms for emphasis. Minimal fix: remove quotes around wallets.
 Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.2-quotation-marks-and-emphasis

---

- [ ] **13. Comma splice and article usage in account model paragraph**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L51

 Independent clauses joined by a comma and missing articles. Minimal fix: split into sentences and add articles: “In TON, there is no such separation. Every valid address represents an on‑chain account … that can be changed through transactions.”
 Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.1-commas-colons-semicolons; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording

---

- [ ] **14. Hyphenation and plurality: smart contract(s)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L51-L53

 Use “smart contract” (no hyphen) as a generic term; apply correct subject‑verb agreement. Minimal fix: “wallets in TON are smart contracts” and “TON wallet smart contracts use …”.
 Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13.2-general-casing-rules

---

- [ ] **15. Hedging and agreement in “user experience stay more or less the same”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L53

 Remove hedge and fix verb agreement. Minimal fix: “meaning that the user experience stays the same.”
 Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.7-avoid-tautology-pleonasm-throat-clearing-and-circular-references; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.1-voice-tense-and-person

---

- [ ] **16. Articles and hyphenation in limited storage paragraph**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L56-L58

 Add missing articles and prefer plain phrasing. Minimal fixes: “in an EVM chain” and “by using a single map inside one contract”.
 Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording

---

- [ ] **17. Danger Aside: tone and grammar**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L61-L65

 Avoid exclamation for neutral guidance; fix grammar. Minimal fix: “Every map expected to grow beyond 1,000 values is risky. In the TVM, map key access is logarithmic, so gas cost increases as the map grows.” (Comma in 1,000 follows American English.)
 Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.6-spelling-and-contractions

---

- [ ] **18. Imperative voice for guidance**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L67

 Prefer direct imperative over “you should”. Minimal fix: “Use sharding instead.”
 Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.1-voice-tense-and-person

---

- [ ] **19. Past participle “lead” → “led”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L69

 Fix obvious grammar. Minimal fix: “have led”.
 Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording

---

- [ ] **20. Proper casing: TypeScript**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L75-L77

 Use official product casing. Minimal fix: “TypeScript”.
 Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13.2-general-casing-rules

---

- [ ] **21. Article in “Recommended programming language … is Tolk”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L79

 Add the article for readability. Minimal fix: “The recommended programming language … is Tolk.”
 Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording

---

- [ ] **22. Sentence clarity before table**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L81

 Improve clarity and grammar. Minimal fix: “Ecosystem overview”.
 Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles (scannability); https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording

---

- [ ] **23. Package/library token formatting and casing**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L85-L90

 Use exact package names and code formatting for tokens. Minimal fixes: render package names as code in link text (e.g., [`@ton/ton`](https://www.npmjs.com/package/@ton/ton), [`@ton/core`](https://www.npmjs.com/package/@ton/core)) and change “Asset-sdk” to “assets-sdk” to match the repository slug.
 Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.3-code-styling; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13.2-general-casing-rules

---

- [ ] **24. Brand consistency: WalletConnect casing**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L86-L122

 Use consistent brand casing across the page. Minimal fix: change “Walletconnect” to “WalletConnect”.
 Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13.2-general-casing-rules

---

- [ ] **25. Web3 casing**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L94

 Use consistent casing for the term. Minimal fix: “Web3 developers”. See usage in `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#L461` (Web3 definition).
 Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13.4-ton-specific-examples; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#web3

---

- [ ] **26. Hyphenation: use cases**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L94

 Prefer the common form without a hyphen in running text. Minimal fix: “use cases”.
 Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording

---

- [ ] **27. Standards section intro grammar**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L108

 Fix article and plurality. Minimal fix: “This section showcases a match between some Ethereum standards and proposals … and their counterparts … in TON (TEP).”
 Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording

---

- [ ] **28. Title uses Title Case instead of sentence case**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L2

The frontmatter `title` is "Coming from Ethereum" (Title Case), but headings and titles must use sentence case. Minimal fix: change to "Coming from Ethereum" → "Coming from ethereum" or rephrase to a clearer sentence‑case title such as "Coming from Ethereum" in sentence case; confirm proper noun casing policy (Ethereum as proper noun stays capitalized, so final should be "Coming from Ethereum" with only the first word capitalized). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.1-case-and-form

---

- [ ] **29. Headings use Title Case; must be sentence case**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L14-L114

Headings like "Execution model", "Asynchronous blockchain", "On-chain get methods", "Account model", "Limited contract storage", "Ecosystem", "Tooling", "Services", and "Standards" are in Title Case. They must use sentence case (capitalize only the first word and proper nouns). Minimal fix: change to "Execution model" → "Execution model" (already sentence case), "Asynchronous blockchain" → "Asynchronous blockchain" (ok), ensure all others follow sentence case: "On-chain get methods", "Account model", "Limited contract storage", "Ecosystem", "Tooling", "Services", "Standards". Verify consistent sentence case across all H2/H3. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.1-case-and-form

---

- [ ] **30. Hyphen used instead of an em dash for parenthetical clause**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L18-L57

Hyphen/dash "-" is used to set off clauses ("TON - every smart contract…"; "contract - you can't call…"). Use an em dash or restructure the sentence. Minimal fix: replace " - " with " — " where it indicates a break, or split into two sentences to avoid long clauses. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.1-commas-colons-semicolons (mechanics) and general readability; house typography implies proper punctuation for breaks.

---

- [ ] **31. Acronyms not expanded on first use**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L29-L49

Terms like DEX and DeFi appear without first expansion. Minimal fix: write "decentralized exchange (DEX)" on first use and "decentralized finance (DeFi)" on first use. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms

---

- [ ] **32. Admonition type and content calibration**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L63–68

The `<Aside type="danger">` warns about large maps but does not include explicit risk/mitigation per the callout guidance. For non‑security technical caution, `type="caution"` may be more appropriate, and the text should include risk + mitigation. Minimal fix: change to `type="caution"` and add mitigation: e.g., "Use sharding to split state". Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#appendix-a-admonition-levels-and-usage

---

- [ ] **33. Table header and labels: sentence case and consistent product names**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L84–90,96–106,116–122

Tables mix capitalization and product styling (e.g., "Walletconnect" should be "WalletConnect"; "Asm playground" should be "Assembly playground" or the product’s proper name; "Revm & Reth" should be consistent with how tools are cased on their repos). Minimal fix: correct to proper nouns and sentence‑case labels where generic: "WalletConnect", "Wagmi", "ASM playground" or use the exact brand/product names. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms and #7.1-case-and-form

---

- [ ] **34. Link text should match target heading where possible**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L11-L120–122

Some links use generic labels instead of the exact page titles or anchors (e.g., "here" links; "Providers overview" not matching the target page title "Overview"). Minimal fix: replace "here" with descriptive link text matching the target heading, and prefer deep anchors when relevant. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16.3-links-and-anchors

---

- [ ] **35. Terminology: “get methods” formatting**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L41–45

When referring to specific contract interface methods, prefer code font for identifiers if they are literal names, otherwise keep as common noun without quotes. The page uses plain text with quotes in some places; remove quotes and avoid inconsistent styling. Minimal fix: remove quotation marks; optionally format as `get methods` only if referring to literal interface name style elsewhere. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.2-quotation-marks-and-emphasis and #10-code-and-command-examples (identifier styling)

---

- [ ] **36. Consistency of list/table punctuation and Oxford comma**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L24–27,84–90,96–106,116–122

Ensure lists in sentences and table labels use consistent commas and the Oxford comma where applicable. Example: "Ethers, Web3.js, Viem" is correct; verify other multi‑item cells follow the same pattern. Minimal fix: add Oxford comma where missing in any three‑item list cells. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.1-commas-colons-semicolons

---

- [ ] **37. Sentence length and readability**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L18–20,31,35,39,43,49–53

Several sentences exceed recommended length with multiple clauses, reducing scan speed. Minimal fix: split into 2–3 shorter sentences and front‑load key points. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#8.1-paragraphs-and-sentences

---

- [ ] **38. Consistent terminology for “trace”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L27-L39

The page introduces "trace" in quotes without a definition and mixes it with "chain of transactions." Prefer one term and avoid quotes. Minimal fix: use "transaction trace" or "chain of transactions" consistently, without quotation marks. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms and #6.2-quotation-marks-and-emphasis

---

- [ ] **39. Avoid idiom “stepping stones”; use plain wording**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L18

“stepping stones” is an idiom; prefer neutral phrasing. Minimal fix: “One of the biggest challenges when learning TON development is the asynchronous execution model.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#55-global-and-inclusive-language

---

- [ ] **40. Tense and capitalization in wallet standard sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L53

Improve tense and casing. Minimal fix: “You can examine the wallet standard implementation and how it has changed as the ecosystem evolved.” (keep link unchanged).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#52-plain-precise-wording

---

- [ ] **41. Article and comma splice/link text “here”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L86-L88

Issues: missing initial article; comma splice; non-descriptive “here” link text. Minimal fixes:
- “The recommended programming language … is Tolk.”
- Split into two sentences.
- Replace “here” with descriptive link text: “…other established languages in the ecosystem. Read more about Tact.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#121-link-text

---

- [ ] **42. Missing period and hyphenation in Services intro**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L104-L106

Add terminal punctuation and unify “use cases” without a hyphen to match prior usage. Minimal fix: “…services that they use for easier on-chain development. This table showcases some of the use cases that existing TON services can cover.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#61-commas-colons-semicolons

---

- [ ] **43. Numeric formatting and redundant phrasing (“1.5+ million”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L39-L59

Use thousands separators for numbers ≥ 10,000, and avoid pleonasm. Minimal fixes: “1.5+ million” → “more than 1,500,000” (replace the redundant “+” with “more than”); “65536” → “65,536”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#14.1-numerals-and-separators; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.7-avoid-tautology-pleonasm-and-intensifiers

---

- [ ] **44. Proper noun capitalization (“TON Blockchain”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L57

“TON blockchain” appears with a lowercase “blockchain” but the proper‑noun form used across these docs is “TON Blockchain”. Minimal fix: capitalize “Blockchain”. If the term bank differs, follow it; otherwise prefer consistency with existing pages (e.g., https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/tblkch.mdx?plain=1).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13.2-general-casing-rules

---

- [ ] **45. Comma splices and run-on sentences**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/from-ethereum.mdx?plain=1#L20-L49

Independent clauses are joined with commas, creating run-ons (e.g., "…in both chains, however … it has different impact."; "The same operation on TON will be different, it will consist …"; "…each have their own balance, they are commonly called …"). Minimal fix: split into shorter sentences or use coordinating conjunctions. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.1-commas-colons-semicolons