### PR TITLE
[AI] fix: API.mdx

### DIFF
--- a/standard/tokens/jettons/API.mdx
+++ b/standard/tokens/jettons/API.mdx
@@ -8,16 +8,16 @@ Jetton message and getter formats per TEP‑74 and TEP‑89.
 
 ### Transfer message layout
 
-| Field                  | Type                | Description                                                                                                               |
-| :--------------------- | :------------------ | :------------------------------------------------------------------------------------------------------------------------ |
-| `transfer`             | `0x0f8a7ea5`        | tag                                                                                                                       |
-| `query_id`             | `uint64`            | arbitrary request number                                                                                                  |
-| `amount`               | `VarUInteger 16`    | amount of transferred jettons in elementary units                                                                         |
-| `destination`          | `MsgAddress`        | address of the new owner of the jettons                                                                                   |
+| Field                  | Type                | Description                                                                                                     |
+| :--------------------- | :------------------ | :-------------------------------------------------------------------------------------------------------------- |
+| `transfer`             | `0x0f8a7ea5`        | tag                                                                                                             |
+| `query_id`             | `uint64`            | arbitrary request number                                                                                        |
+| `amount`               | `VarUInteger 16`    | amount of transferred jettons in elementary units                                                               |
+| `destination`          | `MsgAddress`        | address of the new owner of the jettons                                                                         |
 | `response_destination` | `MsgAddress`        | the address to send a confirmation of a successful transfer and any remaining Toncoin from the incoming message |
-| `custom_payload`       | `Maybe ^Cell`       | optional custom data (which is used by either sender or receiver jetton wallet for inner logic)                           |
-| `forward_ton_amount`   | `VarUInteger 16`    | the amount of nanotons to be sent to the destination address                                                              |
-| `forward_payload`      | `Either Cell ^Cell` | optional custom data that should be sent to the destination address                                                       |
+| `custom_payload`       | `Maybe ^Cell`       | optional custom data (which is used by either sender or receiver jetton wallet for inner logic)                 |
+| `forward_ton_amount`   | `VarUInteger 16`    | the amount of nanotons to be sent to the destination address                                                    |
+| `forward_payload`      | `Either Cell ^Cell` | optional custom data that should be sent to the destination address                                             |
 
 ### Forward payload formats
 
@@ -31,48 +31,48 @@ If the `forward_payload` contains a binary message for interacting with the dest
 
 ### Transfer notification message layout
 
-| Field                   | Type                | Description                                             |
-| ----------------------- | ------------------- | ------------------------------------------------------- |
-| `transfer_notification` | `0x7362d09c`        | tag                                                     |
-| `query_id`              | `uint64`            | should be equal to request's `query_id`                 |
-| `amount`                | `VarUInteger 16`    | amount of transferred jettons                           |
+| Field                   | Type                | Description                                                  |
+| ----------------------- | ------------------- | ------------------------------------------------------------ |
+| `transfer_notification` | `0x7362d09c`        | tag                                                          |
+| `query_id`              | `uint64`            | should be equal to request's `query_id`                      |
+| `amount`                | `VarUInteger 16`    | amount of transferred jettons                                |
 | `sender`                | `MsgAddress`        | the address of the previous owner of the transferred jettons |
-| `forward_payload`       | `Either Cell ^Cell` | should be equal to request's `forward_payload`          |
+| `forward_payload`       | `Either Cell ^Cell` | should be equal to request's `forward_payload`               |
 
 ### Excesses message layout
 
-| Field      | Type         | Description                               |
-| ---------- | ------------ | ----------------------------------------- |
-| `excesses` | `0xd53276db` | tag                                       |
-| `query_id` | `uint64`     | should be equal to request's `query_id`   |
+| Field      | Type         | Description                             |
+| ---------- | ------------ | --------------------------------------- |
+| `excesses` | `0xd53276db` | tag                                     |
+| `query_id` | `uint64`     | should be equal to request's `query_id` |
 
 ### Burn message layout
 
-| Field                  | Type             | Description                                                                                                           |
-| ---------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `burn`                 | `0x595f07bc`     | tag                                                                                                                   |
-| `query_id`             | `uint64`         | arbitrary request number                                                                                              |
-| `amount`               | `VarUInteger 16` | amount of burned jettons                                                                                              |
+| Field                  | Type             | Description                                                                                                 |
+| ---------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------- |
+| `burn`                 | `0x595f07bc`     | tag                                                                                                         |
+| `query_id`             | `uint64`         | arbitrary request number                                                                                    |
+| `amount`               | `VarUInteger 16` | amount of burned jettons                                                                                    |
 | `response_destination` | `MsgAddress`     | the address to send a confirmation of a successful burn and any remaining Toncoin from the incoming message |
-| `custom_payload`       | `Maybe ^Cell`    | optional custom data                                                                                                  |
+| `custom_payload`       | `Maybe ^Cell`    | optional custom data                                                                                        |
 
 ### `get_wallet_data()`
 
 No arguments. Outputs:
 
-| Field                | Type             | Description                          |
-| -------------------- | ---------------- | ------------------------------------ |
-| `balance`            | `VarUInteger 16` | amount of jettons in the wallet      |
-| `owner`              | `MsgAddress`     | the wallet owner's address           |
+| Field                | Type             | Description                               |
+| -------------------- | ---------------- | ----------------------------------------- |
+| `balance`            | `VarUInteger 16` | amount of jettons in the wallet           |
+| `owner`              | `MsgAddress`     | the wallet owner's address                |
 | `jetton`             | `MsgAddress`     | the address of the jetton master contract |
-| `jetton_wallet_code` | `Cell`           | the code of this wallet              |
+| `jetton_wallet_code` | `Cell`           | the code of this wallet                   |
 
 ### `get_jetton_data()`
 
 No arguments. Outputs:
 
-| Field                | Type             | Description                                                        |
-| -------------------- | ---------------- | ------------------------------------------------------------------ |
+| Field                | Type             | Description                                                         |
+| -------------------- | ---------------- | ------------------------------------------------------------------- |
 | `total_supply`       | `VarUInteger 16` | the total number of issued jettons                                  |
 | `mintable`           | `Bool`           | a (-1/0) flag indicating whether the number of jettons can increase |
 | `admin_address`      | `MsgAddress`     | the address of the smart contract that controls the jetton          |
@@ -89,18 +89,18 @@ Output: `jetton_wallet_address` as `MsgAddress`.
 
 ### Provide wallet address message layout
 
-| Field                    | Type         | Description                                                |
-| ------------------------ | ------------ | ---------------------------------------------------------- |
-| `provide_wallet_address` | `0x2c76b973` | tag                                                        |
-| `query_id`               | `uint64`     | arbitrary request number                                   |
-| `owner_address`          | `MsgAddress` | the owner's address of the jetton wallet of interest       |
+| Field                    | Type         | Description                                                    |
+| ------------------------ | ------------ | -------------------------------------------------------------- |
+| `provide_wallet_address` | `0x2c76b973` | tag                                                            |
+| `query_id`               | `uint64`     | arbitrary request number                                       |
+| `owner_address`          | `MsgAddress` | the owner's address of the jetton wallet of interest           |
 | `include_address`        | `Bool`       | whether to include the owner's address in the outgoing message |
 
 ### Take wallet address message layout
 
-| Field                 | Type                | Description                                            |
-| --------------------- | ------------------- | ------------------------------------------------------ |
-| `take_wallet_address` | `0xd1735400`        | tag                                                    |
-| `query_id`            | `uint64`            | arbitrary request number                               |
-| `wallet_address`      | `MsgAddress`        | the address of the jetton wallet of interest            |
+| Field                 | Type                | Description                                                    |
+| --------------------- | ------------------- | -------------------------------------------------------------- |
+| `take_wallet_address` | `0xd1735400`        | tag                                                            |
+| `query_id`            | `uint64`            | arbitrary request number                                       |
+| `wallet_address`      | `MsgAddress`        | the address of the jetton wallet of interest                   |
 | `owner_address`       | `Maybe ^MsgAddress` | optional: the owner's address of the jetton wallet of interest |


### PR DESCRIPTION
- [ ] **1. Title is vague and non-descriptive**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/API.mdx?plain=1#L2

The page title is just "API", which does not make sense out of context and is not specific to jettons. Reference titles should use precise identifiers and headings must make sense in TOC/search. Minimal fix: change to "Jetton API".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.-headings-and-titles; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#reference-complete-factual

---

- [ ] **2. Throat-clearing opening sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/API.mdx?plain=1#L5

"This page describes all messages and methods…" is meta-intro text. Start with the content or remove. Minimal fix: "Jetton message and getter formats per TEP‑74 and TEP‑89." (or remove the sentence).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **3. Grammar and agreement in forward_payload sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/API.mdx?plain=1#L24

Issues: "must starts" → "must start"; "32-bits" → "32-bit"; "equals to" → "equal to". Minimal fix: "…the `forward_payload` must start with `0x00000000` (32‑bit unsigned integer equal to zero)…" (retain the rest unchanged).
Rule: General knowledge — English grammar and hyphenation; enforce clarity per https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1.-goals-and-principles-reader-first-answer-first

---

- [ ] **4. Missing article and awkward phrasing; quotes used for emphasis**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/API.mdx?plain=1#L26

Add the article and simplify phrasing; avoid decorative quotes. Minimal fix: "If the comment does not begin with the byte `0xff`, the comment is text; it can be displayed as is to the end user…" (remove quotes around "as is").
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.2-quotation-marks-and-emphasis; General knowledge — English articles/phrasing

---

- [ ] **5. Undefined acronym DEX on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/API.mdx?plain=1#L30

Spell out the term on first use with the acronym in parentheses. Minimal fix: "…with a decentralized exchange (DEX)…".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms; See also: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#decentralized-exchange-dex

---

- [ ] **6. Preposition error: "equal with" → "equal to"**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/API.mdx?plain=1#L37-L47

Use the correct preposition. Minimal fix in all listed lines: replace "should be equal with" with "should be equal to".
Rule: General knowledge — English prepositions; enforce clarity per https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1.-goals-and-principles-reader-first-answer-first

---

- [ ] **7. Currency naming inconsistent: "Toncoins"/"coins" vs "Toncoin"**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/API.mdx?plain=1#L17-L56

Use the canonical currency term consistently. Nearby pages use "Toncoin" for amounts. Minimal fix: replace "Toncoins" (and "coins" in the burn row) with "Toncoin".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms; Evidence: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L72-L124

---

- [ ] **8. Getter headings should use code font for identifiers**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/API.mdx?plain=1#L59-L82

Reference headings may include code font for API identifiers. Currently they are plain text with escaped underscores. Minimal fix: change to "### `get_wallet_data()`", "### `get_jetton_data()`", and "### `get_wallet_address()`".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.-headings-and-titles

---

- [ ] **9. Missing space after code span**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/API.mdx?plain=1#L86

"`jetton_wallet_address`as" is missing a space. Minimal fix: "`jetton_wallet_address` as `MsgAddress`".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1.-goals-and-principles-reader-first-answer-first (clarity); General knowledge — spacing/typography

---

- [ ] **10. Article and noun phrase fixes in get_wallet_data table**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/API.mdx?plain=1#L66-L68

Improve noun phrases with correct articles. Minimal fixes:
- Line 66: "the wallet owner's address"
- Line 67: "the Jetton master contract address"
- Line 68: "the code of this wallet"
Rule: General knowledge — English articles; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1.-goals-and-principles-reader-first-answer-first

