### PR TITLE
[AI] fix: deploy.mdx

### DIFF
--- a/ecosystem/blueprint/deploy.mdx
+++ b/ecosystem/blueprint/deploy.mdx
@@ -1,27 +1,29 @@
----
-title: "Deployment and interaction"
+title: "How to deploy and interact with contracts"
+sidebarTitle: "Deploy and interact"
 ---
 
-Following development and testing, contracts can be deployed and interacted with. This section outlines deployment scripts, provider configuration, and interaction workflows.
+Following development and testing, contracts can be deployed and interacted with.
 
-## Running scripts
+## Run scripts
 
 Blueprint allows you to run scripts directly from the project.
 
 1. Place your script in the `scripts/` folder.
-2. Each script file must export a `run` function:
+1. Each script file must export a `run` function:
     ```typescript
     export async function run(provider: NetworkProvider, args: string[]) {
       //
     }
     ```
-3. Run the script with: `npx blueprint run <SCRIPT> [arg1, arg2, ...]` command.
+1. Run the script with: `npx blueprint run <SCRIPT>`
 
-## Deploying contracts
+<SCRIPT> — script name.
 
-To deploy a smart contract, create a deployment script in `scripts/deploy<Contract>.ts` with following content.
+## Deploy contracts
 
-```typescript title="./scripts/deploy<Contract>.ts" expandable
+To deploy a smart contract, create a deployment script in `scripts/deploy-<CONTRACT>.ts` with the following content.
+
+```typescript title="./scripts/deploy-<CONTRACT>.ts" expandable
 import { toNano } from '@ton/core';
 import { MyContract } from '../wrappers/MyContract';
 import { compile, NetworkProvider } from '@ton/blueprint';
@@ -37,21 +39,25 @@ export async function run(provider: NetworkProvider) {
 }
 ```
 
-### Interactive mode
+### Use interactive mode
 
-To launch a guided prompt to create a contract step by step, use:
+To launch a guided prompt to deploy a contract step by step, use:
 
 ```bash
 npx blueprint run
 ```
 
-### Non-interactive mode
+### Use non-interactive mode
 
-To create a contract without prompts, provide the contract name and template type:
+To run a deployment script without prompts, provide the contract name and deployment method:
 
 ```bash
 npx blueprint run deploy<CONTRACT> --<NETWORK> --<DEPLOY_METHOD>
 ```
+
+<CONTRACT> — contract name.
+<NETWORK> — network flag value.
+<DEPLOY_METHOD> — deployment method flag.
 
 **Example:**
 
@@ -59,11 +65,11 @@ npx blueprint run deploy<CONTRACT> --<NETWORK> --<DEPLOY_METHOD>
 npx blueprint run deployCounter --mainnet --tonconnect
 ```
 
-## Deploying methods
+## Deployment methods
 
 ### Mnemonic provider
 
-Run scripts with a wallet using mnemonic authentication by configuring environment variables and specifying the `--mnemonic` for a non-interactive method.
+Run scripts with a wallet using mnemonic authentication by configuring environment variables and use the `--mnemonic` option in non-interactive mode.
 
 **Required variables:**
 
@@ -79,7 +85,7 @@ WALLET_VERSION="v4r2"                      # Wallet contract version
 
 **Optional variables:**
 
