### PR TITLE
[AI] fix: built-ins.mdx

### DIFF
--- a/language/func/built-ins.mdx
+++ b/language/func/built-ins.mdx
@@ -1,7 +1,7 @@
 ---
-title: "FunC reserved words and built-ins"
-sidebarTitle: "Reserved words and built-ins"
-noindex: "true"
+title: "FunC reserved keywords and built-ins"
+sidebarTitle: "Reserved keywords and built-ins"
+noindex: true
 ---
 
 import { Aside } from '/snippets/aside.jsx';
@@ -64,13 +64,12 @@ FunC reserves the following symbols and words. These cannot be used as identifie
 
 ## Built-ins
 
-This section covers extra language constructs that are not part of the core but are still important for functionality.
-Although they could be implemented in [stdlib.fc](/language/func/stdlib),
-keeping them as built-in features allows the FunC optimizer to work more efficiently.
+Built-ins are language constructs outside the core that the optimizer handles efficiently.
+Although they could be implemented in [the standard library](stdlib), keeping them built-in enables better optimization.
 
 In addition, FunC does not allow the built-in names in this section to be used as identifiers.
 However, there is an exception: [built-ins with non-symbolic names](#built-ins-with-non-symbolic-names) 
-*can* be used as identifiers for local variables.
+_can_ be used as identifiers for local variables.
 
 ### Built-ins with symbolic names
 
@@ -120,9 +119,7 @@ However, there is an exception: [built-ins with non-symbolic names](#built-ins-w
 
 `run_method0` &emsp; `run_method1` &emsp; `run_method2` &emsp; `run_method3`
 
-<Aside type="danger">
-   The description of each of these built-ins must be specified, together with an example of usage.
-</Aside>
+
 
 #### `throw`
 
@@ -153,11 +150,11 @@ The first argument is a parameter of any type, the second argument defines the e
 Parameterized version of `throw_unless`.
 The first argument is a parameter of any type, the second argument defines the error code, and the third argument is the condition.
 
-#### `~dump`
+#### `~dump` {#dump}
 
 `~dump` outputs a variable to the debug log.
 
-#### `~strdump`
+#### `~strdump` {#strdump}
 
 `~strdump` outputs a string to the debug log.
 
@@ -181,16 +178,12 @@ It uses a 513-bit intermediate result to prevent overflow if the final result fi
 #### `null?`
 
 `null?` checks if the given argument is `null`. In FunC, the value `null` belongs to the TVM type `Null`, which represents the absence of a value for certain atomic types. 
-See [null values](/language/func/types#null-values) for details.
+See [null values](types#null-values) for details.
 
 #### `touch` and `~touch`
 
-`touch` pushes a variable to the top of the stack. `~touch` is identical to `touch`, but it is adapted for use in [modifying syntax](/language/func/functions#modifying-methods). 
-
-<Aside type="danger">
-   Link for modifying syntax is missing.
-</Aside>
+`touch` pushes a variable to the top of the stack. `~touch` is identical to `touch`, but it is adapted for use in [modifying methods](functions#modifying-functions). 
 
 #### `at` 
 
-Function `at` returns the value of a tuple element at the specified position.
+The function `at` returns the value of a tuple element at the specified position.


### PR DESCRIPTION
- [ ] **1. `noindex` should be boolean, not string**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/literals.mdx?plain=1#L4

Frontmatter sets `noindex: "true"` as a string. Per the style guide, use supported frontmatter keys with correct types. Minimal fix: change to `noindex: true` (unquoted boolean).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-2-navigation-labels

---

- [ ] **2. Broken self-link to non-existent anchor `#string-literals`**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/literals.mdx?plain=1#L23

Link text “[string literal]” points to `#string-literals`, which does not exist on this page. Minimal fix: remove the link or update it to a valid local anchor (for example, `#string-without-suffix`) or the canonical string-literals location once defined.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-3-links-and-anchors

---

- [ ] **3. Empty link target for `MsgAddressInt` and placeholder admonition**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/literals.mdx?plain=1#L181

The link [\`MsgAddressInt\` structure]() has an empty URL, and the subsequent `<Aside type="danger">` contains placeholder copy with `!!`. Minimal fix: replace the empty URL with the correct internal anchor (canonical page) or remove the link until confirmed; rewrite or remove the placeholder Aside to neutral text without exclamation marks.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-3-links-and-anchors; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **4. Unlabeled fenced code blocks lack language tag**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/literals.mdx?plain=1#L93-L198

Several code fences do not specify a language, which breaks highlighting and tooling. Minimal fix: change opening fences to ` ```func `.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **5. Code examples missing semicolons (not copy-pasteable)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/literals.mdx?plain=1#L218-L226

In the `H` and `c` suffix examples, the `const` statements lack trailing semicolons, unlike surrounding examples. Minimal fix: add `;` at the end of each statement.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **6. Article usage: “an hexadecimal” → “a hexadecimal”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/literals.mdx?plain=1#L170–171

Grammar issue in “interprets the string as an hexadecimal number”. Minimal fix: change to “a hexadecimal number”. This follows general English grammar (vowel sound rule).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **7. Missing space after code span**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/literals.mdx?plain=1#L118

Text reads `` `value-or-expression`can be …`` without a space after the code span. Minimal fix: add a space → `` `value-or-expression` can be …``.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **8. Terminology consistency: “builtin” → “built-in”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/literals.mdx?plain=1#L73

Uses “reserved builtin name” without a hyphen. Elsewhere the canonical term is “built-in” (see https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/built-ins.mdx?plain=1#built-ins). Minimal fix: change “builtin” to “built-in”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **9. Internal links should be relative, not site-absolute**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/literals.mdx?plain=1#L23-L33

Links use site-absolute paths (`/language/func/...`). Preferred style is relative links. Minimal fix: convert to relative links, e.g., `comments`, `built-ins#reserved-keywords`, `built-ins#built-ins`, `built-ins#built-ins-with-non-symbolic-names`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-3-links-and-anchors

---

- [ ] **10. Heading wording/hyphenation consistency (“multi-line”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/literals.mdx?plain=1#L229

Heading “String with multiple lines” diverges from preferred “multi-line” hyphenation used elsewhere (see https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/comments.mdx?plain=1). Minimal fix: change the heading to “Multi-line strings”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **11. Overuse of bold for long labels in body text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/literals.mdx?plain=1#L13-L122

Multiple standalone lines use long bold spans as labels (for example, “Examples of …”). The guide discourages bolding entire sentences or list items; prefer structure or plain text. Minimal fix: remove bold formatting for these label lines (keep the text and colon), or promote to proper subheadings where appropriate.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **12. Latinisms (“i.e.”/“e.g.”) — prefer plain words**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/literals.mdx?plain=1#L23-L117

Replace “i.e.” with “that is” and “e.g.” with “for example” for clarity and localization. Minimal fix: “(that is, with `"` at the beginning)” and “(for example, `int` or `slice`)”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **13. Partial snippets not labeled as “Not runnable”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/literals.mdx?plain=1#L162–166, 173–177, 187–191, 198–202, 208–210, 215–219, 225–227, 236–241

The page presents focused excerpts that are not full, runnable programs. Partial snippets must be labeled clearly above the block. Minimal fix: add a line “Not runnable” immediately above each affected code block.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **14. Grammar: subject–verb agreement (“contents … is”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/literals.mdx?plain=1#L160

“the contents of the slice is the binary code…” has mismatched agreement. Minimal fix: keep “contents” and use the plural verb: “the contents of the slice are the binary code…”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#8-1-paragraphs-and-sentences

---

- [ ] **15. Punctuation: add comma for nonrestrictive clause**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/literals.mdx?plain=1#L22

“spaces including tabs” reads as nonrestrictive. Add commas around the phrase: “spaces, including tabs,”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **16. Awkward phrasing in list item (comma as noun)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/literals.mdx?plain=1#L126

“Multiple string constants separated with ,” uses a bare comma. Prefer a worded form. Minimal fix: “Multiple string constants separated by commas.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#8-1-paragraphs-and-sentences

---

- [ ] **17. List punctuation inconsistency (trailing comma)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/literals.mdx?plain=1#L67

One list item ends with a trailing comma while adjacent items have no terminal punctuation. Minimal fix: remove the trailing comma for consistent style across the list.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists