### PR TITLE
[AI] fix: index.mdx

### DIFF
--- a/language/func/index.mdx
+++ b/language/func/index.mdx
@@ -38,8 +38,6 @@ which stores the amount to send. The builder finalizes the cell with a call to t
 
 Finally, function [`send_raw_message`](/language/func/stdlib#send-raw-message) sends the message, where the parameter `64` describes a sending mode.
 
- 
-
 ## Compiler
 
 The compiler converts FunC programs into Fift assembler code, generating the corresponding bitcode for the [TON Virtual Machine](/tvm/overview).
@@ -60,7 +58,10 @@ npm create ton@latest
 
 FunC compiler binaries for Windows, macOS (Intel or Arm64), and Ubuntu can be downloaded from [GitHub](https://github.com/ton-blockchain/ton/releases/tag/v2025.07).
 
-<Aside type="note" title="Deprecated">
+<Aside
+  type="note"
+  title="Deprecated"
+>
   The last version for the FunC compiler was v2025.07. The FunC compiler is no longer developed. New releases are focused on the [Tolk](https://github.com/ton-blockchain/ton/releases/latest) compiler.
 </Aside>
 


### PR DESCRIPTION
- [ ] **1. **1. Empty/broken internal links used as placeholders****

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/index.mdx?plain=1#L33

The page contains empty links that render as broken anchors: "[cell builder]()", "[cell]()" (line 33), "[message flags]()" (line 34), and "[sending mode]()" (line 39). Minimal fix: remove the empty link markup around these phrases, or replace each with a correct in-repo anchor when available (e.g., keep the existing working links to `begin_cell`, `store_slice`, `store_coins`, `end_cell`, `send_raw_message`). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-3-links-and-anchors

---

- [ ] **2. **2. Misused danger callout for non-safety/editorial note****

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/index.mdx?plain=1#L41

Callout labeled as `type="danger"` is used for an internal maintenance note about broken links. Danger is reserved for security/funds/chain risk; use the least severe type or remove editorial notes entirely. Minimal fix: delete this `<Aside>` or convert it to `type="note"` with user-facing guidance only (no internal TODOs). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#a-admonition-levels-and-usage

---

- [ ] **3. **3. Superlative/marketing phrasing in technical section****

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/index.mdx?plain=1#L55

“Using the Blueprint framework is the most convenient and quickest way…” uses superlative marketing language. Replace with neutral, precise wording. Minimal fix: “Using the Blueprint framework is a convenient way to begin developing and compiling smart contracts.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles

---

- [ ] **4. **4. Non-descriptive link text (“Follow this link”)****

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/index.mdx?plain=1#L149

Link text “Follow this link” is not descriptive. Replace with meaningful text matching the target page. Minimal fix: “See ‘Examples of smart contracts’” linking to `/techniques/examples`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#15-1-language-and-reading

---

- [ ] **5. **5. Editorial aside with exclamations and vague link text****

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/index.mdx?plain=1#L97

The aside includes an internal complaint (“I cannot find…!!!!!!!”) and vague link text “Introduction”. Remove the editorial note and use descriptive link text that matches the target page. Minimal fix: delete the first sentence; outside of an aside, add: “The best place to start is ‘Your first smart contract’.” with link text “Your first smart contract” to `/guidebook/first-smart-contract`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#a-admonition-levels-and-usage; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#15-1-language-and-reading

---

- [ ] **6. **6. Unexpanded acronym (“JS”) on first mention****

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/index.mdx?plain=1#L53

“JS” appears without first expanding to “JavaScript (JS)”. Spell out on first mention, then use the acronym. Minimal fix: change the heading to “Compile with JavaScript (JS)” and in the sentence “all JavaScript (JS) dependencies”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **7. **7. Broken internal anchor to non-existent section****

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/index.mdx?plain=1#L142

The link `/techniques/examples#ton-smart-challenge-4` points to an anchor that does not exist on the target page (the page is a stub). Minimal fix: link to `/techniques/examples` without the fragment, or update the fragment to a valid, existing anchor once added. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-3-links-and-anchors

---

- [ ] **8. **8. Frontmatter boolean quoted (use boolean literal)****

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/index.mdx?plain=1#L4

`noindex` is set as a quoted string (`"true"`). Prefer the boolean literal for consistency with house examples. Minimal fix: change to `noindex: true`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-2-navigation-labels

---

- [ ] **9. Heading case uses Title Case instead of sentence case**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/index.mdx?plain=1#L2-L151

Headings and titles must be in sentence case. Examples: change `FunC language overview` → `FunC language overview` (title is proper; verify all H2/H3); `Compiler` → `Compiler` (OK); ensure all headings follow sentence case like `Compile with JS` → `Compile with JS` (should be `Compile with JS`? If enforcing sentence case strictly: `Compile with JS` → `Compile with JS`). Apply sentence case consistently (only first word and proper nouns capitalized): `TON Blockchain course` → `TON Blockchain course`; `Smart contract examples` → `Smart contract examples`; `Changelog` → `Changelog`.

Minimal fix: convert headings to sentence case where any non‑proper words are capitalized unnecessarily.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.1-case-and-form

---

- [ ] **10. Internal links should be relative and deep‑link to anchors**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/index.mdx?plain=1#L28–39,49–51,55–56,65–69,139–145,149–153

Where internal references exist, link to precise anchors. Examples to adjust: use `/ton/transaction` only if that page exists and is canonical; prefer anchor like `/ton/transaction#messages-and-transactions` if relevant. For stdlib functions, use existing anchors from `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/stdlib.mdx?plain=1`, e.g., `#begin_cell`, `#store_slice`, `#store_coins`, `#end_cell`, `#send_raw_message` — these anchors exist and should be spelled with hyphens matching heading IDs.

Minimal fix: verify and update these internal links to the exact anchors; remove links where no canonical page/anchor exists yet.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12.2-what-to-link-and-what-not

---

- [ ] **11. Code fence language `func` should be verified; use correct tag**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/index.mdx?plain=1#L16–26

Fenced code blocks MUST specify a correct language. If the site uses a `func` highlighter, leave as is; otherwise, use the closest supported lexer (`fift`, `c`, or `text`) temporarily. This requires confirmation with the docs engine. Minimal fix pending domain decision; label as needs owner confirmation.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10.1-general-rules

---

- [ ] **12. Placeholder and tone issues in external links list**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/index.mdx?plain=1#L119–131

Avoid informal attributions and conversational tone in resource lists; use consistent, descriptive link text without handles where not needed. Also avoid en dashes surrounded by spaces when a colon suffices. Minimal fix: standardize bullets, e.g., “Func and Blueprint video (YouTube)” and move author attribution to parentheses if necessary.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording

---

- [ ] **13. Table should have concise, descriptive headers; use ASCII em dash consistently**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/index.mdx?plain=1#L139–145

Ensure table headers are concise and casing consistent. Replace the em dash placeholder `—` used for missing content with a clear term like “N/A” or leave cell empty per table style. Minimal fix: replace `—` with `N/A`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#15.2-structure-and-tables

---

- [ ] **14. External GitHub release link should be version‑stable or labeled**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/index.mdx?plain=1#L65–69

When linking to specific releases for reproducibility, prefer a tag when referencing a fixed version or `latest` when the intent is to fetch current binaries. If the version is historical context, label it as such. Minimal fix: confirm intent; either pin all items with explicit version context or switch to `releases/latest` per stability rule.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12.5-external-references

---

- [ ] **15. Consistency: glossary and term casing**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/index.mdx?plain=1#L13–15,49–51

Ensure terms like “Fift assembler”, “TVM”, “TON Blockchain”, “smart contracts” follow casing from Glossary and Appendix B. For example, “smart contracts” (lowercase), “TON Blockchain” (proper noun), and avoid capitalizing generic terms mid‑sentence. Minimal fix: audit and adjust casing per term bank.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13.2-general-casing-rules

---

- [ ] **16. Remove redundant phrasing and throat‑clearing**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/index.mdx?plain=1#L14

“To give a taste of FunC syntax, here is a simple example…” is throat‑clearing. Minimal fix: “Example: send a payment in FunC.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **17. Use Oxford comma in series**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/index.mdx?plain=1#L65

“Windows, macOS (Intel or Arm64), and Ubuntu” already uses Oxford comma; verify all lists. If any list lacks the serial comma, add it. Minimal fix: none if consistent; leave as verification note.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.1-commas-colons-semicolons

---

- [ ] **18. Replace hyphenation and abbreviations per term bank**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/index.mdx?plain=1#L13–15

Use “domain‑specific” with a hyphen. Confirm usage matches the term bank. Minimal fix: ensure hyphenation of compound modifiers.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13.3-hyphenation-and-abbreviations

---

- [ ] **19. Course cards: label non‑English resources**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/index.mdx?plain=1#L82–92

Per external reference and accessibility rules, label non‑English links with language. Current cards use titles “(Chinese)” and “(Russian)” only. Minimal fix: make link texts descriptive and include language labels, e.g., “TON Blockchain course (Chinese)” and “TON Blockchain course (Russian)”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12.5-external-references

---

- [ ] **20. Use of "etc." in user‑facing list**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/index.mdx?plain=1#L149

The phrase "multi-signature wallets, etc." uses "etc." in a list. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references. Minimal fix: remove "etc." and end the sentence without it (keep a complete example list or stop after the last example).

---

- [ ] **21. Redundant doublet "Developers and engineers"**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/index.mdx?plain=1#L51

The phrase "Developers and engineers" is a pleonasm/doublet. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references. Minimal fix: use "Developers" only.

---

- [ ] **22. Inconsistent spelling: "FunС" uses a non‑ASCII letter**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/index.mdx?plain=1#L129

The word "FunС" appears with a Cyrillic "С" instead of ASCII "C". Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17-4-proofread. Minimal fix: replace with "FunC".

---

- [ ] **23. Status callout lacks status title and timeline**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/index.mdx?plain=1#L67-L69

The Aside communicates deprecation/legacy status but lacks a status title and removal timeline. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-4-status-labels. Minimal fix: set a clear status title, e.g., `<Aside type="note" title="Deprecated"> … </Aside>`, and state the replacement and removal timeline (date or version). The replacement (Tolk) is already referenced.

---

- [ ] **24. External link used where internal doc exists (internal‑first linking)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/index.mdx?plain=1#L67-L69

The Aside links Tolk via an external GitHub releases page. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not. Minimal fix: link the internal Tolk documentation page (`/language/tolk`) for the language reference; keep the GitHub link only when specifically referring to release artifacts.