-- `WALLET_ID` — wallet ID for versions earlier than `v5r1`, excluding `v5r1`.
+- `WALLET_ID` — wallet ID for versions earlier than `v5r1`.
 - `SUBWALLET_NUMBER` — subwallet number for `v5r1` wallets.
 
 _See the [wallet v5 reference](https://github.com/ton-org/ton/blob/master/src/wallets/v5r1/WalletV5R1WalletId.ts) for `WALLET_ID` construction._
@@ -93,20 +99,20 @@ Run scripts with a wallet using TON Connect by specifying the `--tonconnect` opt
 **Steps:**
 
 1. After running the command, select a wallet from the available options.
-2. Scan the generated QR code in your wallet app or open the provided link.
-3. Confirm the transaction in the wallet's interface.
+1. Scan the generated QR code in your wallet app or open the provided link.
+1. Confirm the transaction in the wallet's interface.
 
 Once confirmed, the contract is deployed.
 
 ## Interaction
 
-After deploying your contracts, you can interact with them using Blueprint scripts. These scripts use the [wrappers](/ecosystem/blueprint/develop#wrappers) you've created to send messages and call get methods on your deployed contracts.
+After deploying your contracts, you can interact with them using Blueprint scripts. These scripts use the [wrappers](./develop#wrappers) you've created to send messages and call get methods on your deployed contracts.
 
-To run following scripts refer to [Running scripts](#runningscripts) section.
+To run the following scripts, see [Run scripts](#run-scripts).
 
-### Sending messages
+### Send messages
 
-To send [messages](/ton/transaction) to your deployed contracts, create a script that calls the `send` methods defined in your wrapper. These methods trigger contract execution and modify the contract's state.
+To send [messages](../../ton/transaction) to your deployed contracts, create a script that calls the `send` methods defined in your wrapper. These methods trigger contract execution and modify the contract's state.
 
 ```typescript title="./scripts/sendIncrease.ts"
 import { Address, toNano } from '@ton/core';
@@ -128,7 +134,9 @@ export async function run(provider: NetworkProvider) {
 }
 ```
 
-### Executing get methods
+<CONTRACT_ADDRESS> — address of the deployed contract.
+
+### Execute get methods
 
 Get methods allow you to read data from your deployed contracts without creating transactions. These methods are free to call and don't modify the contract's state.
 


### PR DESCRIPTION
- [ ] **1. Ordered lists must use `1.` for all items (Running scripts)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#L11

The ordered list under “Running scripts” uses `1., 2., 3.`. Per the guide, ordered lists must use `1.` for every item and let the renderer auto-number. Minimal fix: change items 2 and 3 to start with `1.`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **2. Command shows non-copyable placeholders and ellipsis**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#L18

The command `npx blueprint run <SCRIPT> [arg1, arg2, ...]` uses square-bracket placeholders and a literal ellipsis, making it non–copy-pasteable. Minimal fix: show a runnable form and define placeholders, for example: `npx blueprint run <SCRIPT>` or `npx blueprint run <SCRIPT> <ARG1> <ARG2>`, and explain arguments below.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-5-placeholder-names

---

- [ ] **3. Placeholders are not defined at first use**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#L18

Per the examples rule, placeholders must be defined on first use. Define: `<SCRIPT>` (script name), `<CONTRACT>` (contract name), `<NETWORK>` (network flag value), `<DEPLOY_METHOD>` (deployment method flag), `<CONTRACT_ADDRESS>` (address of the deployed contract). Add brief one-line definitions immediately after the first occurrence in each section.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **4. Broken internal anchor and grammar (“following scripts”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#L105

Link target `#runningscripts` will not resolve; the generated slug is `#running-scripts`. Also add missing articles/punctuation for clarity. Minimal fix: “To run the following scripts, see [Running scripts](#running-scripts).”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format

---

- [ ] **5. Task headings should use imperative verbs (avoid gerunds)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#L7

Headings are procedural but use gerunds: “Running scripts”, “Deploying contracts”, “Sending messages”, “Executing get methods”. Minimal fix: change to “Run scripts”, “Deploy contracts”, “Send messages”, “Execute get methods”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles

---

- [ ] **6. Subsection headings should be imperative (Interactive/Non-interactive)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#L40

Procedural subsections use noun phrases: “Interactive mode”, “Non-interactive mode”. Minimal fix: change to “Use interactive mode” and “Use non-interactive mode”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles

---

- [ ] **7. Grammar: “with following content” → “with the following content”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#L22

Missing article reduces clarity. Minimal fix: “...with the following content.” (Basic English grammar; general knowledge.)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#15-1-language-and-reading

---

- [ ] **8. Placeholder casing inconsistent (`<Contract>` vs `<CONTRACT>`)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#L22

Placeholders must use `<ANGLE_CASE>`. Replace `<Contract>` with `<CONTRACT>` in prose and in the code block title attribute.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-5-placeholder-names

---

- [ ] **9. Partial snippet not labeled “Not runnable” (script skeleton)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#L13

The minimal script skeleton is an excerpt and not runnable as-is. Label it per the partial snippet rule. Minimal fix: add a “Not runnable” label above the block.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **10. External link should use a stable permalink (not `master`)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#L85

The GitHub link points to the moving `master` branch. For normative references, use a tag or commit permalink. Minimal fix: update the URL to a specific commit or release tag path.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references

---

- [ ] **11. Ordered lists must use `1.` for all items (TON Connect steps)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#L95

The ordered list under “Steps:” uses `1., 2., 3.`. Change all items to start with `1.` to let the renderer auto-number.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **12. Partial snippet not labeled “Not runnable” (send script)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#L111

The `sendIncrease.ts` example depends on external wrapper context and is not runnable standalone. Label it as a partial snippet or link to a full runnable example. Minimal fix: add a “Not runnable” label above the block.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **13. Partial snippet not labeled “Not runnable” (get script)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#L135

The `getCounter.ts` example depends on external wrapper context and is not runnable standalone. Label it as a partial snippet or link to a full runnable example. Minimal fix: add a “Not runnable” label above the block.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **14. Ambiguous/gerund heading: make it a clear label**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#deploying-methods

The H2 "Deploying methods" is gerund-based and unclear as a section label. For a concept section that lists options, use a noun phrase. Minimal fix: change to "Deployment methods".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-2-gerunds-and-labels

---

- [ ] **15. Internal links should be relative (avoid root-absolute)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1 (multiple)

Internal links use root-absolute paths: `/ecosystem/blueprint/develop#wrappers` and `/ton/transaction`. Prefer relative links for stability. Minimal fixes: change to `./develop#wrappers` and `../../ton/transaction` respectively.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format

---

- [ ] **16. Filename example not kebab-case; placeholder case inconsistent**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#deploying-contracts

"scripts/deploy<Contract>.ts" and the code block title `./scripts/deploy<Contract>.ts` are not kebab-case and use mixed-case placeholders. Filenames in examples must be kebab-case; placeholders in prose/paths should use `<ANGLE_CASE>`. Minimal fix: use `scripts/deploy-<CONTRACT>.ts` in text and `title="./scripts/deploy-<CONTRACT>.ts"` in the fence title.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **17. Code fence language for .env should be `dotenv`**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#mnemonic-provider

The `.env` example uses "```env" as the language. Use the `dotenv` language tag for `.env` files for accurate highlighting/tooling. Minimal fix: change the fence from `env` to `dotenv`. This relies on general knowledge of common syntax highlighters.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **18. Throat-clearing opener; make it action-oriented**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1 (intro paragraph)

The opener describes the section instead of delivering actionable value ("This section outlines..."). Remove throat-clearing and start with the action. Minimal fix: drop "This section outlines ..." and keep a concise task-oriented opener (e.g., "Deploy and interact with contracts using Blueprint scripts.").
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **19. Redundant word in instruction sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#running-scripts

"Run the script with: `...` command." ends with a redundant "command" after the inline command. Minimal fix: remove the trailing word: "Run the script with: `npx blueprint run ...`" or present the command as a fenced block.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **20. Page title should follow How-to pattern**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#L1

The page reads as a task/how-to guide. Per the How‑to frontmatter pattern, set a task‑oriented title and sidebar label. Minimal fix: change `title: "Deployment and interaction"` to `title: "How to deploy and interact with contracts"` and add `sidebarTitle: "Deploy and interact"` (concise, sentence case).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-1-files-and-titles

---

- [ ] **21. Safety callout missing for secrets and mainnet actions**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#L58–92

This page instructs setting `WALLET_MNEMONIC` and shows a mainnet deploy example. When secrets or funds are involved, include a Caution/Warning `<Aside>` with risk, scope, mitigation, and testnet-first guidance. Minimal fixes:
- Add a Warning `<Aside type="danger" title="Funds at risk">` before any mainnet example, advising to use testnet first and noting irreversibility on mainnet.
- Add a Caution `<Aside type="caution" title="Secrets">` near the mnemonic section, reminding to store mnemonics securely and avoid committing `.env`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-1-when-a-safety-callout-is-required; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#a-admonition-levels-and-usage

---

- [ ] **22. Safer default: use testnet in examples**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#L59

Task pages should default to testnet to reduce risk. Minimal fix: change `--mainnet` to `--testnet` in the non‑interactive example; if showing mainnet, keep it secondary and covered by a Warning callout.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-3-safer-defaults

---

- [ ] **23. Code fence language for .env example**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#L75–78

Use an appropriate language tag (`bash`) for `.env` blocks to aid syntax highlighting and match adjacent docs. Minimal fix: change code fence from `env` to `bash` (the guide is silent on `.env` tags; align with `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/reference.mdx?plain=1#example-env-file`).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **24. Redundant phrasing in optional variables**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#L82

Avoid pleonasm. Minimal fix: `wallet ID for versions earlier than v5r1, excluding v5r1.` → `wallet ID for versions earlier than v5r1.`

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **25. Ellipsis inside example secret value**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#L76

Avoid literal ellipses in code; prefer a single placeholder. Minimal fix: replace `"word1 word2 ... word24"` with `"<MNEMONIC_24_WORDS>"` and define the placeholder below (aligns with `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/reference.mdx?plain=1#example-env-file`). General knowledge: ellipses suggest truncation and are unsafe to copy.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-5-comments-and-omissions; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **26. Mode terminology consistency (“method” vs “mode”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#L48-L66

Use consistent terminology for interactive vs non‑interactive operation. Minimal fix: change “non-interactive method” to “non‑interactive mode” to match the surrounding headings and improve clarity.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **27. Interactive mode text mismatches the `run` command behavior**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#L42–46

Text says “create a contract” but `npx blueprint run` launches interactive script selection (per reference). Minimal fix: “To launch an interactive prompt to select and run a script, use:”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-links-and-cross-references
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles

---

- [ ] **28. Non-interactive mode text mismatches the `run` command**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#L50–54

Text says “create a contract without prompts,” but this section shows running a deployment script. Minimal fix: “To run a deployment script without prompts, provide the contract name and deployment method:”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-links-and-cross-references
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles

---

- [ ] **29. Ambiguous phrasing about `--mnemonic` usage**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#L66

“specifying the `--mnemonic` for a non-interactive method” is unclear. Minimal fix: “and use the `--mnemonic` option in non-interactive mode.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **30. Placeholder misuse inside literal flags**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#non-interactive-mode

The command shows `--<NETWORK>` and `--<DEPLOY_METHOD>` as placeholders embedded in flags. Placeholders should represent values/tokens, not wrap the entire literal flag; alternatively, show concrete flags. Minimal fix: either show a concrete example only (already provided below), or change to `npx blueprint run deploy-<CONTRACT> <NETWORK_FLAG> <METHOD_FLAG>` and define `<NETWORK_FLAG>` (choose one supported network flag) and `<METHOD_FLAG>` (choose `--tonconnect` or `--mnemonic`).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **31. Inline comments inside quoted dotenv values**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#mnemonic-provider

The `.env` example uses inline comments after quoted values (e.g., `"..."  # comment`). Many dotenv parsers treat `#` inside a quoted value as part of the value; inline comments can break copy/paste. Minimal fix: move comments to the preceding line or remove them, e.g., place `# Your wallet mnemonic phrase` on its own line above the assignment. This relies on general knowledge of dotenv parser behavior.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **32. Interactive deploy text says “create a contract”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#interactive-mode

Under "Deploy contracts", the sentence "To launch a guided prompt to create a contract..." contradicts the section’s purpose (deploying). Minimal fix: change "create a contract" to "deploy a contract". This improves accuracy and avoids confusion.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles-reader-first-answer-first

---

- [ ] **33. Inconsistent `run` function signature across examples**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1#running-scripts

Step 2 shows `export async function run(provider: NetworkProvider, args: string[])`, while later examples define `run(provider: NetworkProvider)` without `args`. Examples should be precise and consistent. Minimal fix: clarify in Step 2 that `args` is optional (e.g., show `args?: string[]`) or align all examples to the same signature.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules