### PR TITLE
[AI] fix: merkle.mdx

### DIFF
--- a/tvm/serialization/merkle.mdx
+++ b/tvm/serialization/merkle.mdx
@@ -5,10 +5,11 @@ title: "Merkle proof cells"
 Merkle proof cells verify that some cell tree data belongs to the full tree. See [Merkle proof cells](../../ton/cells/merkle-proof-cells) for details.
 This design allows the verifier to avoid storing the entire tree's content while still being able to verify it using the root hash.
 
-A Merkle proof cell contains exactly 1 reference `c`. Its level `l` (0 ≤ l < 3) is `max{Lvl(c) - 1, 0}`.
+A Merkle proof cell contains exactly 1 reference `c`. Its level `l` (0 ≤ l \< 3) is `max{Lvl(c) - 1, 0}`.
 
 Each Merkle proof cell serializes as follows:
+
 - 1 tag byte with value `0x03`;
 - the first 256-bit [higher hash](../hashes) of the referenced cell `c` or the [representation hash](cells#standard-cell-representation-and-its-hash)
-of `c` if its level equals 0;
+  of `c` if its level equals 0;
 - 2 bytes that store the depth of the deleted subtree that was replaced by the reference.


### PR DESCRIPTION
- [ ] **1. Misspelling in link text: “Merkel” → “Merkle”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/merkle.mdx?plain=1#L5

“Merkel proof cells page” misspells the proper noun “Merkle” and adds an unnecessary “page”. Use the correct spelling and concise link text consistent with the target page title `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/merkle-proof-cells.mdx?plain=1` (title: “Merkle proof cells”). Minimal fix: change to “See Merkle proof cells for details.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.6-spelling-and-contractions; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms

---

- [ ] **2. Internal links use absolute paths; prefer relative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/merkle.mdx?plain=1#L5-L12–13

Internal links are written with absolute root paths. The guide prefers relative internal links. Minimal fixes:
- `/ton/cells/merkle-proof-cells` → `../../ton/cells/merkle-proof-cells`
- `/tvm/hashes` → `../hashes`
- `/tvm/serialization/cells` → `cells`
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16.3-links-and-anchors

---

- [ ] **3. Incorrect compound modifier: “256-bits first …”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/merkle.mdx?plain=1#L12

“the 256-bits first [higher hash] …” is ungrammatical. Use a correctly ordered compound modifier: “the first 256-bit [higher hash] of the referenced cell `c` …”. This also fixes the adjective hyphenation (“256-bit” as a compound modifier). Minimal fix: replace “the 256-bits first” with “the first 256-bit”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording. This fix relies on general English grammar for compound modifiers and adjective order.

---

- [ ] **4. Use numerals for technical quantities (“one reference” → “1 reference”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/merkle.mdx?plain=1#L8

Technical quantities must use numerals. Minimal fix: “A Merkle proof cell contains exactly 1 reference `c`.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#14-1-numerals-and-separators

---

- [ ] **5. Use numerals for technical quantities in list (“one tag byte” → “1 tag byte”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/merkle.mdx?plain=1#L11

Technical quantities must use numerals. Minimal fix: “1 tag byte with value `0x03`”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#14-1-numerals-and-separators

---

- [ ] **6. List items end with semicolons/period; omit terminal punctuation for fragments**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/merkle.mdx?plain=1#L11

List items here are not full sentences, but they end with “;” and the last with “.”. Minimal fix: remove terminal punctuation from all three bullets so they are consistent fragments.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **7. Tautology/repetition (“verify the content … verify the content”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/merkle.mdx?plain=1#L6

The sentence repeats “content” unnecessarily. Minimal fix: “This design allows the verifier to avoid storing the entire tree’s content while still being able to verify it using the root hash.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **8. Inline math formatting (prefer KaTeX or proper inequality symbols)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/merkle.mdx?plain=1#L8

Inline math should use clear mathematical notation. Minimal fix: replace `0 <= l < 3` with `0 ≤ l < 3` (or render via KaTeX), and consider KaTeX for `max{Lvl(c) - 1, 0}` (e.g., `\\max\\{\\mathrm{Lvl}(c) - 1, 0\\}`). Also clarify the variable: “Its level `l` (0 ≤ l < 3) is …”. This improves readability without changing meaning.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#14-4-magnitudes-and-math

---

- [ ] **9. Use deep link to the exact section (“standard cell representation and its hash”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/merkle.mdx?plain=1

The link `[representation hash](/tvm/serialization/cells)` points to the page top instead of the exact section. Minimal fix: update to `/tvm/serialization/cells#standard-cell-representation-and-its-hash`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format

---

- [ ] **10. Title terminology inconsistent with linked page**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/merkle.mdx?plain=1

Frontmatter title is “Merkle proofs”, while the linked canonical page is titled “Merkle proof cells” (`https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/merkle-proof-cells.mdx?plain=1`). To avoid introducing synonyms for the same concept, align the title. Minimal fix: change frontmatter title to “Merkle proof cells”. If a term bank exists with a different canonical form, use that instead.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **11. Use numerals for technical quantities (“one” → “1”; “zero” → “0”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/merkle.mdx?plain=1#L11

Technical counts should use numerals. Minimal fixes: change “one tag byte” → “1 tag byte” (line 11), and “equals zero” → “equals 0” (line 13). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#14-1-numerals-and-separators.

---

- [ ] **12. Semicolons used as list terminators; prefer periods for clarity**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/merkle.mdx?plain=1#L11

List items 1–2 end with semicolons while the last item ends with a period, creating inconsistency. Semicolons should be rare; use short sentences. Minimal fix: end each bullet with a period. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons.