### PR TITLE
[AI] fix: how-to-mint.mdx

### DIFF
--- a/standard/tokens/jettons/how-to-mint.mdx
+++ b/standard/tokens/jettons/how-to-mint.mdx
@@ -1,6 +1,6 @@
 ---
 title: "How to mint new jettons"
-sidebarTitle: "Minting jettons"
+sidebarTitle: "Mint jettons"
 ---
 
 import { Aside } from '/snippets/aside.jsx';
@@ -10,16 +10,15 @@ import { Aside } from '/snippets/aside.jsx';
   title="Warning — funds at risk"
 >
   Minting and sending messages can move funds. Scope: your wallet and the target jetton contracts.
-  Rollback: on-chain transfers are final; rotate keys if a mnemonic leaks. Do first (testnet):
-  use a test wallet and testnet RPC before mainnet.
+  Rollback: on-chain transfers are final; rotate keys if a mnemonic leaks. First, use a test wallet and a testnet Remote Procedure Call (RPC) before mainnet.
 </Aside>
 
-In order to mint new jettons, that particular Jetton must be mintable. Otherwise it's impossible.
-Next, only mintable Jettons are considered.
+To mint new jettons, the jetton must be mintable.
+This guide covers only mintable jettons.
 
-Minting is not a specified operation in any of the existing TEPs.
-Its implementation is left to developer's choice.
-The following `typescript` code example is based on minting implementaion in
+Minting is not a specified operation in any of the existing TON Enhancement Proposals (TEPs).
+Developers choose the implementation.
+The following TypeScript code example is based on the minting implementation in
 [Notcoin jetton minter contract](https://github.com/OpenBuilders/notcoin-contract/blob/main/contracts/jetton-minter.fc).
 This example contains a manual assembly of all the necessary messages and is useful for studying their possible structure.
 
@@ -96,7 +95,7 @@ async function main() {
 void main();
 ```
 
-However, there is an [SDK](https://github.com/ton-community/assets-sdk) that allows you to avoid manually creating all the necessary messages.
+However, there is a Software Development Kit (SDK), the [Assets SDK](https://github.com/ton-community/assets-sdk), that allows you to avoid manually creating all the necessary messages.
 An example of how it can be used to send the mint message is provided below:
 
 ```typescript
@@ -132,4 +131,4 @@ async function main() {
 void main();
 ```
 
-Finally, you can use web services as [TON MINTER](https://minter.ton.org/) and avoid writing code, just follow the guides.
+Finally, you can use web services such as [TON MINTER](https://minter.ton.org/) and avoid writing code; follow the guides.


### PR DESCRIPTION
- [ ] **1. Wordy opener “In order to” violates brevity rule**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-mint.mdx?plain=1#L17

“In order to mint new jettons…” uses a wordy boilerplate opener. Replace with the concise imperative form: “To mint new jettons, the jetton must be mintable.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **2. Inconsistent capitalization of common term “Jetton” in prose**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-mint.mdx?plain=1#L17-L60

“Jetton/Jettons” is capitalized mid‑sentence; use lowercase “jetton/jettons” when not a proper noun to match prevailing usage (for example, https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/explorers/overview.mdx?plain=1#L11). Minimal fixes: “that particular jetton…”, “only mintable jettons…”, “user’s jetton wallet”. If the guide is silent, prefer consistency with nearby pages. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **3. Acronym “TEPs” not expanded on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-mint.mdx?plain=1#L20

Expand at first use: “TON Enhancement Proposals (TEPs)”. Current: “existing TEPs”. Minimal fix: “existing TON Enhancement Proposals (TEPs)”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **4. Typo: “implementaion” spelled incorrectly**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-mint.mdx?plain=1#L22

Fix spelling: “implementation”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-6-spelling-and-contractions

---

- [ ] **5. Grammar: missing article in “left to developer’s choice”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-mint.mdx?plain=1#L21

Add the definite article for standard English: “left to the developer’s choice.” This is an obvious grammar fix using general English rules. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **6. Article and phrasing in TEP comment**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-mint.mdx?plain=1#L43

Comment reads: “internal transfer is also unspecified by standard, but there is suggested format in TEP 0074”. Fix articles for clarity: “internal transfer is also unspecified by the standard, but there is a suggested format in TEP 0074”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **7. Unclear fragment in code comment “either forward_payload”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-mint.mdx?plain=1#L51

The fragment is incomplete. Make the instruction explicit: change to “we have forward_payload”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **8. Terminology: “toncoins” inconsistent with project usage**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-mint.mdx?plain=1#L60

Use canonical asset naming: replace “toncoins intended to user’s Jetton wallet” with “TON intended for the user’s jetton wallet”. This aligns with common usage of “TON” and “nanotons” elsewhere (see https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-transfer.mdx?plain=1#L12). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **9. Comma splice in final sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-mint.mdx?plain=1#L135

“…, and avoid writing code, just follow the guides.” joins independent clauses with a comma. Replace the comma with a coordinating conjunction or period: “…, and follow the guides.” or “…. Follow the guides.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **10. Placeholders not defined at first use**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-mint.mdx?plain=1#L31–35

The code introduces `<JETTON_MASTER_ADDR>`, `<RECEIVER_ADDR>`, and `<WALLET_ADDR>` but does not define them for the reader. Add a brief definitions block after the snippet, for example: “<JETTON_MASTER_ADDR> — address of the jetton master contract; <RECEIVER_ADDR> — recipient’s wallet address; <WALLET_ADDR> — your wallet address.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-constructing-examples

---

- [ ] **11. Transitional throat-clearing “Next,” adds noise**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-mint.mdx?plain=1#L18

“Next, only mintable Jettons are considered.” Remove the filler transition and apply consistent casing: “This guide covers only mintable jettons.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **12. Sidebar title should be imperative, not gerund**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-mint.mdx?plain=1#L3

`sidebarTitle: "Minting jettons"` uses a gerund. For how‑to pages, the sidebar label should be the task phrased in sentence case and start with an imperative verb. Minimal fix: change to `sidebarTitle: "Mint jettons"`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-2-navigation-labels

---

- [ ] **13. Passive wording; prefer active voice**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-mint.mdx?plain=1#L21

“Its implementation is left to developer's choice.” uses passive voice and a possessive typo. Minimal fix: “Developers choose the implementation.” (active voice) or “The implementation is up to the developer.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-1-voice-tense-and-person

---

- [ ] **14. Typo and language name formatting (“implementaion”, “typescript”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-mint.mdx?plain=1#L22

Contains a typo (“implementaion”) and formats the language name as code and lowercase (“`typescript`”). Minimal fix: correct to “implementation” and “TypeScript” (no code font; capitalize the proper noun). Also add the article: “based on the minting implementation in …”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-6-spelling-and-contractions
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-3-code-styling

---

- [ ] **15. Informal code comment; prefer imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-mint.mdx?plain=1#L36

Comment “// let's add some forward_payload” is informal. Minimal fix: “// Add a forward payload.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#4-voice-and-tone

---

- [ ] **16. Reference style inconsistency (“TEP 0074” → “TEP‑74”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-mint.mdx?plain=1#L43

Comment references “TEP 0074” with a space and zero padding. Elsewhere in the docs the convention is “TEP‑74”. Minimal fix: change to “TEP‑74”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17-4-proofread
Evidence (consistency): https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#mintless-jettons

---

- [ ] **17. Toncoin casing in comment**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-mint.mdx?plain=1#L60

Comment uses “toncoins” in lowercase. The canonical casing is “Toncoin/Toncoins”. Minimal fix: change to “Toncoin”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#b-banned-and-preferred-terms

---

- [ ] **18. Placeholder definitions missing for second code sample**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-mint.mdx?plain=1#L125

String placeholders `'MY_JETTON_ADDRESS'` and `'RECEIVER_ADDRESS'` are used without definitions. Minimal fix: add a brief placeholder definitions list after the code block.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **19. Fragment before colon inside warning aside**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-mint.mdx?plain=1#L13

“Do first (testnet):” is a fragment before a colon. Colons should follow a complete clause. Minimal fix: “First, use a test wallet and a testnet RPC before mainnet.” (remove the colon and make it a complete sentence).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **20. Plain wording (“as” → “such as”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-mint.mdx?plain=1#L135

“use web services as [TON MINTER]” is awkward phrasing. Minimal fix: “use web services such as [TON MINTER] …”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **21. Example should default to testnet endpoint**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-mint.mdx?plain=1#L73

Use testnet by default in risky examples. Minimal fix: change `endpoint: 'https://toncenter.com/api/v2/jsonRPC'` → `endpoint: 'https://testnet.toncenter.com/api/v2/jsonRPC'`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-3-safer-defaults; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **22. Banned filler word in closing sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-mint.mdx?plain=1#L135

Remove "just" in "and avoid writing code, just follow the guides." Minimal fix: "and avoid writing code; follow the guides." (General English rule; banned filler per Appendix B.)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#b-banned-and-preferred-terms

---

- [ ] **23. Acronyms not expanded on first mention (TEP, RPC, SDK)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-mint.mdx?plain=1#L14-L99

First mentions of “TEPs”, “RPC”, and “SDK” are not expanded. Minimal fixes:
- Line 20: “TON Enhancement Proposals (TEPs)”.
- Line 14: “Remote Procedure Call (RPC)”.
- Line 99: “Software Development Kit (SDK)”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms

---

- [ ] **24. Reference to TEP‑74 lacks a link**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-mint.mdx?plain=1#L43

First useful mention of the standard should link to the canonical reference. Minimal fix: link “TEP‑74” to the standard (e.g., `https:https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860///github.com/ton-blockchain/TEPs/blob/master/text/0074-jettons-standard.md?plain=1`) or a specific anchor if applicable.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12.2-what-to-link-and-what-not; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16.3-links-and-anchors

---

- [ ] **25. Casing and grammar in Toncoin/jetton wallet comment**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-mint.mdx?plain=1#L60

Capitalize the currency (Toncoin) and lowercase the common noun (jetton). Fix article and preposition. Minimal fix: “// Toncoin intended for the user’s jetton wallet”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules. For the article/preposition change, this is an obvious grammar fix (general knowledge).

---

- [ ] **26. Placeholder style inconsistent within code examples**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-mint.mdx?plain=1#L32

Use a single placeholder style within a page. The first example uses `<JETTON_MASTER_ADDR>`/`<RECEIVER_ADDR>` while the second uses `MY_JETTON_ADDRESS`/`RECEIVER_ADDRESS`. Minimal fix: prefer UPPER_SNAKE without angle brackets inside code for consistency (e.g., `JETTON_MASTER_ADDR`, `RECEIVER_ADDRESS`, `WALLET_ADDR`).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-5-placeholder-names; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **27. Non-descriptive link text “SDK”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-mint.mdx?plain=1#L99

Link text must be descriptive. Minimal fix: change link text to “Assets SDK” while keeping the same URL.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text