### PR TITLE
[AI] fix: addresses-workflow.mdx

### DIFF
--- a/ecosystem/wallet-apps/addresses-workflow.mdx
+++ b/ecosystem/wallet-apps/addresses-workflow.mdx
@@ -2,24 +2,24 @@
 title: "Addresses workflow"
 ---
 
-To understand this article, it is necessary to periodically refer to [account statuses page](/ton/statuses).
+See [Account statuses](../../ton/statuses) as needed.
 
-At the moment, TON wallets work with [addresses](/ton/addresses/address-formats) as follows:
+TON wallets work with [address formats](../../ton/addresses/address-formats) as follows:
 
-For receiving:
+## Receiving
 
 - Wallets display the user's address in a user-friendly bounceable or non-bounceable form.
 
-When sending:
+## Sending
 
-0) A user sends a message with funds and, possibly, a comment to the destination's wallet address in one of the user-friendly formats through the wallet application.
+1. A user sends a message with funds and optionally a comment to the destination's wallet address in one of the user-friendly formats through the wallet app.
 
-1) The wallet app checks the validity of the destination address representation - its length, valid characters, prefix and checksum. If the address is not valid, then an alert is shown and the sending operation is not performed.
+1. The wallet app checks the validity of the destination address representation: its length, valid characters, prefix, and checksum. If the address is not valid, the wallet app shows an alert and does not send.
 
-2) If the address has a testnet flag, and the wallet app works with the mainnet network, then an alert is shown and the sending operation is not performed.
+1. If the address has a [Testnet-only flag](../../ton/addresses/address-formats#flag-definitions) and the wallet app works on Mainnet, then the wallet app shows an alert and does not send.
 
-3) The wallet app retrieve from address bounceable flag.
+1. The wallet app retrieves the bounceable flag from the address.
 
-4) The wallet app check the destination address. If it has `unitialized` status, the app force set `bounce` field of sending message to `false` and ignore bounceable/non-bounceable flag from address representation.
+1. The wallet app checks the destination address. If it has `uninit` status, the app forces the `bounce` field of the sending message to `false` and ignores the bounceable/non-bounceable flag in the address representation.
 
-5) If destination is not `unitialized` then the wallet app uses the bounceable/non-bounceable flag from the address representation for the `bounce` field of sending message.
+1. If the destination is not `uninit`, then the wallet app uses the bounceable/non-bounceable flag from the address representation for the `bounce` field of the sending message.


### PR DESCRIPTION
- [ ] **1. Throat-clearing opener and non-descriptive link text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/wallet-apps/addresses-workflow.mdx?plain=1#L5

The sentence “To understand this article, it is necessary to periodically refer to [account statuses page](/ton/statuses).” is meta/throat-clearing and the link text is vague. Minimal fix: “See [Account statuses](/ton/statuses) as needed.” This removes the throat-clearing and makes the link text descriptive.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.7-avoid-tautology-pleonasm-throat-clearing-and-circular-references; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12.1-link-text

---

