### PR TITLE
[AI] fix: aside.mdx

### DIFF
--- a/contribute/snippets/aside.mdx
+++ b/contribute/snippets/aside.mdx
@@ -8,10 +8,10 @@ import { Aside } from '/snippets/aside.jsx';
 To display secondary information alongside a page’s main content, use the `<Aside>` component.
 
 <Aside>
-  Include nonessential, supplementary information in a regular `<Aside>`. If some information is important or might lead to bad cases when not taken into consideration, specify a different [`type`](#type), such as `"caution"` or `"danger"`.
+  Include supplementary information in a regular `<Aside>`. If the information is important or could cause issues if ignored, specify a different [`type`](#type), such as `caution` or `danger`.
 </Aside>
 
-It is a wrapper over built-in [Callout components](https://www.mintlify.com/docs/components/callouts) provided by Mintlify, but with a unified interface and a way to specify a title.
+It wraps the built-in [Callout components](https://www.mintlify.com/docs/components/callouts) provided by Mintlify and lets you specify a title via a unified interface.
 
 ## Import
 
@@ -21,9 +21,9 @@ import { Aside } from '/snippets/aside.jsx';
 
 ## Usage
 
-Display an aside (also known as "admonitions" or "callouts") using the `<Aside>` component.
+Display an aside (also known as admonitions or callouts) using the `<Aside>` component.
 
-An `<Aside>` can have an optional [`type`](#type) attribute, which controls the aside’s color, icon, and default title.
+The optional [`type`](#type) attribute controls the aside’s color, icon, and default title.
 
 ````mdx
 import { Aside } from '/snippets/aside.jsx';
@@ -65,8 +65,8 @@ The `<Aside>` component accepts the following props:
 
 ### `type`
 
-**type:** `"note" | "tip" | "caution" | "danger"` <br />
-**default:** `"note"`
+**type:** `note | tip | caution | danger` <br />
+**default:** `note`
 
 The type of aside to display:
 


### PR DESCRIPTION
- [ ] **1. Quotation marks used for terms instead of literal strings**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/aside.mdx?plain=1#L24

The sentence uses quotation marks around terms ("admonitions" and "callouts") that are not literal UI/log messages. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#62-quotation-marks-and-emphasis. Minimal fix: remove the quotation marks so it reads: “Display an aside (also known as admonitions or callouts) using the `<Aside>` component.”

---

- [ ] **2. Redundant doublet in initial Aside guidance**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/aside.mdx?plain=1#L11

The phrase “nonessential, supplementary information” is a pleonasm (synonyms doubled). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#57-avoid-tautology-pleonasm-throat-clearing-and-circular-references. Minimal fix: drop one adjective, e.g., “Include supplementary information in a regular `<Aside>`.”

---

- [ ] **3. Wordy and vague phrasing in risk qualifier**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/aside.mdx?plain=1#L11

“might lead to bad cases when not taken into consideration” is wordy and vague (“bad cases”). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#57-avoid-tautology-pleonasm-throat-clearing-and-circular-references. Minimal fix: tighten and use clear terms: “If the information is important or could cause issues if ignored, specify a different [`type`](#type), such as `"caution"` or `"danger"`.”

---

- [ ] **4. Redundant “also” with “other content”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/aside.mdx?plain=1#L37

“Other content is also supported in asides.” repeats the idea (“other” + “also”). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#57-avoid-tautology-pleonasm-throat-clearing-and-circular-references. Minimal fix: remove “also”: “Other content is supported in asides.”

---

- [ ] **5. Decorative italics in example**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/aside.mdx?plain=1#L56

The word "with" is italicized in "A warning aside _with_ a custom title." Emphasis should be used sparingly and only when it clarifies meaning; here it is decorative. Minimal fix: remove italics. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.2-quotation-marks-and-emphasis

---

- [ ] **6. Unpinned GitHub link to implementation**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/aside.mdx?plain=1#L62

The "Implementation" link targets the moving `main` branch. For specific files, prefer a versioned/permanent URL to keep references stable. Minimal fix: change to a commit permalink for `snippets/aside.jsx`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12.5-external-references

---

- [ ] **7. Terminology variance by introducing synonyms**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/aside.mdx?plain=1#L24

The parenthetical "also known as … admonitions … or callouts" introduces multiple terms for the same concept, which can dilute terminology discipline. Minimal fix: remove the parenthetical or align with the canonical term from the term bank/glossary for consistency (needs domain confirmation). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-terminology-and-naming

---

- [ ] **8. Quoted tokens inside code spans**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/aside.mdx?plain=1#L11

Inline code shows type values with quotes (for example, `"caution"`, `"danger"`). Tokens should appear without extra punctuation: use `caution` and `danger`. This keeps code spans copyable and consistent with token styling elsewhere on the page. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#63-code-styling

---

- [ ] **9. Wordy construction “It is a wrapper over …”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/aside.mdx?plain=1#L14

Prefer a concise verb. Minimal fix: "It wraps the built‑in [Callout components](https://www.mintlify.com/docs/components/callouts) provided by Mintlify and lets you specify a title via a unified interface." Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#57-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **10. Escaped quotes in MDX/JSX props inside code examples**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/aside.mdx?plain=1#L33-L55

Props in examples escape quotes (for example, `type=\"tip\"`). In JSX/MDX code, use normal quotes without escaping inside code fences: `type="tip"` → `type="tip"` becomes `type="tip"` without backslashes; more concretely, write `type="tip"` as `type="tip"` where the rendered code shows `type="tip"` with no backslashes. Minimal fix examples: `<Aside type="caution">` → `<Aside type="caution">`; `<Aside type="danger">` → `<Aside type="danger">`; `<Aside type="caution" title="Watch out!">` → `<Aside type="caution" title="Watch out!">`. This keeps examples syntactically correct and readable. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#63-code-styling

---

- [ ] **11. Pleonasm: “can have an optional”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/aside.mdx?plain=1#L26

“An `<Aside>` can have an optional [`type`] attribute …” is pleonastic; “optional” already implies “can have”. Minimal fix: “The optional [`type`](#type) attribute controls the aside’s color, icon, and default title.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.7-avoid-tautology-pleonasm-throat-clearing-and-circular-references