### PR TITLE
[AI] fix: expressions.mdx

### DIFF
--- a/language/func/expressions.mdx
+++ b/language/func/expressions.mdx
@@ -9,6 +9,7 @@ import { Aside } from '/snippets/aside.jsx';
 Expressions in FunC combine literals, variables, operators, and function calls to produce a value when evaluated.
 
 An expression in FunC can be:
+
 - A [number literal](/language/func/literals#number-literals)
 - An [identifier](/language/func/literals#identifiers)
 - A [compile-time built-in](/language/func/literals#compile-time-built-ins)
@@ -16,24 +17,27 @@ An expression in FunC can be:
 - A [variable declaration](#variable-declaration)
 - A [function call](#function-call)
 
-We focus on variable declarations and function calls, since the other kinds of expressions are 
+We focus on variable declarations and function calls, since the other kinds of expressions are
 explained in their respective articles.
 
 As a general rule, all subexpressions inside an expression are evaluated from left to right,
 except in cases where [asm stack rearrangement](/language/func/functions#rearranging-stack-entries) explicitly defines the order.
 
 ## Variable declaration
+
 Local variables must be initialized at the time of declaration. Since variable declarations are expressions, the result of evaluating a declaration like:
 Not runnable
+
 ```func
 type iden = expr
 ```
+
 returns the value produced by `expr`, in addition to defining variable `iden` with value `expr`.
 
 For instance:
 `(int x = 3) + x;`
-declares `x` and assigns to it the value `3`. The result of the expression `(int x = 3)` is therefore `3`, which means that 
-`(int x = 3) + x` evaluates to `6`, since `x` has value `3` after the declaration. 
+declares `x` and assigns to it the value `3`. The result of the expression `(int x = 3)` is therefore `3`, which means that
+`(int x = 3) + x` evaluates to `6`, since `x` has value `3` after the declaration.
 
 Here are further examples of variable declarations, where each line is independent of the others.
 It is possible to use the keyword `var` to let the type checker infer the type (see [hole types](/language/func/types#hole-type)).
@@ -46,9 +50,10 @@ var x = 2;               ;; Equivalent to previous, but with type inference
 [int, var, int] t = [1, 2, 3];
 ```
 
-In the previous examples, `p` and `t` store the entire tensor and tuple, respectively. 
-But it is possible to deconstruct tensors and tuples and assign each component to different variables. 
-Here are some examples that showcase different ways of deconstructing tensors and tuples: 
+In the previous examples, `p` and `t` store the entire tensor and tuple, respectively.
+But it is possible to deconstruct tensors and tuples and assign each component to different variables.
+Here are some examples that showcase different ways of deconstructing tensors and tuples:
+
 ```func
 (int x, int y, int z) = (1, 2, 3);       ;; Assign each tensor component to x, y, and z.
 (int, int, int) (x, y, z) = (1, 2, 3);   ;; Equivalent to previous
@@ -77,6 +82,7 @@ int x = 2;
 int y = x + 1;
 (int, int) x = (y, y + 1);
 ```
+
 After the third line, variable `x` has type `(int, int)`.
 
 ### Variable redeclaration in nested scopes
@@ -101,6 +107,7 @@ However, global variables **cannot** be redeclared. See [Global variables](/lang
 The underscore `_` is used when a value is not needed.
 For example, if `foo` is a function of type `int -> (int, int, int)`,
 you can retrieve only the first return value while ignoring the rest:
+
 ```func
 (int fst, _, _) = foo(42);
 ```
@@ -112,12 +119,14 @@ the function name is followed by its arguments, separated by commas.
 However, unlike many conventional languages, FunC also treats functions as taking a single tensor argument.
 
 For example, suppose `foo` is a function of type `(int, int, int) -> int`. The following two lines are equivalent ways of calling `foo`:
+
 ```func
 int x = foo(1, 2, 3);    ;; Three arguments separated by ,
 int x = foo((1, 2, 3));  ;; The tensor (1, 2, 3) passed as a single argument
 ```
 
 Equivalently, we could assign tensor `(1, 2, 3)` to a variable, and then call `foo`:
+
 ```func
 (int, int, int) t = (1, 2, 3);
 int x = foo(t);    ;; Pass the tensor as a single argument
@@ -125,7 +134,7 @@ int x = foo(t);    ;; Pass the tensor as a single argument
 
 ### Function composition
 
-To illustrate how function composition works in FunC, suppose that together with the previous `foo` function, there is also a `bar` function of type `int -> (int, int, int)`. 
+To illustrate how function composition works in FunC, suppose that together with the previous `foo` function, there is also a `bar` function of type `int -> (int, int, int)`.
 Since `foo` expects a single tensor argument, you can pass the entire result of `bar(42)` directly into `foo`:
 
 ```func
@@ -143,10 +152,10 @@ int x = foo(a, b, c);
 
 In FunC, functions are first-class objects: they can be assigned to variables, passed as arguments to other functions, and returned from functions.
 
-For example, the following function `apply` receives a function `f` of type `int -> int`, and a value `v` of type `int` as arguments. Function `apply` invokes `f` 
+For example, the following function `apply` receives a function `f` of type `int -> int`, and a value `v` of type `int` as arguments. Function `apply` invokes `f`
 with argument `v` and returns the result of the application, i.e., `apply` computes the expression `f(v)`.
 
-```func 
+```func
 int apply(int -> int f, int v) {
   return f(v);
 }
@@ -154,7 +163,7 @@ int apply(int -> int f, int v) {
 
 Let us suppose we have an increment function:
 
-```func 
+```func
 int inc(int x) {
   return x + 1;
 }
@@ -162,7 +171,7 @@ int inc(int x) {
 
 We can then invoke `apply` by passing the increment function:
 
-```func 
+```func
 apply(inc, 2);   ;; produces 3, or equivalently, inc(2)
 ```
 
@@ -174,30 +183,29 @@ var f = inc;
 
 or return it from functions:
 
-```func 
+```func
 int -> int return_inc() {
   return inc;
 }
 ```
 
 <Aside>
-
-FunC does not support lambda expressions. 
-This means that it is not possible to create [anonymous functions](https://en.wikipedia.org/wiki/Anonymous_function).
-
+  FunC does not support lambda expressions.
+  This means that it is not possible to create [anonymous functions](https://en.wikipedia.org/wiki/Anonymous_function).
 </Aside>
 
 ### Special function call notation
 
-In addition to the standard syntax for calling a function, FunC supports two function call notations for specific situations, 
+In addition to the standard syntax for calling a function, FunC supports two function call notations for specific situations,
 the [non-modifying notation](#non-modifying-notation) and the [modifying notation](#modifying-notation), which are explained next.
 
 #### Non-modifying notation
 
-In FunC, a function with at least one argument can be called using the dot `.` notation, also called *non-modifying notation*.
+In FunC, a function with at least one argument can be called using the dot `.` notation, also called _non-modifying notation_.
 
-For example, the function [`store_uint`](/language/func/stdlib#store_uint), which stores an unsigned integer into a cell builder and returns the modified builder, 
+For example, the function [`store_uint`](/language/func/stdlib#store_uint), which stores an unsigned integer into a cell builder and returns the modified builder,
 has type `(builder, int, int) -> builder`, where:
+
 - The first argument is the builder object.
 - The second argument is the value to store.
 - The third argument is the unsigned integer bit length.
@@ -208,7 +216,9 @@ The following way of calling `store_uint` (here, [`begin_cell`](/language/func/s
 builder b = begin_cell();
 b = store_uint(b, 239, 8);
 ```
+
 is equivalent to:
+
 ```func
 builder b = begin_cell();
 b = b.store_uint(239, 8);   ;; Uses non-modifying notation
@@ -220,7 +230,9 @@ simplifying the code further:
 ```func
 builder b = begin_cell().store_uint(239, 8);
 ```
+
 which is equivalent to the standard syntax for calling a function:
+
 ```func
 builder b = store_uint(begin_cell(), 239, 8);
 ```
@@ -261,17 +273,17 @@ builder b = store_uint(
 #### Modifying notation
 
 If a function's first argument is of type `A` and its return type follows the structure `(A, B)`,
-where `B` is an arbitrary type, the function can be called using the `~` notation, also called *modifying notation*.
+where `B` is an arbitrary type, the function can be called using the `~` notation, also called _modifying notation_.
 
 The primary purpose of the `~` notation is to automatically update the first argument in a function call.
-More concretely, suppose `foo` is a function of type `(builder, int, int) -> (builder, int)`, then 
-the call `v = b~foo(2, 3)`, which uses the `~` notation, is equivalent to the standard call `(b, v) = foo(b, 2, 3)`. 
-The statement `(b, v) = foo(b, 2, 3)` reassigns (or updates) the first argument `b` after the call to `foo` finishes. 
+More concretely, suppose `foo` is a function of type `(builder, int, int) -> (builder, int)`, then
+the call `v = b~foo(2, 3)`, which uses the `~` notation, is equivalent to the standard call `(b, v) = foo(b, 2, 3)`.
+The statement `(b, v) = foo(b, 2, 3)` reassigns (or updates) the first argument `b` after the call to `foo` finishes.
 The `~` notation serves as a shortcut to express this reassignment of the first argument.
 
-One possible application of the `~` notation is for working with cell slices. 
-For example, consider a cell slice `cs` and the function `load_uint`, which has type: `(slice, int) -> (slice, int)`. 
-The function `load_uint` takes a cell slice and a number of bits to load, returning the remaining slice and the loaded unsigned integer value. 
+One possible application of the `~` notation is for working with cell slices.
+For example, consider a cell slice `cs` and the function `load_uint`, which has type: `(slice, int) -> (slice, int)`.
+The function `load_uint` takes a cell slice and a number of bits to load, returning the remaining slice and the loaded unsigned integer value.
 The following three calls are equivalent:
 
 ```func
@@ -280,7 +292,7 @@ The following three calls are equivalent:
 int x = cs~load_uint(8);            ;; Call using modifying notation (i.e., `~`)
 ```
 
-#### Adapting functions to use ~
+#### Adapting functions to use \~
 
 When a function type is of the form `(A, ...) -> A`, it is possible to adapt the function so that the `~` notation can be used on such a function.
 This can be achieved using unit types, by redefining the function type to `(A, ...) -> (A, ())`.
@@ -299,11 +311,12 @@ To increment a variable `y` using `inc`, the function should be used as follows:
 y = inc(y);
 ```
 
-Attempting to use the `~` notation on `inc` would fail: 
+Attempting to use the `~` notation on `inc` would fail:
 
 ```func
 y~inc();    ;; DOES NOT COMPILE
 ```
+
 because `inc` does not have a return type of the form `(int, B)`, where `B` is some type.
 
 To use the `~` notation on `inc`, first redefine the function so that it now has type `int -> (int, ())` as follows:
@@ -320,9 +333,9 @@ Now, the following code increments `y`:
 y~inc();
 ```
 
-#### . and ~ in function names
+#### . and \~ in function names
 
-Previously, we redefined `inc` to have type `int -> (int, ())` so that it was possible to use the `~` notation on it. 
+Previously, we redefined `inc` to have type `int -> (int, ())` so that it was possible to use the `~` notation on it.
 However, it would be bothersome to use `inc` in cases where we do not want to increment a variable, but we just want to store the increment in a different variable:
 
 ```func
@@ -330,11 +343,12 @@ However, it would be bothersome to use `inc` in cases where we do not want to in
 ```
 
 In other words, we would also like to use `inc` as if it was the original function with type `int -> int`:
+
 ```func
 int y = inc(x);
 ```
 
-In FunC, it is possible to *also* keep the original `inc` of type `int -> int` so that we can use `inc` in different ways, like:
+In FunC, it is possible to _also_ keep the original `inc` of type `int -> int` so that we can use `inc` in different ways, like:
 
 ```func
 x~inc(); ;; Increments x, using modifying notation


### PR DESCRIPTION
- [ ] **1. Broken link for `store_uint`**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/expressions.mdx?plain=1#L198

The link text `store_uint` has an empty URL (`[]()`), which renders as a broken link. Minimal fix: replace with the correct deep link to the reference entry: `/language/func/stdlib#store_uint`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#123-link-targets-and-format

---

- [ ] **2. Misused danger callout as editorial TODO**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/expressions.mdx?plain=1#L204

An `<Aside type="danger">` is used to display an internal note (“Missing link to `store_uint`...”), which is not a user-facing warning. Danger/Warning callouts are reserved for safety-critical risks. Minimal fix: remove this Aside entirely after fixing the link in item 1.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#111-when-a-safety-callout-is-required; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#112-how-to-write-the-callout

---

- [ ] **3. Incorrect anchor for `begin_cell`**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/expressions.mdx?plain=1#L208

Link uses `/language/func/stdlib#begin-cell`, but the reference heading is ``#### `begin_cell` `` (underscore). Other pages link to `#begin_cell`. Minimal fix: change the link to `/language/func/stdlib#begin_cell` for anchor stability and consistency (see `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/stdlib.mdx?plain=1#L1033` and links in `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1`).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#123-link-targets-and-format

---

- [ ] **4. Code formatting in headings**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/expressions.mdx?plain=1#L286-L326

Headings contain inline code (`` `~` `` and `` `.` ``). Headings must not include styling other than text (reference pages are the only exception). Minimal fix: remove backticks from headings, e.g., “Adapting functions to use ~” and “. and ~ in function names”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#74-formatting-restrictions

---

- [ ] **5. Trailing slash in internal link**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/expressions.mdx?plain=1#L96

Link to Global variables uses a trailing slash: `/language/func/global-variables/`. Internal links should follow a consistent trailing‑slash policy; elsewhere pages omit it. Minimal fix: `/language/func/global-variables`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#163-links-and-anchors

---

- [ ] **6. Unnecessary comma in two‑item list**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/expressions.mdx?plain=1#L191–193

The sentence lists two items with a comma before “and”: “the non‑modifying notation, and the modifying notation”. Use a comma only for lists of three or more. Minimal fix: remove the comma: “the non‑modifying notation and the modifying notation”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#61-commas-colons-semicolons

---

- [ ] **7. Hyphenation for “compile‑time built‑in”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/expressions.mdx?plain=1#L14

Link text reads “compile‑time builtin”. Hyphenate per house style and related pages: “compile‑time built‑in”. Minimal fix: change to “A [compile‑time built‑in](/language/func/literals#compile-time-built-ins)”. (Hyphenation follows house rules; article is already correct.)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#133-hyphenation-and-abbreviations

---

- [ ] **8. Banned filler “just”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/expressions.mdx?plain=1#L83

Phrase “just like in C” uses banned filler “just”. Minimal fix: “as in C” or “like in C”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#136-banned-and-preferred-terms

---

- [ ] **9. Italics used for decoration**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/expressions.mdx?plain=1#L340

Italics emphasize “also” in running text, which is not a first‑mention term or a title. Minimal fix: remove italics around “also”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#62-quotation-marks-and-emphasis

---

- [ ] **10. Plural agreement in “other kind(s) of expressions”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/expressions.mdx?plain=1#L19–20

Text: “the other kind of expressions are…”. Plural noun requires plural form: “other kinds of expressions are…”. Minimal fix: change “kind” → “kinds”. (Basic English grammar.)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#81-paragraphs-and-sentences

---

- [ ] **11. Label partial snippet as “Not runnable”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/expressions.mdx?plain=1#L27–30

The fenced block shows syntax (`type iden = expr`), not runnable code. Partial snippets must be labeled. Minimal fix: add a preceding line “Not runnable” above the code block.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#102-partial-snippets

---

- [ ] **12. Superfluous comma after subject**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/expressions.mdx?plain=1#L145–146

Sentence: “the following function `apply`, receives a function `f` …”. The comma after the subject is unnecessary and slows reading. Minimal fix: remove the comma: “the following function `apply` receives a function `f` …”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#61-commas-colons-semicolons

---

- [ ] **13. Introductory phrase missing comma**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/expressions.mdx?plain=1#L231

“Using the `.` notation it is possible to chain …” lacks a comma after the introductory phrase. Minimal fix: “Using the `.` notation, it is possible to chain …” (Alternatively: “Using the `.` notation, you can chain …” for concision.)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **14. Redundancy: “Equivalently, we could also …”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/expressions.mdx?plain=1#L121

“Equivalently” already implies “also”; using both is pleonastic. Minimal fix: drop “also”: “Equivalently, we could assign the tensor …”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **15. Wordiness: “independent from the other ones”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/expressions.mdx?plain=1#L37

Phrase is wordy; “other ones” can be simplified. Minimal fix: “each line is independent of the others.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **16. Awkward comment punctuation in example**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/expressions.mdx?plain=1#L115

The inline comment ends “separated by ,”. Minimal fix: “separated by commas.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording

---

- [ ] **17. Terminology casing: “compile-time builtin” (singular) vs “built-ins”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/expressions.mdx?plain=1#L14

Link text says “compile-time builtin” (singular, no hyphen), but the canonical term and target heading are “Compile-time built-ins”. Minimal fix: change link text to “compile-time built-ins” to match `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/literals.mdx?plain=1#compile-time-built-ins`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#acronyms-and-terms

---

- [ ] **18. Frontmatter boolean as string**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/expressions.mdx?plain=1#L4

`noindex: "true"` uses a string; the guide specifies `noindex: true` (boolean) when excluding from search. Minimal fix: change to `noindex: true`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#files-and-titles

---

- [ ] **19. Prefer “subexpressions” (no hyphen) for consistency**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/expressions.mdx?plain=1#L22–23

The page uses “sub-expressions”. Elsewhere in the corpus, the canonical TVM page uses “subexpressions” (no hyphen) (see `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/tvm.mdx?plain=1#L3846`). The guide is silent here; prefer consistency with related pages. Minimal fix: replace “sub-expressions” with “subexpressions”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-terminology-and-naming