- [ ] **2. Time-relative phrasing (“At the moment,”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/wallet-apps/addresses-workflow.mdx?plain=1#L7

Avoid time-relative qualifiers. Minimal fix: remove “At the moment,” → “TON wallets work with [address formats](/ton/addresses/address-formats) as follows:”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17.2-timelessness

---

- [ ] **3. Link text “addresses” is not descriptive**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/wallet-apps/addresses-workflow.mdx?plain=1#L7

The link text “[addresses](/ton/addresses/address-formats)” is too generic. Use a descriptive label. Minimal fix: change to “[address formats](/ton/addresses/address-formats)”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12.1-link-text

---

- [ ] **4. Punctuation: use colon for list and Oxford comma**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/wallet-apps/addresses-workflow.mdx?plain=1#L17

Replace the dash introducing a list with a colon and add the serial comma. Minimal fix: “checks the validity of the destination address representation: its length, valid characters, prefix, and checksum.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.1-commas-colons-semicolons

---

- [ ] **5. Pleonasm and terminology: “mainnet network”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/wallet-apps/addresses-workflow.mdx?plain=1#L19

“mainnet network” is redundant. Use “mainnet” as a common noun and remove the duplicate “network”. Minimal fix: “…the wallet app works on mainnet…”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.7-avoid-tautology-pleonasm-throat-clearing-and-circular-references; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13.3-hyphenation-and-abbreviations

---

- [ ] **6. Grammar: subject–verb agreement and wording**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/wallet-apps/addresses-workflow.mdx?plain=1#L21

Fix agreement and phrasing. Minimal fix: “The wallet app retrieves the bounceable flag from the address.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording. General knowledge: English subject–verb agreement.

---

- [ ] **7. Status term, spelling, and grammar in step 4**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/wallet-apps/addresses-workflow.mdx?plain=1#L23

Use the canonical status name, fix spelling, and improve phrasing. Minimal fix: “The wallet app checks the destination address. If it has `uninit` status, the app forces the `bounce` field of the sending message to `false` and ignores the bounceable/non-bounceable flag in the address representation.” Also correct the misspelling “unitialized” → `uninit`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.6-spelling-and-contractions. Cross-doc: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#status-variety (uses `uninit`). General knowledge: English grammar and article usage.

---

- [ ] **8. Status term, spelling, and grammar in step 5**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/wallet-apps/addresses-workflow.mdx?plain=1#L25

Maintain the same canonical status term and fix grammar. Minimal fix: “If the destination is not `uninit`, then the wallet app uses the bounceable/non-bounceable flag from the address representation for the `bounce` field of the sending message.” Also correct “unitialized” → `uninit`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.6-spelling-and-contractions. Cross-doc: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/statuses.mdx?plain=1#status-variety (uses `uninit`). General knowledge: English grammar and article usage.

---

- [ ] **9. Use proper H2 headings instead of colon fragments**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/wallet-apps/addresses-workflow.mdx?plain=1#L9-L13

“For receiving:” and “When sending:” are fragment lines ending with colons, not headings. Use real headings for structure and navigation. Minimal fix: Replace with “## Receiving” and “## Sending”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#headings-and-titles; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **10. Ordered list formatting uses `0)`/`1)` instead of `1.`**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/wallet-apps/addresses-workflow.mdx?plain=1#L15–25

Procedural steps must use Markdown ordered lists with `1.` for each item (auto‑numbered). Minimal fix: Convert items 0–5 to an ordered list where each line starts with `1.` and remove the closing parentheses.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **11. Use active voice in steps (alerts and cancellation)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/wallet-apps/addresses-workflow.mdx?plain=1#L17-L19

Passive phrasing (“an alert is shown and the sending operation is not performed”) reduces clarity. Minimal fix: Rewrite as active voice, e.g., “the wallet app shows an alert and does not send.” Apply to both occurrences.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-1-voice-tense-and-person

---

- [ ] **12. Deep‑link first mention of flags to the reference**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/wallet-apps/addresses-workflow.mdx?plain=1#L19

On first mention of a flag, link to the canonical reference anchor. Minimal fix: Change “testnet flag” to “[Testnet‑only flag](/ton/addresses/address-formats#flag-definitions)”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not

---

- [ ] **13. Network names casing and redundancy (“testnet flag”, “mainnet network”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/wallet-apps/addresses-workflow.mdx?plain=1#L19

Project usage capitalizes these network names; also “mainnet network” is redundant. Minimal fix: “If the address has a Testnet flag and the wallet app works on Mainnet, then an alert is shown and the sending operation is not performed.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#b-banned-and-preferred-terms
Evidence: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1 (uses “Testnet” and “Mainnet”)

---

- [ ] **14. Terminology consistency: “wallet app” vs “wallet application”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/wallet-apps/addresses-workflow.mdx?plain=1#L15

Step 0 uses “wallet application” while subsequent steps say “wallet app”. Minimal fix: standardize on “wallet app” throughout this page for consistency.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **15. Plain wording and comma usage (“possibly, a comment”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/wallet-apps/addresses-workflow.mdx?plain=1#L15

Text: “and, possibly, a comment”. Prefer plain wording and avoid unnecessary commas around short adverbs. Minimal fix: “and optionally a comment”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **16. Prefer relative internal links**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/wallet-apps/addresses-workflow.mdx?plain=1#L5

Internal links are root-absolute (`/ton/...`). Prefer relative links to avoid domain/path coupling. From this page, change `/ton/statuses` → `../../ton/statuses` and `/ton/addresses/address-formats` → `../../ton/addresses/address-formats`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format