### PR TITLE
[AI] fix: core.mdx

### DIFF
--- a/ecosystem/node/mytonctrl/core.mdx
+++ b/ecosystem/node/mytonctrl/core.mdx
@@ -28,7 +28,7 @@ about <mode_name>
 | `nominator-pool`   | Standard nominator pools.                                                                                                                |
 | `single-nominator` | Orbs' single nominator pools.                                                                                                            |
 | `liquid-staking`   | Liquid staking controllers.                                                                                                              |
-| `liteserver`       | For liteserver usage only, without the validator.                                                                                         |
+| `liteserver`       | For liteserver usage only, without the validator.                                                                                        |
 | `collator`         | Collator-only module.                                                                                                                    |
 | `alert-bot`        | Telegram bot alerts.                                                                                                                     |
 | `prometheus`       | Prometheus-format data exporter.                                                                                                         |
@@ -220,13 +220,14 @@ installer enable THA
 
 **Purpose:** Revert MyTonCtrl to the legacy `MTC1` configuration format.
 
-<Aside type="caution" title="Destructive operation">
-
-- Risk: Reverts configuration and removes the `modes` map.
-- Scope: Local MyTonCtrl configuration on this node.
-- Mitigation: Back up first; restore from backup to revert.
-- Environment: Operational impact; not network-specific.
-
+<Aside
+  type="caution"
+  title="Destructive operation"
+>
+  - Risk: Reverts configuration and removes the `modes` map.
+  - Scope: Local MyTonCtrl configuration on this node.
+  - Mitigation: Back up first; restore from backup to revert.
+  - Environment: Operational impact; not network-specific.
 </Aside>
 
 **Syntax**


### PR DESCRIPTION
- [ ] **1. Command headings should use code font (reference page)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/core.mdx?plain=1#L6-L307

Headings list command identifiers as plain text (e.g., "## about"). On reference pages, identifiers in headings MAY use code font, which preserves exact casing and improves scanability. Minimal fix: wrap each command name in code font in the H2 heading, for example: "## `about`", "## `benchmark`", "## `disable_mode`", etc. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles

---

- [ ] **2. Placeholders not in required <ANGLE_CASE> and undefined on first use**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/core.mdx?plain=1#L12-L313

Placeholders use lower/kebab case (e.g., `<mode_name>`, `<setting-name>`, `<installer_command>`, `<author>/<repo>`, `<user>`) and are not defined on first use. Minimal fix: convert all placeholders to `<ANGLE_CASE>` with UPPER_SNAKE (e.g., `<MODE_NAME>`, `<SETTING_NAME>`, `<SETTING_VALUE>`, `<INSTALLER_COMMAND>`, `<INSTALLER_ARGS>`, `<AUTHOR>`, `<REPO>`, `<BRANCH>`, `<USER>`), and add one-line definitions immediately below each first Syntax block where they appear. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-code-and-command-examples

---

- [ ] **3. Bold used on code tokens in settings list**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/core.mdx?plain=1#L163-L192

List items render tokens as **`code`** (bold + code). Tokens MUST use code font only, not bold. Minimal fix: remove bold styling and keep backticks only (e.g., change `**\`stake\`**` → `` `stake` `` across the list). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **4. Undefined acronym “FIO” on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/core.mdx?plain=1#L54

“FIO” appears without expansion. Minimal fix: “the Flexible I/O Tester (FIO)”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **5. Undefined abbreviation “l/s” in modes table**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/core.mdx?plain=1#L27

The abbreviation “l/s” is unclear. Minimal fix: replace with the full term “liteserver”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **6. Inconsistent casing for “MyTonCore”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/core.mdx?plain=1#L188-L250

The service name appears as “mytoncore” in prose, while other pages use “MyTonCore” (see https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/installer.mdx?plain=1#L76). Minimal fix: standardize to “MyTonCore” in these occurrences. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **7. Modes table: inconsistent sentence‑ending punctuation**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/core.mdx?plain=1#L33-L34

Some description cells end without a period (“Telegram bot alerts”, “Prometheus format data exporter”), while adjacent rows end with periods. Minimal fix: add trailing periods to these rows for consistency. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-punctuation-and-mechanics

---

- [ ] **8. Modes table: grammar/clarity issues in two rows**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/core.mdx?plain=1#L27-L32

- “Activates participating in elections and staking. If pools and l/s modes are disabled stakes from validator wallet.” → Minimal fix: “Participates in elections and staking. If pool and liteserver modes are disabled, stakes from the validator wallet.”
- “Blocks collator-only module.” → Minimal fix: “Collator-only module.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **9. Safety callout missing for destructive rollback operation**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/core.mdx?plain=1#L219-L233

`rollback` is explicitly destructive. Safety callouts are required for operations that modify validator/node configuration. Minimal fix: add an `<Aside type="caution" title="Destructive operation">` before or within the section with: risk (reverts config and removes the `modes` map), scope (local MyTonCtrl configuration on this node), rollback/mitigation (back up first; restore from backup to revert), and environment label (testnet/mainnet not applicable, but note operational impact). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-safety‑critical-content and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout

---

- [ ] **10. First mention of ADNL not expanded**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/core.mdx?plain=1#L248-L251

“ADNL addresses” appears without expansion. Minimal fix: “Abstract Datagram Network Layer (ADNL) addresses” on first mention in this page. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **11. Hyphenation: compound modifier “Prometheus format”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/core.mdx?plain=1#L34

Compound adjective lacks a hyphen. Minimal fix: “Prometheus-format data exporter.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **12. Comma missing after introductory clause**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/core.mdx?plain=1#L21

“When a mode has no dedicated settings the command states that explicitly.” Minimal fix: add a comma after the introductory clause: “When a mode has no dedicated settings, the command states that explicitly.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **13. Frontmatter title is generic; use a descriptive title**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/core.mdx?plain=1#L2

The `title` is a one-word generic label ("Core"), which is not self-describing for search or deep links. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-2-navigation-labels. Minimal fix: change to a descriptive, self‑describing title such as "Core commands".

---

- [ ] **14. Optional arguments shown with square brackets in commands**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/core.mdx?plain=1#L130; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/core.mdx?plain=1#L201–203; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/core.mdx?plain=1#L313–314

Square brackets are used to denote optional parts (e.g., `[--force]`, `[installer_args...]`, `[<branch>]`, `[-u <user>]`) in command blocks. The guide forbids `{}`/`[]` placeholders in commands. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#severity-model-release‑blocking. Minimal fix: remove bracket notation and show separate syntax variants or state optionality in prose. Examples: change `set <SETTING_NAME> <SETTING_VALUE> [--force]` to two Syntax lines: `set <SETTING_NAME> <SETTING_VALUE>` and `set <SETTING_NAME> <SETTING_VALUE> --force`; change `installer <INSTALLER_COMMAND> [<INSTALLER_ARGS>]` to `installer <INSTALLER_COMMAND> <INSTALLER_ARGS>` with a note that `<INSTALLER_ARGS>` is optional; change `upgrade [<BRANCH>]` to two lines: `upgrade` and `upgrade <BRANCH>`; change `upgrade --btc-teleport [<BRANCH>] [-u <USER>]` to explicit variants and explain optional flags in Behavior.

---

- [ ] **15. Silent truncation of address in example**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/core.mdx?plain=1#L144

The example uses a truncated address with `...` ("0:abc123..."). Silent truncation of IDs/addresses is disallowed. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#severity-model-release‑blocking. Minimal fix: replace with a placeholder, for example: `set liquid_pool_addr "<POOL_ADDRESS>"`, and add a one-line definition: `<POOL_ADDRESS> — liquid staking pool address`.

---

- [ ] **16. Informal tone word "Handy" in procedural guidance**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/core.mdx?plain=1#L276

"Handy for auditing" is conversational. Prefer precise, neutral wording. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording. Minimal fix: change to "Useful for auditing which modules are active before enabling or disabling more features."

---

- [ ] **17. Quotes used for emphasis instead of code font**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/core.mdx?plain=1#L221

The phrase "legacy “MTC1” configuration" uses quotation marks to denote a label, not a literal UI/log string. Per the guide, quotes are for literal messages only. Minimal fix: use code formatting instead: `legacy \`MTC1\` configuration` (or remove quotes entirely).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **18. Tokens in prose should use code formatting**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/core.mdx?plain=1#L250

The status description lists service names without code styling and escapes an underscore manually: "mytoncore, validator, btc\_teleport". Tokens, service names, and literals must use code formatting. Minimal fix: change to `` `MyTonCore` ``, `` `validator` ``, and `` `btc_teleport` `` (and remove the manual backslash).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-3-code-styling; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17-4-proofread

---

- [ ] **19. Improve clarity with article/comma in liteserver row**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/core.mdx?plain=1#L31

"For liteserver usage only without validator." is awkward and missing an article/comma. Minimal fix (style/grammar only): "For liteserver usage only, without the validator." Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording