### PR TITLE
[AI] fix: addresses-general-info.mdx

### DIFF
--- a/ton/addresses/addresses-general-info.mdx
+++ b/ton/addresses/addresses-general-info.mdx
@@ -1,77 +1,79 @@
 ---
-title: "General information"
+title: "Addresses: general information"
 ---
 
-TON implements **Actor model**, where all entities, including wallets, are smart contracts. Each actor:
+import { Aside } from '/snippets/aside.jsx';
 
-- processes incoming messages;
-- updates its internal state;
-- generates outgoing messages.
+TON implements **actor model**, where all entities, including wallets, are smart contracts. Each actor:
 
-As a result, every actor must have a unique address to ensure the correct message routing. This section explains how these addresses are structured and why they are fundamental to the TON architecture.
+- processes incoming messages
+- updates its internal state
+- generates outgoing messages
 
-There are several types of addresses used in the TON blockchain. Here, we will focus on the two most important ones for developers: **internal** and **external**.
-Every account in the TON blockchain has an internal address. External addresses are intended to be used by off-chain software.
+As a result, every actor must have a unique address to ensure the correct message routing.
 
-For the so called **Intermediate** and **DNS** addresses see the [Hypercube Routing](/ton/hypercube-routing) and [DNS: .ton domains](/services/dns) pages respectively.
+There are several types of addresses used in the TON Blockchain. This page focuses on the two most important types for developers: internal and external.
+Every account in the TON Blockchain has an internal address. External addresses are intended to be used by off-chain software.
+
+For the so‑called intermediate and Domain Name System (DNS) addresses, see the [Hypercube Routing](/ton/hypercube-routing) and [DNS: .ton domains](/services/dns) pages, respectively.
 
 ## Internal addresses
 
-Each smart contract deployed on TON blockchain has this type of the address. Let's look at the corresponding TL-B schemes:
+Each smart contract deployed on the TON Blockchain has this type of address. Type Language Binary (TL‑B) schemes:
 
-```
+```tlb
 addr_std$10 anycast:(Maybe Anycast) 
    workchain_id:int8 address:bits256 = MsgAddressInt;
 addr_var$11 anycast:(Maybe Anycast) addr_len:(## 9) 
    workchain_id:int32 address:(bits addr_len) = MsgAddressInt.
 ```
 
-As we can see, there are two constructors:
+There are two constructors:
 
-- `addr_std`: standardized addresses with a fixed length that are suitable for [SHA256 encryption](https://en.wikipedia.org/wiki/SHA-2). Must be used whenever possible.
-- `addr_var`: represents addresses in workchains with a _large_ `workchain_id`, or addresses with a length not equal to 256. Currently is not used and intended for future extensions.
+- `addr_std`: standardized addresses with a fixed length that are suitable for [SHA‑256 hashing](https://en.wikipedia.org/wiki/SHA-2). Use by default.
+- `addr_var`: represents addresses in workchains with a _large_ `workchain_id`, or addresses with a length not equal to 256. It is not used and is intended for future extensions.
 
 And four components:
 
-- `workchain_id`: the WorkChain id (signed 8- or 32-bit integer).
-- `address`: an address of the account (64-512 bits, depending on the WorkChain). In order not to confuse this field with a whole address, it is usually called `account_id`.
-- `addr_len`: a length of the non-standardized address.
-- `anycast`: not currently used in the blockchain and is always replaced with a zero bit. It was designed to implement [Shard splitting](https://docs.ton.org/v3/documentation/smart-contracts/shards/shards-intro/) of _global_ (or _large_) accounts, but then was deprecated since [TVM 10](https://github.com/ton-blockchain/ton/blob/master/doc/GlobalVersions.md#anycast-addresses-and-address-rewrite).
+- `workchain_id`: the workchain ID (signed 8- or 32-bit integer).
+- `address`: an address of the account (64–512 bits, depending on the workchain). To avoid confusion with the full address, this field is usually called `account_id`.
+- `addr_len`: the length of the non-standardized address.
+- `anycast`: not currently used in the blockchain and is always replaced with a zero bit. It was designed to implement [shard splitting](/ton/shards) of _global_ (or _large_) accounts, but was deprecated starting with [TVM 10](https://github.com/ton-blockchain/ton/blob/master/doc/GlobalVersions.md#anycast-addresses-and-address-rewrite).
 
-### WorkChain id
+### Workchain ID
 
-TON Blockchain is actually a collection of blockchains, with WorkChain being one of them. TON supports up to `2^32` unique WorkChains, each with its own rules and even virtual machines. The 32-bit `workchain_id` prefix in smart contract addresses ensures interoperability, allowing contracts to send and receive messages across different WorkChains.
+TON Blockchain is a collection of blockchains, with workchain being one of them. TON supports up to `2^32` unique workchains, each with its own rules and even virtual machines. The 32-bit `workchain_id` prefix in smart contract addresses ensures interoperability, allowing contracts to send and receive messages across different workchains.
 
-Currently, two WorkChains are active:
+Two workchains are active:
 
-- **MasterChain** (`workchain_id = -1`): contains general information about the TON blockchain protocol and the current values of its parameters, the set of validators and their stakes, the set of currently active workchains and their shards, and, most importantly, the set of hashes of the most recent blocks of all workchains and shard chains.
-- **BaseChain** (`workchain_id = 0`): the default WorkChain for most operations.
+- **masterchain** (`workchain_id = -1`): contains general information about the TON blockchain protocol and the current values of its parameters, the set of validators and their stakes, the set of currently active workchains and their shards, and, most importantly, the set of hashes of the most recent blocks of all workchains and shard chains.
+- **basechain** (`workchain_id = 0`): the default workchain for most operations.
 
 Both use **256-bit addresses** for accounts.
 
-### Account id
+### Account ID
 
-In currently used WorkChains an account id is defined as the result of applying a hash function to a `state_init` structure that stores initial code and data of a smart contract.
+In currently used workchains, an account ID is defined as the result of applying a hash function to a `state_init` structure that stores the initial code and data of a smart contract.
 
-```
+```text
 account_id = hash(initial_code, initial_data)
 ```
 
-So, for each pair (`initial_code`, `initial_data`), there exists a unique account id to which a smart contract with such code and data can be deployed (this logic may become more complex when [TVM 11](https://github.com/ton-blockchain/ton/blob/master/doc/GlobalVersions.md#version-11) is deployed on the main network.).
+So, for each pair (`initial_code`, `initial_data`), there exists a unique account ID to which a smart contract with such code and data can be deployed (this logic may become more complex when TON Virtual Machine (TVM) 11 is deployed on the main network).
 
-<Tip>
+<Aside type="tip">
   Although the deployed smart contract code and data may change during its lifetime, the address where it's deployed does not change.
-</Tip>
+</Aside>
 
-Additionally, a 64-bit prefix of an account id is crucial for sharding process and delivering messages from one shard to another during [Hypercube Routing](/ton/hypercube-routing).
+Additionally, a 64-bit prefix of an account ID is crucial for the sharding process and delivering messages from one shard to another during [Hypercube Routing](/ton/hypercube-routing).
 
 ## External addresses
 
-External addresses are closely related to [External messages](http://localhost:3000/ton/transaction): ones that originates outside the blockchain or is intended for actors outside it. These messages enable interaction between smart contracts and the external world.
+External addresses are closely related to [External messages](/ton/transaction): messages that originate outside the blockchain or are intended for actors outside it. These messages enable interaction between smart contracts and the external world.
 
-Actually, external addresses are ignored by the TON Blockchain software altogether, but may be used by external software for its own purposes.
+External addresses are ignored by the TON Blockchain software altogether, but may be used by external software for its own purposes.
 
-The corresponding Tl-B schemes are as follows:
+The corresponding TL‑B schemes are as follows:
 
 ```tlb
 addr_none$00 = MsgAddressExt;
@@ -80,16 +82,16 @@ addr_extern$01 len:(## 9) external_address:(bits len)
 ```
 
 - `addr_none`: it is used as a stub for the source or destination field in incoming and outgoing external messages when there is no need to put any explanatory information for off-chain actors. It is also used as a stub for the source address of internal messages, since this field is always overwritten to the correct one by the validators.
-- `addr_extern`: contains up to nine bits of additional information. For example, a special external service may inspect the destination address of all outbound external messages found in all blocks of the blockchain, and, if a special magic number is present in the `external_address` field, parse the remainder as an IP address and UDP port or a (TON Network) ADNL address, and send a datagram with a copy of the message to the network address thus obtained.
+- `addr_extern`: contains up to nine bits of additional information. For example, a special external service may inspect the destination address of all outbound external messages found in all blocks of the blockchain, and, if a special magic number is present in the `external_address` field, parse the remainder as an IP address and UDP port or a TON Network Abstract Datagram Network Layer (ADNL) address, and send a datagram with a copy of the message to the network address thus obtained.
 
 ## Summary
 
-- **Every actor is a smart contract**, each with a unique address for message routing.
+- Every actor is a smart contract, each with a unique address for message routing.
 - **Main internal address fields**:
-  - `workchain_id` (32-bit): identifies the WorkChain.
+  - `workchain_id` (32-bit): identifies the workchain.
   - `account_id` (256-bit): a hash of the contract’s initial code and data.
-- **Active WorkChains**: MasterChain and BaseChain, both using 256-bit ids.
-- **Flexibility**: TON supports up to `2^32` WorkChains, allowing future chains to customize address lengths (64–512 bits).
+- **Active workchains**: masterchain and basechain, both using 256-bit IDs.
+- **Flexibility**: TON supports up to `2^32` workchains, allowing future chains to customize address lengths (64–512 bits).
 - **External addresses**: may be used by external software for its own purposes but are ignored by the TON Blockchain software.
 
 ## Next steps
@@ -97,4 +99,4 @@ addr_extern$01 len:(## 9) external_address:(bits len)
 For more technical details, refer to:
 
 - [Internal address formats](/ton/addresses/address-formats): encoding rules and practical examples.
-- [Account statuses](/ton/statuses): how addresses evolve (active, frozen, etc.).
+- [Account statuses](/ton/statuses): how addresses evolve.


### PR DESCRIPTION
- [ ] **1. Unlabeled code fence for TL‑B schema block**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L22

The fenced block showing TL‑B constructors has no language tag. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules. Minimal fix: add a language to the fence, for example change ``` to ```tlb on lines 22–27.

---

- [ ] **2. Unlabeled code fence for formula snippet**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L56

The inline formula block lacks a language tag. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules. Minimal fix: set the fence to ```text (or another appropriate language) for lines 56–58.

---

- [ ] **3. Localhost link for “External messages” (non-canonical URL)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L70

Link points to http://localhost:3000/ton/transaction which won’t resolve for readers and violates clean/relative link rules. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format, https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references. Minimal fix: change the href to a relative internal link: [External messages](/ton/transaction). If a deep anchor exists later, update to that anchor.

---

- [ ] **4. Inconsistent casing of TON terms (“WorkChain”, “MasterChain”, “BaseChain”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L36-L54

Generic TON chain terms must be lowercase mid‑sentence: workchain, masterchain, basechain. The page mixes “WorkChain/MasterChain/BaseChain”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules, https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-4-ton-specific-examples. Minimal fixes:
- Change heading “### WorkChain id” to “### Workchain ID”.
- In bullets and prose, use “workchain”, “masterchain”, “basechain” (except when part of a proper name like “TON Blockchain”).

---

- [ ] **5. Acronym casing: use “ID”, not “id”, in headings and summaries**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L41-L91

Acronyms should use standard casing after first use; “ID” is conventional. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms. Minimal fixes:
- “### Account id” → “### Account ID”.
- “WorkChain id” → “Workchain ID”.
- “256-bit ids” → “256-bit IDs”.

---

- [ ] **6. List punctuation uses semicolons; not per list rules**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L7-L9

Unordered list items end with semicolons and a period; items are fragments, so omit terminal punctuation consistently. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists. Minimal fix: remove “;” and “.” at the ends of lines 7–9.

---

- [ ] **7. Throat‑clearing sentence (“This section explains…”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L11

Avoid meta text describing what the section does. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references. Minimal fix: delete the sentence “This section explains how these addresses are structured and why they are fundamental to the TON architecture.”

---

- [ ] **8. Use <Aside> component for callouts instead of <Tip>**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L62-L64

Admonitions must use the unified Aside component. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout, https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#19-appendices. Minimal fix: replace:
- <Tip>…</Tip> → import { Aside } from '/snippets/aside.jsx'; then use <Aside type="tip">…</Aside>.

---

- [ ] **9. External link used where internal exists (“Shard splitting”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L39

Prefer internal docs when available. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not. Minimal fix: replace the shard splitting link target with the internal concept page, e.g., [sharding](/ton/shards). Also lowercase the generic term: “shard splitting”.

---

- [ ] **10. Moving-target GitHub link for TVM version (needs permalink)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L39-L60

Links to GitHub “master” for https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/GlobalVersions.md?plain=1 are not stable for precision‑critical references. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references. Minimal fix: switch to a versioned/commit permalink for the same section (owner to select an appropriate commit/tag).

---

- [ ] **11. TL‑B capitalization inconsistent (“Tl‑B”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L74

Use consistent casing for the spec name. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules. Minimal fix: “Tl‑B” → “TL‑B”.

---

- [ ] **12. SHA‑256 terminology and hyphenation (“SHA256 encryption”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L31

Use correct term and hyphenation; SHA‑256 is a hash, not encryption (general knowledge). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-3-hyphenation-and-abbreviations, https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references (Wikipedia allowed for general concepts). Minimal fix: change link text to “SHA‑256 hashing” and keep the URL, or link to an internal page if one exists.

---

- [ ] **13. Hyphenation and article usage (“so called”; missing comma)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L16

Grammar/style: “so called” should be hyphenated; add a comma for readability. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons. Minimal fix: “For the so‑called Intermediate and DNS addresses, see …”. Also consider lowercasing generic terms per casing rules.

---

- [ ] **14. Awkward phrasing and articles (“on TON blockchain … this type of the address”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L20

Obvious grammar: add definite article and remove unnecessary “the”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-wording-and-clarity. Minimal fix: “Each smart contract deployed on the TON Blockchain has this type of address.”

---

- [ ] **15. Subject–verb agreement in sentence about external messages**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L70-L72

“ones that originates” should be plural (“that originate”), and “actors outside it” should agree in number. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-wording-and-clarity. Minimal fix: “External addresses are closely related to External messages: messages that originate outside the blockchain or are intended for actors outside it …”

---

- [ ] **16. Consistent naming of “TON Blockchain” vs “TON blockchain”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L13-L73

Use the proper noun form “TON Blockchain” consistently. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-4-ton-specific-examples. Minimal fix: capitalize “Blockchain” when referring to the proper name (“TON Blockchain”), and keep generic “blockchain” lowercase elsewhere.

---

- [ ] **17. Generic concept capitalized mid‑sentence ("Actor model")**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L5

Generic concepts must not be capitalized mid‑sentence. Minimal fix: change “Actor model” to “actor model” (keep or remove bold per emphasis rules; bold is not required here).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules

---

- [ ] **18. Boilerplate phrasing (“Let’s look…”, “As we can see,”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L20-L29

Collapse throat‑clearing into direct statements. Minimal fixes: “Let’s look at the corresponding TL‑B schemes:” → “TL‑B schemes:”; “As we can see, there are two constructors:” → “There are two constructors:”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **19. Banned intensifier “actually”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L43-L72

Avoid hedges/intensifiers like “actually.” Minimal fix: remove “actually” in both sentences without changing meaning.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **20. Over‑emphasis: long bold span in list item**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L87

Avoid bolding full sentences/long clauses in list items; keep bold spans short (≤ 3 words) and rare. Minimal fix: remove bold from “Every actor is a smart contract”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **21. Avoid “etc.” in lists**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L100

“etc.” in lists leaves scope ambiguous. Minimal fix: remove the parenthetical entirely or list only concrete examples without “etc.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **22. Title not self-describing to context**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L2

The frontmatter title "General information" is generic and not self-describing out of context. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#title-vs-sidebar-semantics. Minimal fix: change the title to include the subject, e.g., `title: "Addresses: general information"`.

---

- [ ] **23. Throat-clearing phrasing: "Here, we will focus…"**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L13

Avoid throat-clearing and meta-intros; be direct. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references. Minimal fix: "This page focuses on the two most important types for developers: internal and external." (or simply start the sentence with the fact).

---

- [ ] **24. Time-relative wording: "Currently"**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L45

Avoid time-relative words; prefer durable phrasing. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17-2-timelessness. Minimal fix: remove "Currently," → "Two workchains are active:". Also, in line 32, prefer "is not used" without "Currently".

---

- [ ] **25. Article usage: "for sharding process"**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L66

Obvious grammar issue. (General English rule.) Minimal fix: "for the sharding process".

---

- [ ] **26. Article/determiner: "a length of the non-standardized address"**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L38

Obvious grammar issue. (General English rule.) Minimal fix: "the length of the non-standardized address".

---

- [ ] **27. Grammar: missing subject and parallelism in `addr_var` bullet**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L32

Use a subject and parallel form. Minimal fix: “Currently, it is not used and is intended for future extensions.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **28. Double period after parenthetical**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L60

Avoid redundant punctuation. Minimal fix: remove the period after the closing parenthesis: end the sentence as “…on the main network).” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicola

---

- [ ] **29. Article and acronym casing in “account id” sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L66

Use the article and acronym casing. Minimal fix: “Additionally, a 64‑bit prefix of an account ID is crucial for the sharding process …”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **30. Multiple bold spans in one paragraph**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L13

Within a paragraph, keep bold use minimal (≤ 1 short span). Minimal fix: remove bold from “internal” and “external.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#emphasis-bold-and-italics

---

- [ ] **31. Wordy boilerplate: “In order not to…”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L37

Prefer concise “to …”. Minimal fix: “To avoid confusion with the full address, this field is usually called `account_id`.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **32. Acronyms not expanded on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L20-L39–41,60,62,16,83

Several acronyms appear before being defined on this page. Provide the full term on first mention, then use the acronym thereafter. Minimal fixes:
- Line 20: “TL‑B” → “Type Language Binary (TL‑B)”.
- Line 39/60: “TVM 10/11” → “TON Virtual Machine (TVM) 10/11”.
- Line 16: “DNS” → “Domain Name System (DNS)”.
- Line 83: “ADNL” → “Abstract Datagram Network Layer (ADNL)”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **33. Grammar and punctuation cleanups**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L20-L74

Apply small fixes for clarity and correctness (American English; general grammar rules).
- Line 20: “this type of the address” → “this type of address”.
- Line 32: “Currently is not used and intended” → “Currently it is not used and is intended…”.
- Line 54: Add a comma after the introductory phrase: “In currently used WorkChains, an account id is…”.
- Line 60: Remove the extra period before the closing parenthesis: “…main network)”.
- Line 66: Add the article: “for the sharding process”.
- Line 70: Fix agreement and avoid “ones”: “messages that originate outside the blockchain…”.
- Line 74: Capitalization: “Tl‑B” → “TL‑B”.
- Line 39: Use correct preposition: “was deprecated in TVM 10” (or “has been deprecated since TVM 10”).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-6-spelling-and-contractions

---

- [ ] **34. Hyphenation, casing, and excess bolding in “so‑called intermediate and DNS addresses”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1

Issues in “For the so called **Intermediate** and **DNS** addresses see …”: missing hyphen in “so‑called”, unnecessary mid‑sentence capitalization (“Intermediate”), and two bold spans in one short sentence. Minimal fix: “For the so‑called intermediate and DNS addresses, see …” and remove bold from both terms.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **35. Capitalization consistency: “workchains” → “WorkChains”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1

Within the `addr_var` description, “workchains” is lowercase while elsewhere the docs use “WorkChain/WorkChains” as a defined term (e.g., https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#workchain-configuration-parameters). Minimal fix: capitalize to “WorkChains”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#15-3-localization-readiness (prefer stable terminology)

---

- [ ] **36. Awkward phrasing: “but then was deprecated since TVM 10”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1

Use a clear temporal construction. Minimal fix: “but was deprecated starting with TVM 10.” (Basic English usage; general knowledge.)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles (clarity and concision)

---

- [ ] **37. Hedge phrase: “Must be used whenever possible.”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1

The phrase combines a soft hedge (“whenever possible”) with an imperative. Replace the hedge with a precise, concise directive. Minimal fix: “Use by default.” (Do not add new conditions.)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references (replace hedges with facts)