### PR TITLE
[AI] fix: avatar.mdx

### DIFF
--- a/ecosystem/tma/telegram-ui/reference/avatar.mdx
+++ b/ecosystem/tma/telegram-ui/reference/avatar.mdx
@@ -1,5 +1,4 @@
-title: "Avatar component"
----
+## title: "Avatar component"
 
 Renders an image styled as an avatar, including optional acronym display and badge support. It uses the `Image` component for core functionality.
 


### PR DESCRIPTION
- [ ] **1. Replace “Utilizes” with “Uses”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/telegram-ui/reference/avatar.mdx?plain=1#L5

The sentence uses “Utilizes,” which the style guide discourages in favor of the simpler “use.” Minimal fix: change “Utilizes the Image component…” to “Uses the Image component…”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#52-plain-precise-wording

---

- [ ] **2. Format code identifier `Image` in code font**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/telegram-ui/reference/avatar.mdx?plain=1#L5

Component/class names must use code formatting. Minimal fix: wrap Image in backticks: “Uses the `Image` component for core functionality…”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#132-general-casing-rules

---

- [ ] **3. Make external link text descriptive**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/telegram-ui/reference/avatar.mdx?plain=1#L7

The link displays the raw URL, which is not descriptive for screen readers. Minimal fix: change to descriptive text, e.g., “Avatar — Storybook documentation” while keeping the same URL: `- [Avatar — Storybook documentation](https://tgui.xelene.me/?path=/docs/blocks-avatar--documentation)`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#151-language-and-reading

---

- [ ] **4. Sentence fragment and formal verb**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/telegram-ui/reference/avatar.mdx?plain=1#L5

The second sentence begins with “Utilizes the Image component…”, which is a sentence fragment (missing subject) and uses the formal verb “utilizes”. Use a complete sentence and prefer a simpler verb. Minimal fix: replace with “It uses the Image component for core functionality, enhancing it with avatar-specific features like acronyms and badges.” General knowledge: complete sentences require a subject; “use” is simpler than “utilize”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **5. Wordy phrasing (“specific styles… avatar presentation”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/telegram-ui/reference/avatar.mdx?plain=1#L5

The phrase “specific styles for an avatar presentation” is verbose. Prefer concise, direct wording. Minimal fix: “Renders an image styled as an avatar, including optional acronym display and badge support.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **6. Redundant repetition (tautology) in description**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/telegram-ui/reference/avatar.mdx?plain=1#L5

The sentence repeats the same features (“acronym(s) and badges”) across two clauses. Remove the duplicate mention to reduce tautology. Minimal fix: keep the first mention and delete "enhancing it with avatar-specific features like acronyms and badges." Result: "Renders an image with specific styles for an avatar presentation, including optional acronym display and badge support. Uses the `Image` component for core functionality." Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **7. One-word generic title**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/telegram-ui/reference/avatar.mdx?plain=1#L2

The frontmatter `title` is a single generic word ("Avatar"). One-word generic titles are discouraged except on top-level pages or when the page is a proper name/term. Make the title self-describing. Minimal fix: change to `title: "Avatar component"`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-1-files-and-titles