### PR TITLE
[AI] fix: create-mini-app.mdx

### DIFF
--- a/ecosystem/tma/create-mini-app.mdx
+++ b/ecosystem/tma/create-mini-app.mdx
@@ -1,7 +1,6 @@
 title: "How to create a Mini App with the CLI"
 sidebarTitle: "Create a Mini App with the CLI"
----
-
+----------------------------------------------
 
 ## Overview
 
@@ -31,14 +30,16 @@ your application by sequentially prompting for the following information:
 ### Choose preferred technologies
 
 #### TMA software development kits (SDKs)
+
 - **tma.js** [@telegram-apps/sdk](https://www.npmjs.com/package/@telegram-apps/sdk)  – A TypeScript library for communication with Telegram Mini Apps
 - **Telegram SDK** [@twa-dev/sdk](https://www.npmjs.com/package/@twa-dev/sdk) – This package allows you to work with the SDK as an npm package
 
 #### Frameworks
- - **React.js** [template](https://github.com/Telegram-Mini-Apps/reactjs-template)
- - **Next.js** [template](https://github.com/Telegram-Mini-Apps/nextjs-template)
- - **Solid.js** [template](https://github.com/Telegram-Mini-Apps/solidjs-js-template)
- - **Vue.js** [template](https://github.com/Telegram-Mini-Apps/vuejs-template)
+
+- **React.js** [template](https://github.com/Telegram-Mini-Apps/reactjs-template)
+- **Next.js** [template](https://github.com/Telegram-Mini-Apps/nextjs-template)
+- **Solid.js** [template](https://github.com/Telegram-Mini-Apps/solidjs-js-template)
+- **Vue.js** [template](https://github.com/Telegram-Mini-Apps/vuejs-template)
 
 ### Enter the Git remote repository URL
 


### PR DESCRIPTION
- [ ] **1. Incorrect internal anchor for `target` link**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/image.mdx?plain=1#L15

The link for [`target`](#href) points to `#href` instead of `#target`, breaking navigation. Minimal fix: change the link to [`target`](#target).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-3-links-and-anchors

---

- [ ] **2. Acronym “SVG” not defined on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/image.mdx?plain=1#L12

"SVG" is used without expansion. Minimal fix: "When an `src` path points to a Scalable Vector Graphics (SVG) image …".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **3. Acronym “CDN” not defined on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/image.mdx?plain=1#L88

"CDN" is used without expansion. Minimal fix: "…host them on a content delivery network (CDN) such as Amazon S3."
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **4. Storage size unit should use binary units**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/image.mdx?plain=1#L88

Use binary units for storage sizes. Minimal fix: change "20 MB" to "20 MiB".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#14-2-units-and-conventions

---

- [ ] **5. Hyphenation: use “subfolder” instead of “sub-folder”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/image.mdx?plain=1#L94

Use consistent spelling. The guide is silent on this term; prefer consistency with nearby pages (for example, https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/create-mini-app.mdx?plain=1#L30“subfolder”). Minimal fix: change "sub-folder" to "subfolder".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17-4-proofread

---

- [ ] **6. Remove intensifier (“incredibly useful”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/image.mdx?plain=1#L101

Avoid hedges and intensifiers. Minimal fix: "It is mandatory and useful for accessibility — …" or simply "It is required for accessibility — …" (keep domain truth intact).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **7. Awkward phrasing: "allows to change"**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/image.mdx?plain=1#L15

Prefer precise, natural phrasing. Minimal fix: "…the [`target`](#target) property allows you to change the browsing context …" or "…allows changing the browsing context …".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **8. Awkward phrasing: "in respect to the new set `height`"**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/image.mdx?plain=1#L167

Simplify the sentence. Minimal fix: "…adjusted according to the aspect ratio based on the new `height`" or "…adjusted to preserve the aspect ratio based on the new `height`."
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **9. Placeholders not defined on first use in examples**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/image.mdx?plain=1#L33

Placeholders like `<IMAGE>`, `<IMAGE_DARK_THEME>`, `<ALT_TEXT>`, `<ALT_TEXT_DARK_THEME>`, and `<CLICKABLE_LINK>` are used without definitions. Minimal fix: after the code block, add brief definitions (e.g., “`<IMAGE>` — path to the image file relative to the page; `<IMAGE_DARK_THEME>` — dark-theme variant; `<ALT_TEXT>` — image alt text; `<ALT_TEXT_DARK_THEME>` — dark-theme alt text; `<CLICKABLE_LINK>` — destination URL”).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **10. Quotation marks used for emphasis**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/image.mdx?plain=1#L155

In the `_top` bullet, the word “highest” is in quotation marks for emphasis. Quotes must be reserved for literal strings or UI text. Remove the quotation marks around highest. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **11. Latinism “i.e.,” in prose**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/image.mdx?plain=1#L155

Prefer common words over Latinisms. Replace “i.e.,” with “that is,” (or rephrase). Minimal change: “the topmost browsing context, that is, the highest context …”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **12. Partial snippet not labeled “Not runnable”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/image.mdx?plain=1#L33-L67

The multi-example `mdx` block uses placeholders (for example, `<IMAGE>`), so it is not runnable as-is. Label partial snippets clearly above the block with “Not runnable”. Minimal fix: add a plain line `Not runnable` immediately before the code fence. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **13. Article choice: “the SVG image” → “an SVG image”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/image.mdx?plain=1#L12

Use the indefinite article when referring to a generic SVG. Change “the SVG image” to “an SVG image.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **14. External GitHub link used for internal implementation reference**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/image.mdx?plain=1#L71

Prefer internal, stable links. Replace the absolute GitHub URL with a repo‑relative path `snippets/image.jsx` (or site‑relative if rendered). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format

---

- [ ] **15. Headings use code font; remove backticks**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/image.mdx?plain=1#L69-L176

Headings include code spans (for example, `## `<Image>` props`, `### `src` (required)`, and similar for `alt`, `darkSrc`, `darkAlt`, `href`, `target`, `height`, `width`). Headings must not contain code formatting. Minimal fix: remove backticks in headings. Examples: change `## `<Image>` props` → `## Image props`; `### `src` (required)` → `### src (required)` (apply to all affected headings).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles

---

- [ ] **16. Possible broken anchor: `src` heading includes “(required)”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/image.mdx?plain=1#L9-L75

Intro links to “[`src`](#src)”, but the heading is “`### `src` (required)`”. Many slug generators include the parenthetical in the anchor (general knowledge), yielding `#src-required`. Minimal fix: change the intro anchor to `#src-required` or remove “(required)” from the heading so the anchor becomes `#src`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12.3-link-targets-and-format

---

- [ ] **17. Idiom “double as” — prefer neutral phrasing**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/image.mdx?plain=1#L15

“making an image double as a clickable link” uses an idiom. Minimal fix: “also make the image a clickable link”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.5-global-and-inclusive-language

---

- [ ] **18. Incorrect description for `darkAlt` (calls it a URL)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/image.mdx?plain=1#L129

The text says the `darkAlt` property “specifies the image file URL”, but `alt`/`darkAlt` are textual alternatives. Minimal fix: “Similar to the `alt` property, but specifies the textual replacement (alt text) for the dark theme only.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles-reader-first-answer-first

---

- [ ] **19. Preposition: “pasting the image to text” → “into text”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/image.mdx?plain=1#L105

Use the conventional preposition (general knowledge). Minimal fix: “when copying and pasting the image into text”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording

---

- [ ] **20. “alt” described as mandatory conflicts with optional default**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/image.mdx?plain=1#L99-L106

The prose states the `alt` attribute “is mandatory,” but the props table shows a default of `""`, which implies the prop is optional. Minimal fix: soften wording to avoid conflict, for example: “Alt text is required for accessibility and should describe the image,” or mark the prop as required. This needs a domain decision if the component is intended to require `alt`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles-reader-first-answer-first

---

- [ ] **21. Article and wording in caution Aside**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/image.mdx?plain=1#L12

Grammar/usage: “an `src` path” → “the `src` path”, and “the SVG image” → “an SVG image”. Minimal fix: “When the `src` path points to an SVG image …”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **22. Redundant repeated sentence in `target` section**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/image.mdx?plain=1#L148

Repeats “The `<a>` anchor element wraps the image, making it clickable.” already stated in `href`. Minimal fix: remove the duplicate opening sentence from the `target` section.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **23. Opening sentence can be clearer and parallel**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/image.mdx?plain=1#L9

Improve parallel structure and clarity. Minimal fix: “It lets you display either a single image for all themes (`src`) or separate images for light (`src`) and dark (`darkSrc`) themes.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording