### PR TITLE
[AI] fix: collator.mdx

### DIFF
--- a/ecosystem/node/mytonctrl/collator.mdx
+++ b/ecosystem/node/mytonctrl/collator.mdx
@@ -5,8 +5,11 @@ description: "Collator mode lets a node produce blocks for selected shardchains 
 
 ## Operational notes
 
-<Aside type="danger" title="Validator/network risk">
-Misconfiguration of validator or networking settings can halt your node, produce invalid blocks, or fork it from the network. Scope: this node’s validator and Abstract Datagram Network Layer (ADNL) settings. Rollback/mitigation: revert MyTonCtrl changes or restore a known-good validator configuration backup. Prefer testing changes on a testnet first.
+<Aside
+  type="danger"
+  title="Validator/network risk"
+>
+  Misconfiguration of validator or networking settings can halt your node, produce invalid blocks, or fork it from the network. Scope: this node’s validator and Abstract Datagram Network Layer (ADNL) settings. Rollback/mitigation: revert MyTonCtrl changes or restore a known-good validator configuration backup. Prefer testing changes on a testnet first.
 </Aside>
 
 - Collator mode cannot be enabled while validator mode is active (`enable_mode collator` requires `disable_mode validator` first).
@@ -26,11 +29,15 @@ Misconfiguration of validator or networking settings can halt your node, produce
 setup_collator [--force] [--adnl <ADNL_ID>] <WORKCHAIN>:<SHARD_HEX> [<ADDITIONAL_SHARDS>...]
 ```
 
-<Aside type="caution" title="Potential outage or data loss">
-Using `--force` bypasses shard coverage checks and widens monitoring. Scope: local validator and engine arguments. Rollback: remove added shard arguments and rerun without `--force`.
+<Aside
+  type="caution"
+  title="Potential outage or data loss"
+>
+  Using `--force` bypasses shard coverage checks and widens monitoring. Scope: local validator and engine arguments. Rollback: remove added shard arguments and rerun without `--force`.
 </Aside>
 
 Define placeholders (first use):
+
 - `<ADNL_ID>` — ADNL address in base64.
 - `<WORKCHAIN>:<SHARD_HEX>` — shard identifier pair; `<SHARD_HEX>` is a 16-character hexadecimal prefix.
 - `<ADDITIONAL_SHARDS>` — additional shard identifiers in the same format.
@@ -61,6 +68,7 @@ stop_collator <ADNL_HEX> <WORKCHAIN>:<SHARD_HEX>
 ```
 
 Define placeholders (first use):
+
 - `<ADNL_HEX>` — ADNL address in hexadecimal.
 - `<WORKCHAIN>:<SHARD_HEX>` — shard identifier pair.
 
@@ -105,6 +113,7 @@ add_validator_to_collation_wl <ADNL_HEX> [<ADDITIONAL_ADNL>...]
 ```
 
 Define placeholders (first use):
+
 - `<ADNL_HEX>` — ADNL address in hexadecimal.
 - `<ADDITIONAL_ADNL>` — additional ADNL addresses in hexadecimal.
 
@@ -131,6 +140,7 @@ delete_validator_from_collation_wl <ADNL_HEX> [<ADDITIONAL_ADNL>...]
 ```
 
 Define placeholders (first use):
+
 - `<ADNL_HEX>` — ADNL address in hexadecimal.
 - `<ADDITIONAL_ADNL>` — additional ADNL addresses in hexadecimal.
 