---

- [ ] **11. Grammar in get_jetton_data table**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/API.mdx?plain=1#L76-L80

Minimal fixes:
- Line 76: "the total number of issued jettons"
- Line 77: "a (-1/0) flag indicating whether the number of jettons can increase"
- Line 78: "the address of the smart contract that controls the Jetton"
- Line 79: "data in accordance with TEP‑64" (use "with" and hyphenated TEP style for consistency with nearby pages)
- Line 80: "the wallet code for that jetton"
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms (terminology consistency for TEP-64); General knowledge — English grammar
Evidence: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/metadata.mdx?plain=1#L8"TEP‑64"

---

- [ ] **12. Articles and phrasing in provide/take wallet address tables**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/API.mdx?plain=1#L96-L106

Minimal fixes:
- Line 96: "the owner's address of the Jetton wallet of interest"
- Line 97: "whether to include the owner's address in the outgoing message"
- Line 105: "the address of the Jetton wallet of interest"
- Line 106: "optional: the owner's address of the Jetton wallet of interest"
Rule: General knowledge — English articles; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1.-goals-and-principles-reader-first-answer-first

---

- [ ] **13. Prefer plain English over Latinisms (“e.g.”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/API.mdx?plain=1#L28

Replace “e.g.” with “for example” for clarity and localization: “…The intended use of binary comments is, for example, to contain…”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording.

---

- [ ] **14. Mid-sentence capitalization of “Jetton”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/API.mdx?plain=1#L5

Use lowercase “jetton” mid‑sentence. Instances include line 5 (“Jetton processing”), 67 (“Jetton master contract”), 78 (“controls Jetton”), and similar. Minimal fix: lowercase “Jetton” where it is a common noun. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-4-ton-specific-examples.

---

- [ ] **15. External TEP links use moving “master” branch (unstable)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/API.mdx?plain=1#L7

Links to TEPs point to `.../blob/master/...`, which is a moving target. Replace with stable permalinks to a specific tag/commit for reproducibility. If a stable commit is not yet chosen, this item requires a domain decision to select the correct permalink(s). Also consider deep‑linking to the exact section within the TEP. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references (Stable permalinks; Deep links) [HIGH].

---

- [ ] **16. Non-descriptive H2 headings for TEPs**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/API.mdx?plain=1#L7-L88

The headings `## TEP 0074` and `## TEP 0089` are not self-describing out of context. Minimal fix: make them descriptive while keeping the links, for example: "TEP‑74 — Jetton standard" and "TEP‑89 — Jetton wallet discovery".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#headings-and-titles; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#link-text-and-headings

---

- [ ] **17. Quotes used for emphasis around binary comment(s)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/API.mdx?plain=1#L28

Avoid quotation marks for emphasis around terms. Minimal fix: remove quotes around binary comment / binary comments (keep plain text).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **18. Article and noun phrase clarity**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/API.mdx?plain=1#L39

"an address of the previous owner of transferred jettons" is awkward. Minimal fix: "the address of the previous owner of the transferred jettons."
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles-reader-first-answer-first

---

- [ ] **19. Awkward phrasing in response_destination descriptions; Toncoin consistency**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/API.mdx?plain=1#L17-L56

Phrasing is awkward and inconsistent with other pages. Minimal fix (align with existing usage): "the address to send a confirmation of a successful transfer/burn and any remaining Toncoin from the incoming message." See: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#token-transfer.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles-reader-first-answer-first

---

- [ ] **20. get_wallet_data() table: article/preposition fixes**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/API.mdx?plain=1#L65–68

Minimal fixes:
- "amount of jettons on wallet" → "amount of jettons in the wallet"
- "an address of wallet owner" → "the wallet owner's address"
- "an address of Jetton master contract" → "the address of the Jetton master contract"
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles-reader-first-answer-first