### PR TITLE
[AI] fix: btc_teleport.mdx

### DIFF
--- a/ecosystem/node/mytonctrl/btc_teleport.mdx
+++ b/ecosystem/node/mytonctrl/btc_teleport.mdx
@@ -3,6 +3,8 @@ title: "BTC Teleport"
 description: "The BTC Teleport module manages the optional Bitcoin bridge (Teleport) client shipped with MyTonCtrl. Use these commands to inspect proposals, vote on them, or remove the Teleport installation when no longer needed."
 ---
 
+import { Aside } from '/snippets/aside.jsx';
+
 ## Operational notes
 
 - Teleport installation happens automatically when validator mode is enabled unless `btcTeleportDisabled` is set. Use these commands to check governance participation or clean up.
@@ -50,7 +52,15 @@ vote_offer_btc_teleport <offer-hash> [additional_offer_hashes...]
   - Saves the offer locally, builds the vote request, signs it with the validator key, wraps it in a wallet transaction (1.5 TON attach), and submits it to the Teleport configurator.
 - Outputs warnings for missing or already-voted offers and continues processing the rest.
 
+<Aside type="danger" title="Funds at risk">Voting attaches 1.5 TON from the validator wallet.
+Risk: funds deducted from the validator wallet.
+Scope: validator wallet used for voting.
+Rollback/Mitigation: verify balance and offer status before sending.
+Environment: test on TON Testnet before using on TON Mainnet.</Aside>
+
 **Example**
+
+Not runnable:
 
 ```mytonctrl
 vote_offer_btc_teleport 0xabc123... 0xdef456...
@@ -66,11 +76,11 @@ vote_offer_btc_teleport 0xabc123... 0xdef456...
 remove_btc_teleport [--force]
 ```
 
-<Caution>`--force` removes Teleport binaries and service configuration.
+<Aside type="caution">`--force` removes Teleport binaries and service configuration.
 Risk: loss of Teleport state; service downtime.
 Scope: this node’s Teleport installation (binaries, keystore, systemd unit).
 Rollback/Mitigation: reinstall Teleport or restore from a backup of `/usr/src/ton-teleport-btc-periphery` and related configs.
-Environment: applies on both TON Testnet and TON Mainnet nodes.</Caution>
+Environment: test on TON Testnet before using on TON Mainnet.</Aside>
 
 **Behavior**
 


### PR DESCRIPTION
- [ ] **1. Use Aside component for safety callout instead of <Caution>**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/btc_teleport.mdx?plain=1#L69

The safety callout uses a non-standard `<Caution>` component. Safety callouts must use the unified Aside component with the correct type mapping. Minimal fix: add `import { Aside } from '/snippets/aside.jsx';` below the frontmatter, and replace the entire `<Caution>...</Caution>` block with `<Aside type="caution">...</Aside>` without changing the content.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout

---

- [ ] **2. Safety callout must state testnet-first environment**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/btc_teleport.mdx?plain=1#L69

The Environment line says “applies on both TON Testnet and TON Mainnet nodes,” but the callout must include an environment label with safer default instructions first (testnet-first). Minimal fix: change the Environment line to “Environment: test on TON Testnet before using on TON Mainnet.” This mirrors the pattern used in `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/backups.mdx?plain=1` and satisfies the safer-defaults requirement.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-3-safer-defaults

---

- [ ] **3. Truncated IDs with ellipses in example (not copy-pasteable)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/btc_teleport.mdx?plain=1#L56

The example `vote_offer_btc_teleport 0xabc123... 0xdef456...` uses ellipses to truncate hashes, making the command non-runnable and violating the copy/paste requirement. It also triggers the high-severity rule against silent truncation of IDs/addresses. Minimal fix: replace with placeholders and define them immediately below the block, for example:

```mytonctrl
vote_offer_btc_teleport <OFFER_HASH_1> <OFFER_HASH_2>
```

Define placeholders (first use): `<OFFER_HASH_N>` — Teleport proposal hash to vote on.

Alternatively, if you must show truncated values, add a “Not runnable” label above the block per partial snippet rules.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#14-2-units-and-conventions; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#severity-model-release-blocking

---

- [ ] **4. Placeholder style in syntax must use <ANGLE_CASE> and define on first use**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/btc_teleport.mdx?plain=1#L42

The syntax line uses `<offer-hash> [additional_offer_hashes...]` with lowercase and an underscored/ellipsized optional. Placeholders in commands must use `<ANGLE_CASE>` and be defined on first use; for variadic arguments, repeat the same placeholder with `[...]`. Minimal fix:

```mytonctrl
vote_offer_btc_teleport <OFFER_HASH> [<OFFER_HASH>...]
```

Then add a brief definition under the block: `Define placeholders (first use): <OFFER_HASH> — Teleport proposal hash to vote on.`

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **5. Missing safety callout for funds moved by `vote_offer_btc_teleport`**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/btc_teleport.mdx?plain=1#L50

Voting attaches 1.5 TON from the validator wallet, which moves funds. A safety callout is required. Minimal fix: add an `<Aside type="danger" title="Funds at risk">` under this command summarizing Risk (funds deducted), Scope (validator wallet), Rollback/Mitigation (verify balance and offer status before sending), and Environment (test on TON Testnet first).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-1-when-a-safety-callout-is-required