@@ -187,6 +197,7 @@ set_collation_config <PATH_OR_URL>
 ```
 
 Define placeholders (first use):
+
 - `<PATH_OR_URL>` — local filesystem path or an HTTP or HTTPS URL to a JSON document.
 
 **Behavior**


### PR DESCRIPTION
- [ ] **1. Missing safety callout for validator/network configuration changes**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/collator.mdx?plain=1#L6

The page describes operations that modify validator configuration and networking (enabling collator mode, adjusting shard monitoring, and managing collation allowlists) but does not include the required safety callout. Add a Warning callout that states risk, scope, rollback/mitigation, and environment label. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11.1-when-a-safety-callout-is-required and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11.2-how-to-write-the-callout and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#rendering-component-high. Minimal fix: Insert an `<Aside type="danger" title="Validator/network risk">` near the top (before or under “Operational notes”) explaining that misconfiguration can halt or fork nodes; scope is this node’s validator/ADNL settings; rollback by reverting MyTonCtrl changes or restoring a known-good validator config backup; prefer testnet first.

---

- [ ] **2. Destructive flag `--force` lacks required warning**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/collator.mdx?plain=1#L29

`--force` bypasses shard coverage checks and widens monitoring, but no callout warns about potential impact. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11.3-safer-defaults and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11.2-how-to-write-the-callout. Minimal fix: Add an `<Aside type="caution" title="Potential outage or data loss">` adjacent to the `setup_collator` section describing the risk (widening monitored shards and bypassing safety checks), scope (local validator/engine arguments), and rollback (remove added shard arguments and re-run without `--force`).

---

- [ ] **3. Silent truncation of identifiers in examples**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/collator.mdx?plain=1#L60-L120

Examples show truncated ADNL IDs like `2F3C7A...B91` and `6AD1CE...004` without labeling, which is disallowed. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#severity-model-release-blocking (silent truncation of IDs/addresses). Minimal fix: Replace with placeholders (`<ADNL_HEX>`) or clearly invalid full-length samples; do not use ellipses.

---

- [ ] **4. Acronyms not expanded on first use (ADNL, RPC)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/collator.mdx?plain=1#L9-L11

“validator-console RPCs” and “ADNL keys” appear before expansion. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms. Minimal fix: On first mention, write “remote procedure call (RPC)” and “Abstract Datagram Network Layer (ADNL)”; thereafter, use the acronyms.

---

- [ ] **5. Latinism “e.g.” in prose; prefer plain wording**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/collator.mdx?plain=1#L10

Uses “e.g.” in prose. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording. Minimal fix: Replace “(e.g. `2000000000000000`)” with “(for example, `2000000000000000`)”.

---

- [ ] **6. Inconsistent term: “validator-console” vs “validator console”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/collator.mdx?plain=1#L9-L41

Hyphenated “validator-console” is used here, while nearby pages use the unhyphenated term “validator console” (for example, https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/installer.mdx?plain=1#L31/node/mytonctrl/core.mdx:161–163). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13.1-term-bank-canonical-source and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms. Minimal fix: Change “validator-console” to “validator console” in prose; keep code/literal identifiers as-is.

---

- [ ] **7. Moving-target URL used as a normative default (needs decision)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/collator.mdx?plain=1#L173-L188

The example and default reference a `main` branch raw URL for JSON options. When a versioned permalink exists, avoid moving targets for normative references. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12.5-external-references. Minimal fix: If a tagged or otherwise versioned permalink is available, use it; otherwise, add a short note that the URL tracks `main` and may change over time. This requires a domain decision.

---

- [ ] **8. Improper code styling for proper noun (“MyTonInstaller”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/collator.mdx?plain=1#L9

Backticks are used around “mytoninstaller” in prose where a proper noun is intended, not a literal command. Minimal fix: use “MyTonInstaller” (no backticks) in prose; reserve code font for exact commands/flags (e.g., `mytoninstaller -e …`).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-3-code-styling

---

- [ ] **9. Placeholders not defined on first use in Syntax blocks**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/collator.mdx?plain=1

Placeholders appear without local definitions: `<ADNL_ID>` (line 21), `<ADNL_HEX>` (line 47), `<ADDITIONAL_SHARDS>` (line 22), `<ADDITIONAL_ADNL>` (line 109), and `<PATH_OR_URL>` (line 161). Minimal fix: under each “Syntax” section, add a short “Define placeholders (first use):” list clarifying each placeholder (e.g., “`<ADNL_ID>` — ADNL address in base64; `<ADNL_HEX>` — ADNL address in hex; `<PATH_OR_URL>` — local path or HTTPS URL to JSON.”). Keep definitions concise.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **10. Tautology: “allowlist that is allowed”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/collator.mdx?plain=1#L82

Phrase repeats the idea (“allowlist that is allowed to receive…”). Minimal fix: reword to “Enable and populate the validator allowlist to receive collated blocks.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **11. Unexpanded acronym “JSON” at first mention in body**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/collator.mdx?plain=1#L156

“collator options JSON” uses the acronym without expansion at first body mention. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms. Minimal fix: “collator options JavaScript Object Notation (JSON)”.

---

- [ ] **12. Unexpanded acronyms “HTTP(S)” and “URL”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/collator.mdx?plain=1#L166

“HTTP(S) URL” introduces two acronyms without expansion. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms. Minimal fix: “an HTTP or HTTPS Uniform Resource Locator (URL)”. If desired, expand HTTP on first use: “Hypertext Transfer Protocol (HTTP or HTTPS) Uniform Resource Locator (URL)”.

---

- [ ] **13. Replace semicolons joining independent clauses with periods**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/collator.mdx?plain=1#L9-L136

The guide recommends avoiding semicolons and preferring shorter sentences. Minimal fix: split into two sentences:
- Line 9: “…node arguments. Ensure `mytoninstaller` utilities are present and the node runs with permissions to edit `/etc/ton/validator-engine.conf`.”
- Line 115: “Does not disable the allowlist itself. Use `disable_collation_wl` for that.”
- Line 136: “Requires no arguments. Prints an error if the console command fails.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **14. Add comma after “e.g.”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/collator.mdx?plain=1#L10

“(e.g. `2000000000000000`)” is missing the comma after “e.g.” Minimal fix: “(e.g., `2000000000000000`)”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons. The guide is otherwise silent on “e.g.” punctuation; this aligns with nearby pages (https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/validator.mdx?plain=1#L107) and general American English usage (general knowledge).

---

- [ ] **15. Avoid []/{} notation in command syntax (copy/paste hazard)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/collator.mdx?plain=1#L22-L109

Syntax blocks use `[...]` to denote optional items (e.g., “`[--force]`”, “`[<ADDITIONAL_ADNL>...]`”). Bracket notation in copy‑pasteable commands is prohibited. Minimal fix: remove square brackets in the code block and describe optionality in prose or an Options list. For example:
- `setup_collator <WORKCHAIN>:<SHARD_HEX> <ADDITIONAL_SHARDS>...` and below add “Options: `--force` (optional); `--adnl <ADNL_ID>` (optional).”
- `add_validator_to_collation_wl <ADNL_HEX> <ADNL_HEX>...` with prose noting additional IDs are optional.
- `delete_validator_from_collation_wl <ADNL_HEX> <ADNL_HEX>...` with the same clarification.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-5-placeholder-names

---

- [ ] **16. Make placeholder names consistent and define on first use**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/collator.mdx?plain=1#L31

Follow-up command uses `<ADNL>` and `<SHARD>` while earlier sections use `<ADNL_HEX>` and `<WORKCHAIN>:<SHARD_HEX>`. Minimal fix: use the same placeholders as earlier (e.g., `<ADNL_HEX>` and `<WORKCHAIN>:<SHARD_HEX>`) or define `<ADNL>`/`<SHARD>` before use.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-5-placeholder-names