### PR TITLE
[AI] fix: library-cells.mdx

### DIFF
--- a/ton/cells/library-cells.mdx
+++ b/ton/cells/library-cells.mdx
@@ -11,7 +11,7 @@ One of the native features of how TON stores data in cells is deduplication: dup
 A library allows extending the deduplication mechanism onchain, enabling the same efficiency in custom smart contracts.
 
 <Aside type="note">
-You can think of a library cell as a const weak C++ pointer: a small cell that references a larger one, which may include many references. The referenced cell must exist and be registered publicly, that is, published.
+  You can think of a library cell as a const weak C++ pointer: a small cell that references a larger one, which may include many references. The referenced cell must exist and be registered publicly, that is, published.
 </Aside>
 
 ### Low-level details
@@ -44,7 +44,7 @@ The library environment of a smart contract is a hashmap mapping 256-bit cell (r
 ### Hosting a library cell
 
 Libraries are hosted in the states of accounts. More specifically, they reside in the `library` field in the account.
- 
+
 ```tlb
 _ fixed_prefix_length:(Maybe (## 5)) special:(Maybe TickTock)
   code:(Maybe ^Cell) data:(Maybe ^Cell)
@@ -52,7 +52,7 @@ _ fixed_prefix_length:(Maybe (## 5)) special:(Maybe TickTock)
 
 simple_lib$_ public:Bool root:^Cell = SimpleLib;
 ```
- 
+
 One can see the `public` flag in `SimpleLib`.
 This flag allows making a library cell private (accessible only from the account hosting it), even if the account hosting it resides in the masterchain.
 


### PR DESCRIPTION
- [ ] **1. Generic “Introduction” heading**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/library-cells.mdx?plain=1#L7

Heading uses a generic label. Headings must be unique, descriptive, and avoid repeated “Introduction”. Minimal fix: rename to “Overview of library cells”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#headings-and-titles

---

- [ ] **2. Ungrammatical phrasing and inconsistent “onchain” spelling**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/library-cells.mdx?plain=1#L11

Text reads “Library allows to extend deduplication mechanism on-chain…”. Fix grammar and align spelling with nearby pages that use “onchain” (e.g., https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/techniques/using-onchain-libraries.mdx?plain=1). Minimal fix: “A library allows extending the deduplication mechanism onchain, enabling the same efficiency in custom smart contracts.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording; consistency per nearby docs when guide is silent

---

- [ ] **3. Aside missing explicit type**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/library-cells.mdx?plain=1#L13

Admonitions must use the `<Aside>` component with a supported `type` value. Minimal fix: add `type="note"` to the Aside: `<Aside type="note"> … </Aside>`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11.2-how-to-write-the-callout; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#a-admonition-levels-and-usage

---

- [ ] **4. Code token formatting inconsistent (`CTOS`, `XCTOS`)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/library-cells.mdx?plain=1#L28

Tokens and identifiers must be in code font. `XLOAD` is formatted, but `CTOS` and `XCTOS` are not. Minimal fix: “not automatically dereferenced by the `CTOS` instruction (`begin_parse` in FunC)… Use `XLOAD` or `XCTOS` to dereference explicitly.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.2-quotation-marks-and-emphasis

---

- [ ] **5. Hyphenated “Smart-contract” in heading**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/library-cells.mdx?plain=1#L32

Use the canonical term “smart contract” and sentence case in headings. Minimal fix: change heading to “Smart contract library environment”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#headings-and-titles; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#b-banned-and-preferred-terms

---

- [ ] **6. Incorrect casing of “Masterchain”/“Basechain”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/library-cells.mdx?plain=1#L38-L57

TON-specific chain names are lowercased (masterchain, basechain). Minimal fix: replace “Masterchain” → “masterchain” and “Basechain” → “basechain” in these occurrences. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#b-banned-and-preferred-terms

---

- [ ] **7. Missing blank lines around code block**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/library-cells.mdx?plain=1#L46-L54

Provide breathing room around code blocks with blank lines before and after. Minimal fix: add a blank line before the opening ```tlb fence and one after the closing fence. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#headings-and-titles (scannability and spacing)

---

- [ ] **8. Non-descriptive link text (“pattern”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/library-cells.mdx?plain=1#L61

Link text must be descriptive. Minimal fix: change “…read more about this [pattern]…” to “…read more in [Using onchain libraries](/techniques/using-onchain-libraries).” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12.1-link-text

---

- [ ] **9. Throat‑clearing fillers (“Note, however,” / “Also,”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/library-cells.mdx?plain=1#L42-L57

Avoid throat‑clearing phrases. Minimal fix: remove “Note, however,” and “Also,” while keeping the sentences intact (e.g., start directly with the fact). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.7-avoid-tautology-pleonasm-and-throat-clearing

---

- [ ] **10. Ambiguous pronoun (“They always have level 0.”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/library-cells.mdx?plain=1#L19

Prefer precise wording. Minimal fix: replace with “Library cells always have level 0.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording

---

- [ ] **11. Quotation marks used for emphasis around published**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/library-cells.mdx?plain=1#L14

The Aside uses quotes for emphasis: i.e. “published”. Quotes should be reserved for literal UI/log strings or direct quotations. Minimal fix: remove the quotation marks: “i.e., published”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **12. Vague tone: “is fine”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/library-cells.mdx?plain=1#L30

“Creating libraries … is fine.” is informal. Prefer precise wording. Minimal fix: “Creating libraries that reference a cell whose tree contains other library cells is allowed.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **13. Code identifier in prose not styled as code**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/library-cells.mdx?plain=1#L54

`SimpleLib` is a type/identifier referenced in prose and should use code font. Minimal fix: “One can see the `public` flag in `SimpleLib`.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules

---

- [ ] **14. Field names not styled as code in prose**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/library-cells.mdx?plain=1#L40-L42

Field identifiers should be in code font. Minimal fix: add backticks around field names: “…stored in the `library` field of the smart contract’s state… the `library` field of the `init` field of the inbound message…”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules

---

- [ ] **15. Ordered list numbering should use 1. for all items**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/library-cells.mdx?plain=1#L38–42

List items are numbered 1., 2., 3. The guide requires using `1.` for every item and letting the parser auto‑number. Minimal fix: change items 2 and 3 to start with `1.`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.4-lists

---

- [ ] **16. Quotes used for emphasis and Latinism in callout**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/library-cells.mdx?plain=1#L14

Quotation marks are for literal UI/log strings, not emphasis; here “published” is emphasis. Also prefer plain English over Latinisms. Minimal fix: remove quotes and replace “i.e.” with “that is”: “…must exist and be registered publicly, that is, published.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **17. Numeric exit code should be monospaced**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/library-cells.mdx?plain=1#L28

Treat error/exit codes as literals for clarity. Minimal fix: render as “exit code `9`”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#error-and-log-style

---

- [ ] **18. Minor grammar (“in account storage”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/library-cells.mdx?plain=1#L24

Possessive clarifies scope. Minimal fix: “stored in an account’s storage”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording