### PR TITLE
[AI] fix: limits.mdx

### DIFF
--- a/ton/limits.mdx
+++ b/ton/limits.mdx
@@ -8,122 +8,123 @@ import { Aside } from '/snippets/aside.jsx'
 Current limits and configuration parameters used in The Open Network (TON).
 
 There are two sources of network parameter definitions:
+
 - Blockchain config
 - Node source code
 
 <Aside>
-You can check all the blockchain parameters live in the explorers: [Tonviewer](https://tonviewer.com/config) or [Tonscan](https://tonscan.org/config).
+  You can check all the blockchain parameters live in the explorers: [Tonviewer](https://tonviewer.com/config) or [Tonscan](https://tonscan.org/config).
 
-Parameters defined in the code can be found in the [source code repository](https://github.com/ton-blockchain/ton).
+  Parameters defined in the code can be found in the [source code repository](https://github.com/ton-blockchain/ton).
 </Aside>
 
 ## Message and transaction limits
 
-| Name                       | Description                                                | Value    | Units  | Type   | Defined in                                                                                         |
-|----------------------------|------------------------------------------------------------|----------|--------|--------|----------------------------------------------------------------------------------------------------|
-| `max_size`                 | Maximum external message size in bytes                     | 65,535   | bytes  | `uint32` | [mc-config.h:392](https://github.com/ton-blockchain/ton/blob/05bea13375448a401d8e07c6132b7f709f5e3a32/crypto/block/mc-config.h#L392) |
-| `max_depth`                | Maximum external message depth                             | 512      | levels | `uint16` | [mc-config.h:393](https://github.com/ton-blockchain/ton/blob/05bea13375448a401d8e07c6132b7f709f5e3a32/crypto/block/mc-config.h#L393) |
+| Name                       | Description                                                | Value      | Units  | Type     | Defined in                                                                                                                           |
+| -------------------------- | ---------------------------------------------------------- | ---------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `max_size`                 | Maximum external message size in bytes                     | 65,535     | bytes  | `uint32` | [mc-config.h:392](https://github.com/ton-blockchain/ton/blob/05bea13375448a401d8e07c6132b7f709f5e3a32/crypto/block/mc-config.h#L392) |
+| `max_depth`                | Maximum external message depth                             | 512        | levels | `uint16` | [mc-config.h:393](https://github.com/ton-blockchain/ton/blob/05bea13375448a401d8e07c6132b7f709f5e3a32/crypto/block/mc-config.h#L393) |
 | `max_msg_bits`             | Maximum message size in bits                               | 2,097,152  | bits   | `uint32` | [mc-config.h:395](https://github.com/ton-blockchain/ton/blob/05bea13375448a401d8e07c6132b7f709f5e3a32/crypto/block/mc-config.h#L395) |
-| `max_msg_cells`            | Maximum number of cells a message can occupy               | 8192     | cells  | `uint32` | [mc-config.h:396](https://github.com/ton-blockchain/ton/blob/05bea13375448a401d8e07c6132b7f709f5e3a32/crypto/block/mc-config.h#L396) |
-| `max_vm_data_depth`        | Maximum cell depth in messages and `c4` and `c5` registers | 512      | levels | `uint16` | [mc-config.h:398](https://github.com/ton-blockchain/ton/blob/05bea13375448a401d8e07c6132b7f709f5e3a32/crypto/block/mc-config.h#L398) |
-| `max_actions`              | Maximum number of actions                                  | 256      | count  | `uint32` | [transaction.h](https://github.com/ton-blockchain/ton/blob/05bea13375448a401d8e07c6132b7f709f5e3a32/crypto/block/transaction.h)      |
-| `max_library_cells`        | Maximum number of library cells                            | 1000     | cells  | `uint32` | [mc-config.h:397](https://github.com/ton-blockchain/ton/blob/05bea13375448a401d8e07c6132b7f709f5e3a32/crypto/block/mc-config.h#L397) |
-| `max_acc_state_cells`      | Maximum number of cells that an account state can occupy   | 65,536    | cells  | `uint32` | [mc-config.h:400](https://github.com/ton-blockchain/ton/blob/05bea13375448a401d8e07c6132b7f709f5e3a32/crypto/block/mc-config.h#L400) |
+| `max_msg_cells`            | Maximum number of cells a message can occupy               | 8192       | cells  | `uint32` | [mc-config.h:396](https://github.com/ton-blockchain/ton/blob/05bea13375448a401d8e07c6132b7f709f5e3a32/crypto/block/mc-config.h#L396) |
+| `max_vm_data_depth`        | Maximum cell depth in messages and `c4` and `c5` registers | 512        | levels | `uint16` | [mc-config.h:398](https://github.com/ton-blockchain/ton/blob/05bea13375448a401d8e07c6132b7f709f5e3a32/crypto/block/mc-config.h#L398) |
+| `max_actions`              | Maximum number of actions                                  | 256        | count  | `uint32` | [transaction.h](https://github.com/ton-blockchain/ton/blob/05bea13375448a401d8e07c6132b7f709f5e3a32/crypto/block/transaction.h)      |
+| `max_library_cells`        | Maximum number of library cells                            | 1000       | cells  | `uint32` | [mc-config.h:397](https://github.com/ton-blockchain/ton/blob/05bea13375448a401d8e07c6132b7f709f5e3a32/crypto/block/mc-config.h#L397) |
+| `max_acc_state_cells`      | Maximum number of cells that an account state can occupy   | 65,536     | cells  | `uint32` | [mc-config.h:400](https://github.com/ton-blockchain/ton/blob/05bea13375448a401d8e07c6132b7f709f5e3a32/crypto/block/mc-config.h#L400) |
 | `max_acc_state_bits`       | Maximum account state size in bits                         | 67,043,328 | bits   | `uint32` | [mc-config.h:401](https://github.com/ton-blockchain/ton/blob/05bea13375448a401d8e07c6132b7f709f5e3a32/crypto/block/mc-config.h#L401) |
-| `max_acc_public_libraries` | Maximum number of public libraries per account             | 256      | count  | `uint32` | [mc-config.h:402](https://github.com/ton-blockchain/ton/blob/05bea13375448a401d8e07c6132b7f709f5e3a32/crypto/block/mc-config.h#L402) |
+| `max_acc_public_libraries` | Maximum number of public libraries per account             | 256        | count  | `uint32` | [mc-config.h:402](https://github.com/ton-blockchain/ton/blob/05bea13375448a401d8e07c6132b7f709f5e3a32/crypto/block/mc-config.h#L402) |
 
 ## Gas and fee parameters
 
-| Name                | Description                                                         | Value    | Units          | Type       | Defined in |
-| ------------------- | ------------------------------------------------------------------- | -------- | -------------- | ---------- | --------------- |
-| `free_stack_depth`  | Stack depth without gas consumption                                 | 32       | stack entries  | `enum_value` | [vm.h:120](https://github.com/ton-blockchain/ton/blob/05bea13375448a401d8e07c6132b7f709f5e3a32/crypto/vm/vm.h#L120)            |
-| `runvm_gas_price`   | TVM start gas consumption                                           | 40       | gas units      | `enum_value` | [vm.h:122](https://github.com/ton-blockchain/ton/blob/05bea13375448a401d8e07c6132b7f709f5e3a32/crypto/vm/vm.h#L122)            |
-| `flat_gas_limit`    | Gas below `flat_gas_limit` is provided at the price of `flat_gas_price` | 100      | gas units      | `uint64`     | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)        |
-| `flat_gas_price`    | Cost of launching the TON Virtual Machine (TVM)                    | 40,000   | nanotons       | `uint64`     | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)        |
-| `gas_price`         | Price of gas in the network in nanotons per 65,536 gas units        | 26,214,400 | nanotons       | `uint64`     | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)        |
-| `special_gas_limit` | Limit on gas for special (system) contract transactions             | 1,000,000  | gas units      | `uint64`     | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)        |
-| `gas_limit`         | Maximum amount of gas per transaction                               | 1,000,000  | gas units      | `uint64`     | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)        |
-| `gas_credit`        | Gas credit for checking external messages                           | 10,000    | gas units      | `uint64`     | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)        |
-| `block_gas_limit`   | Maximum gas per block                                               | 10,000,000 | gas units      | `uint64`     | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)        |
+| Name                | Description                                                             | Value      | Units         | Type         | Defined in                                                                                                          |
+| ------------------- | ----------------------------------------------------------------------- | ---------- | ------------- | ------------ | ------------------------------------------------------------------------------------------------------------------- |
+| `free_stack_depth`  | Stack depth without gas consumption                                     | 32         | stack entries | `enum_value` | [vm.h:120](https://github.com/ton-blockchain/ton/blob/05bea13375448a401d8e07c6132b7f709f5e3a32/crypto/vm/vm.h#L120) |
+| `runvm_gas_price`   | TVM start gas consumption                                               | 40         | gas units     | `enum_value` | [vm.h:122](https://github.com/ton-blockchain/ton/blob/05bea13375448a401d8e07c6132b7f709f5e3a32/crypto/vm/vm.h#L122) |
+| `flat_gas_limit`    | Gas below `flat_gas_limit` is provided at the price of `flat_gas_price` | 100        | gas units     | `uint64`     | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)                                                           |
+| `flat_gas_price`    | Cost of launching the TON Virtual Machine (TVM)                         | 40,000     | nanotons      | `uint64`     | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)                                                           |
+| `gas_price`         | Price of gas in the network in nanotons per 65,536 gas units            | 26,214,400 | nanotons      | `uint64`     | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)                                                           |
+| `special_gas_limit` | Limit on gas for special (system) contract transactions                 | 1,000,000  | gas units     | `uint64`     | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)                                                           |
+| `gas_limit`         | Maximum amount of gas per transaction                                   | 1,000,000  | gas units     | `uint64`     | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)                                                           |
+| `gas_credit`        | Gas credit for checking external messages                               | 10,000     | gas units     | `uint64`     | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)                                                           |
+| `block_gas_limit`   | Maximum gas per block                                                   | 10,000,000 | gas units     | `uint64`     | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)                                                           |
 
 ## Storage fees and limits
 
-| Name               | Description                                  | Value      | Units         | Type   | Defined in                                                                     |
-| ------------------ | -------------------------------------------- | ---------- | ------------- | ------ |-------------------------------------------------------------------------------------|
-| `freeze_due_limit` | Storage fees (nanotons) for contract freezing | 100,000,000  | nanotons      | `uint64` | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)        |
-| `delete_due_limit` | Storage fees (nanotons) for contract deletion | 1,000,000,000 | nanotons      | `uint64` | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)        |
-| `bit_price_ps`     | Storage price for one bit for 65536 seconds  | 1          | nanotons/bit  | `uint64` | [Param 18](/ton/config#param-18-storage-prices)                                                                    |
-| `cell_price_ps`    | Storage price for one cell for 65536 seconds | 500        | nanotons/cell | `uint64` | [Param 18](/ton/config#param-18-storage-prices)               |
+| Name               | Description                                   | Value         | Units         | Type     | Defined in                                                |
+| ------------------ | --------------------------------------------- | ------------- | ------------- | -------- | --------------------------------------------------------- |
+| `freeze_due_limit` | Storage fees (nanotons) for contract freezing | 100,000,000   | nanotons      | `uint64` | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices) |
+| `delete_due_limit` | Storage fees (nanotons) for contract deletion | 1,000,000,000 | nanotons      | `uint64` | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices) |
+| `bit_price_ps`     | Storage price for one bit for 65536 seconds   | 1             | nanotons/bit  | `uint64` | [Param 18](/ton/config#param-18-storage-prices)           |
+| `cell_price_ps`    | Storage price for one cell for 65536 seconds  | 500           | nanotons/cell | `uint64` | [Param 18](/ton/config#param-18-storage-prices)           |
 
 ## Block size limits
 
-| Name                  | Description                                  | Value    | Units     | Type   | Defined in |
-| --------------------- | -------------------------------------------- | -------- | --------- | ------ | --------------- |
-| `bytes_underload`     | Block size limit for underload state         | 131,072   | bytes     | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits)        |
-| `bytes_soft_limit`    | Block size soft limit                        | 524,288   | bytes     | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits)        |
-| `bytes_hard_limit`    | Absolute maximum block size in bytes         | 1,048,576  | bytes     | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits)        |
-| `gas_underload`       | Block gas limit for underload state          | 2,000,000  | gas units | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits)        |
-| `gas_soft_limit`      | Block gas soft limit                         | 10,000,000 | gas units | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits)        |
-| `gas_hard_limit`      | Absolute maximum block gas                   | 20,000,000 | gas units | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits)        |
-| `lt_delta_underload`  | Logical time delta limit for underload state | 1000     | logical time units (lt)  | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits)        |
-| `lt_delta_soft_limit` | Logical time delta soft limit                | 5,000     | lt units  | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits)        |
-| `lt_delta_hard_limit` | Absolute maximum logical time delta          | 10,000    | lt units  | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits)        |
+| Name                  | Description                                  | Value      | Units                   | Type     | Defined in                                                  |
+| --------------------- | -------------------------------------------- | ---------- | ----------------------- | -------- | ----------------------------------------------------------- |
+| `bytes_underload`     | Block size limit for underload state         | 131,072    | bytes                   | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits) |
+| `bytes_soft_limit`    | Block size soft limit                        | 524,288    | bytes                   | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits) |
+| `bytes_hard_limit`    | Absolute maximum block size in bytes         | 1,048,576  | bytes                   | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits) |
+| `gas_underload`       | Block gas limit for underload state          | 2,000,000  | gas units               | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits) |
+| `gas_soft_limit`      | Block gas soft limit                         | 10,000,000 | gas units               | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits) |
+| `gas_hard_limit`      | Absolute maximum block gas                   | 20,000,000 | gas units               | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits) |
+| `lt_delta_underload`  | Logical time delta limit for underload state | 1000       | logical time units (lt) | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits) |
+| `lt_delta_soft_limit` | Logical time delta soft limit                | 5,000      | lt units                | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits) |
+| `lt_delta_hard_limit` | Absolute maximum logical time delta          | 10,000     | lt units                | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits) |
 
 ## Message forwarding costs
 
-| Name         | Description                                          | Value      | Units         | Type   | Defined in |
-| ------------ | ---------------------------------------------------- | ---------- | ------------- | ------ | --------------- |
-| `lump_price` | Base price for message forwarding                    | 400,000     | nanotons      | `uint64` | [Param 24 and 25](/ton/config#param-24-and-25-message-price)        |
-| `bit_price`  | Cost per 65,536 bits of message forwarding           | 26,214,400   | nanotons/bit  | `uint64` | [Param 24 and 25](/ton/config#param-24-and-25-message-price)        |
-| `cell_price` | Cost per 65,536 cells for message forwarding         | 2,621,440,000 | nanotons/cell | `uint64` | [Param 24 and 25](/ton/config#param-24-and-25-message-price)        |
-| `ihr_price_factor` | Factor for immediate hypercube routing cost          | 98,304      | factor        | `uint32` | [Param 24 and 25](/ton/config#param-24-and-25-message-price)        |
-| `first_frac` | Fraction for first transition in message route       | 21,845      | fraction      | `uint32` | [Param 24 and 25](/ton/config#param-24-and-25-message-price)        |
-| `next_frac`  | Fraction for subsequent transitions in message route | 21,845      | fraction      | `uint32` | [Param 24 and 25](/ton/config#param-24-and-25-message-price)        |
+| Name               | Description                                          | Value         | Units         | Type     | Defined in                                                   |
+| ------------------ | ---------------------------------------------------- | ------------- | ------------- | -------- | ------------------------------------------------------------ |
+| `lump_price`       | Base price for message forwarding                    | 400,000       | nanotons      | `uint64` | [Param 24 and 25](/ton/config#param-24-and-25-message-price) |
+| `bit_price`        | Cost per 65,536 bits of message forwarding           | 26,214,400    | nanotons/bit  | `uint64` | [Param 24 and 25](/ton/config#param-24-and-25-message-price) |
+| `cell_price`       | Cost per 65,536 cells for message forwarding         | 2,621,440,000 | nanotons/cell | `uint64` | [Param 24 and 25](/ton/config#param-24-and-25-message-price) |
+| `ihr_price_factor` | Factor for immediate hypercube routing cost          | 98,304        | factor        | `uint32` | [Param 24 and 25](/ton/config#param-24-and-25-message-price) |
+| `first_frac`       | Fraction for first transition in message route       | 21,845        | fraction      | `uint32` | [Param 24 and 25](/ton/config#param-24-and-25-message-price) |
+| `next_frac`        | Fraction for subsequent transitions in message route | 21,845        | fraction      | `uint32` | [Param 24 and 25](/ton/config#param-24-and-25-message-price) |
 
 ## Masterchain-specific parameters
 
-| Name                     | Description                                     | Value       | Units         | Type   | Defined in                                                                         |
-| ------------------------ | ----------------------------------------------- | ----------- | ------------- | ------ |-----------------------------------------------------------------------------------------|
-| `mc_bit_price_ps`        | Storage price for one bit for 65,536 seconds     | 1000        | nanotons/bit  | `uint64` | [Param 18](/ton/config#param-18-storage-prices)                   |
-| `mc_cell_price_ps`       | Storage price for one cell for 65,536 seconds    | 500,000      | nanotons/cell | `uint64` | [Param 18](/ton/config#param-18-storage-prices)                   |
-| `mc_flat_gas_limit`      | Gas below `flat_gas_limit` on masterchain       | 100         | gas units     | `uint64` | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)            |
-| `mc_flat_gas_price`      | TVM launch cost on masterchain                   | 1,000,000     | nanotons      | `uint64` | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)            |
-| `mc_gas_price`           | Gas price on masterchain                        | 655,360,000   | nanotons      | `uint64` | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)            |
-| `mc_special_gas_limit`   | Special contract gas limit on masterchain       | 70,000,000    | gas units     | `uint64` | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)            |
-| `mc_gas_limit`           | Maximum gas per transaction on masterchain      | 1,000,000     | gas units     | `uint64` | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)            |
-| `mc_gas_credit`          | Gas credit for checking external messages       | 10,000       | gas units     | `uint64` | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)            |
-| `mc_block_gas_limit`     | Maximum gas per masterchain block               | 2,500,000     | gas units     | `uint64` | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)            |
-| `mc_freeze_due_limit`    | Storage fees for contract freezing              | 100,000,000   | nanotons      | `uint64` | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)            |
-| `mc_delete_due_limit`    | Storage fees for contract deletion              | 1,000,000,000  | nanotons      | `uint64` | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)            |
-| `mc_bytes_underload`     | Block size limit for underload state            | 131,072      | bytes         | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits)            |
-| `mc_bytes_soft_limit`    | Block size soft limit                           | 524,288      | bytes         | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits)            |
-| `mc_bytes_hard_limit`    | Absolute maximum block size in bytes            | 1,048,576     | bytes         | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits)            |
-| `mc_gas_underload`       | Block gas limit for underload state             | 200,000      | gas units     | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits)            |
-| `mc_gas_soft_limit`      | Block gas soft limit                            | 1,000,000     | gas units     | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits)            |
-| `mc_gas_hard_limit`      | Absolute maximum block gas                      | 2,500,000     | gas units     | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits)            |
-| `mc_lump_price`          | Base price for message forwarding               | 10,000,000    | nanotons      | `uint64` | [Param 24 and 25](/ton/config#param-24-and-25-message-price)            |
-| `mc_bit_price`           | Cost per 65,536 bits of message forwarding        | 655,360,000   | nanotons/bit  | `uint64` | [Param 24 and 25](/ton/config#param-24-and-25-message-price)            |
-| `mc_cell_price`          | Cost per 65,536 cells for message forwarding      | 65,536,000,000 | nanotons/cell | `uint64` | [Param 24 and 25](/ton/config#param-24-and-25-message-price)            |
-| `mc_ihr_factor`          | Factor for immediate hypercube routing cost     | 98,304       | factor        | `uint32` | [Param 24 and 25](/ton/config#param-24-and-25-message-price)            |
-| `mc_first_frac`          | Fraction for first transition in message route  | 21,845       | fraction      | `uint32` | [Param 24 and 25](/ton/config#param-24-and-25-message-price)        |
-| `mc_next_frac`           | Fraction for subsequent transitions in route    | 21,845       | fraction      | `uint32` | [Param 24 and 25](/ton/config#param-24-and-25-message-price)        |
-| `mc_lt_delta_underload`  | Logical time delta limit for underload state    | 1000        | logical time units (lt)      | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits)            |
-| `mc_lt_delta_soft_limit` | Logical time delta soft limit                   | 5,000        | lt units      | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits)        |
-| `mc_lt_delta_hard_limit` | Absolute maximum logical time delta             | 10,000       | lt units      | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits)        |
-| `mc_catchain_lifetime`   | masterchain catchain groups lifetime in seconds | 250         | seconds       | `uint32` | [Param 28](/ton/config#param-28-catchain-config)                                                                           |
+| Name                     | Description                                     | Value          | Units                   | Type     | Defined in                                                   |
+| ------------------------ | ----------------------------------------------- | -------------- | ----------------------- | -------- | ------------------------------------------------------------ |
+| `mc_bit_price_ps`        | Storage price for one bit for 65,536 seconds    | 1000           | nanotons/bit            | `uint64` | [Param 18](/ton/config#param-18-storage-prices)              |
+| `mc_cell_price_ps`       | Storage price for one cell for 65,536 seconds   | 500,000        | nanotons/cell           | `uint64` | [Param 18](/ton/config#param-18-storage-prices)              |
+| `mc_flat_gas_limit`      | Gas below `flat_gas_limit` on masterchain       | 100            | gas units               | `uint64` | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)    |
+| `mc_flat_gas_price`      | TVM launch cost on masterchain                  | 1,000,000      | nanotons                | `uint64` | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)    |
+| `mc_gas_price`           | Gas price on masterchain                        | 655,360,000    | nanotons                | `uint64` | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)    |
+| `mc_special_gas_limit`   | Special contract gas limit on masterchain       | 70,000,000     | gas units               | `uint64` | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)    |
+| `mc_gas_limit`           | Maximum gas per transaction on masterchain      | 1,000,000      | gas units               | `uint64` | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)    |
+| `mc_gas_credit`          | Gas credit for checking external messages       | 10,000         | gas units               | `uint64` | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)    |
+| `mc_block_gas_limit`     | Maximum gas per masterchain block               | 2,500,000      | gas units               | `uint64` | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)    |
+| `mc_freeze_due_limit`    | Storage fees for contract freezing              | 100,000,000    | nanotons                | `uint64` | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)    |
+| `mc_delete_due_limit`    | Storage fees for contract deletion              | 1,000,000,000  | nanotons                | `uint64` | [Param 20 and 21](/ton/config#param-20-and-21-gas-prices)    |
+| `mc_bytes_underload`     | Block size limit for underload state            | 131,072        | bytes                   | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits)  |
+| `mc_bytes_soft_limit`    | Block size soft limit                           | 524,288        | bytes                   | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits)  |
+| `mc_bytes_hard_limit`    | Absolute maximum block size in bytes            | 1,048,576      | bytes                   | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits)  |
+| `mc_gas_underload`       | Block gas limit for underload state             | 200,000        | gas units               | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits)  |
+| `mc_gas_soft_limit`      | Block gas soft limit                            | 1,000,000      | gas units               | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits)  |
+| `mc_gas_hard_limit`      | Absolute maximum block gas                      | 2,500,000      | gas units               | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits)  |
+| `mc_lump_price`          | Base price for message forwarding               | 10,000,000     | nanotons                | `uint64` | [Param 24 and 25](/ton/config#param-24-and-25-message-price) |
+| `mc_bit_price`           | Cost per 65,536 bits of message forwarding      | 655,360,000    | nanotons/bit            | `uint64` | [Param 24 and 25](/ton/config#param-24-and-25-message-price) |
+| `mc_cell_price`          | Cost per 65,536 cells for message forwarding    | 65,536,000,000 | nanotons/cell           | `uint64` | [Param 24 and 25](/ton/config#param-24-and-25-message-price) |
+| `mc_ihr_factor`          | Factor for immediate hypercube routing cost     | 98,304         | factor                  | `uint32` | [Param 24 and 25](/ton/config#param-24-and-25-message-price) |
+| `mc_first_frac`          | Fraction for first transition in message route  | 21,845         | fraction                | `uint32` | [Param 24 and 25](/ton/config#param-24-and-25-message-price) |
+| `mc_next_frac`           | Fraction for subsequent transitions in route    | 21,845         | fraction                | `uint32` | [Param 24 and 25](/ton/config#param-24-and-25-message-price) |
+| `mc_lt_delta_underload`  | Logical time delta limit for underload state    | 1000           | logical time units (lt) | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits)  |
+| `mc_lt_delta_soft_limit` | Logical time delta soft limit                   | 5,000          | lt units                | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits)  |
+| `mc_lt_delta_hard_limit` | Absolute maximum logical time delta             | 10,000         | lt units                | `uint32` | [Param 22 and 23](/ton/config#param-22-and-23-block-limits)  |
+| `mc_catchain_lifetime`   | masterchain catchain groups lifetime in seconds | 250            | seconds                 | `uint32` | [Param 28](/ton/config#param-28-catchain-config)             |
 
 ## Validator parameters
 
-| Name                        | Description                                         | Value      | Units         | Type   | Defined in |
-| --------------------------- | --------------------------------------------------- | ---------- | ------------- | ------ | --------------- |
-| `shard_catchain_lifetime`   | shardchain catchain groups lifetime in seconds      | 250        | seconds       | `uint32` | [Param 28](/ton/config#param-28-catchain-config)        |
-| `shard_validators_lifetime` | shardchain validators group lifetime in seconds     | 1000       | seconds       | `uint32` | [Param 28](/ton/config#param-28-catchain-config)        |
-| `shard_validators_num`      | Number of validators in shardchain validation group | 23         | count         | `uint32` | [Param 28](/ton/config#param-28-catchain-config)        |
-| `masterchain_block_fee`     | Reward for block creation                           | 1,700,000,000 | nanotons      | `Grams`  | [Param 14](/ton/config#param-14-block-reward)        |
-| `basechain_block_fee`       | Basechain block fee                                 | 1,000,000,000 | nanotons      | `Grams`  | [Param 14](/ton/config#param-14-block-reward)        |
+| Name                        | Description                                         | Value         | Units    | Type     | Defined in                                       |
+| --------------------------- | --------------------------------------------------- | ------------- | -------- | -------- | ------------------------------------------------ |
+| `shard_catchain_lifetime`   | shardchain catchain groups lifetime in seconds      | 250           | seconds  | `uint32` | [Param 28](/ton/config#param-28-catchain-config) |
+| `shard_validators_lifetime` | shardchain validators group lifetime in seconds     | 1000          | seconds  | `uint32` | [Param 28](/ton/config#param-28-catchain-config) |
+| `shard_validators_num`      | Number of validators in shardchain validation group | 23            | count    | `uint32` | [Param 28](/ton/config#param-28-catchain-config) |
+| `masterchain_block_fee`     | Reward for block creation                           | 1,700,000,000 | nanotons | `Grams`  | [Param 14](/ton/config#param-14-block-reward)    |
+| `basechain_block_fee`       | Basechain block fee                                 | 1,000,000,000 | nanotons | `Grams`  | [Param 14](/ton/config#param-14-block-reward)    |
 
 ## Time parameters
 
-| Name          | Description                                  | Value | Units    | Type     | Defined in |
-| ------------- | -------------------------------------------- | ----- | -------- | -------- | --------------- |
-| `utime_since` | Initial Unix timestamp for price application | 0     | seconds  | `UnixTime` | [Param 18](/ton/config#param-18-storage-prices)        |
+| Name          | Description                                  | Value | Units   | Type       | Defined in                                      |
+| ------------- | -------------------------------------------- | ----- | ------- | ---------- | ----------------------------------------------- |
+| `utime_since` | Initial Unix timestamp for price application | 0     | seconds | `UnixTime` | [Param 18](/ton/config#param-18-storage-prices) |


### PR DESCRIPTION
- [ ] **1. Throat-clearing opener and undefined acronym on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/limits.mdx?plain=1#L8

The opener describes the document instead of delivering value and uses “TON” without definition. Minimal fix: replace with a concise purpose and define the acronym on first use, for example: “Current limits and configuration parameters used in The Open Network (TON).”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **2. Awkward phrasing: “network parameters definitions”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/limits.mdx?plain=1#L10

The phrase is unidiomatic. Minimal fix: change to “network parameter definitions” (or “definitions of network parameters”). Do not use an HTML line break here; a normal paragraph followed by an ordered list renders correctly in Markdown (general Markdown behavior).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **3. Heading casing and compound modifier: “MasterChain specific parameters”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/limits.mdx?plain=1#L83

Violates TON-specific casing (“MasterChain” → “masterchain”) and missing hyphen in the compound modifier. Minimal fix: “Masterchain-specific parameters”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#b-banned-and-preferred-terms; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form

---

- [ ] **4. TON-specific casing in body text: “MasterChain” should be “masterchain”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/limits.mdx?plain=1#L87-L113

Multiple descriptions in the Masterchain section capitalize “MasterChain”. Per term casing, use lowercase “masterchain”. Minimal fix examples:
- “on MasterChain” → “on masterchain”
- “MasterChain block” → “masterchain block”
- “MasterChain catchain…” → “masterchain catchain…”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#b-banned-and-preferred-terms

---

- [ ] **5. TON-specific casing: “ShardChain” should be “shardchain”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/limits.mdx?plain=1#L119-L121

Use lowercase “shardchain” per house casing. Minimal fixes:
- “ShardChain catchain…” → “shardchain catchain…”
- “ShardChain validators group…” → “shardchain validators group…”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#b-banned-and-preferred-terms

---

- [ ] **6. TON-specific casing: “BaseChain” should be “basechain”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/limits.mdx?plain=1#L123

Use lowercase “basechain” per house casing. Minimal fix: “BaseChain block fee” → “Basechain block fee”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#b-banned-and-preferred-terms

---

- [ ] **7. Undefined acronym “VM”; define and use “TVM” consistently**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/limits.mdx?plain=1#L40-L42

“VM start gas consumption” uses an undefined acronym. Define the term on first mention and use the acronym thereafter. Minimal fixes:
- Line 42: “Cost of launching the TON Virtual Machine (TVM)” (also singular “Cost”, not “Costs”).
- Line 40: “TVM start gas consumption”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **8. Ordered list numbering must use `1.` for every item**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/limits.mdx?plain=1#L11–12

Per house style, ordered lists should use `1.` for all items. Minimal fix: change “2. Node source code” to “1. Node source code”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **9. Types and identifiers in tables should use code font**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/limits.mdx?plain=1#L22–33,37–47,51–58,62–70,74–81,85–113,117–123,127–129

Values in the “Type” column (e.g., uint32, uint16, uint64, enum_value, Grams, UnixTime) are plain text. Per code styling, tokens and identifiers must use code formatting. Minimal fix: wrap these values in backticks (e.g., `uint32`, `enum_value`, `Grams`, `UnixTime`) consistently across all tables.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-3-code-styling

---

- [ ] **10. Non‑descriptive link text in “Defined in” column**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/limits.mdx?plain=1#L41–47,53–54,89–97,98–106,108–113,119–123,129

Links labeled “[config21]”, “[config20]”, “[config23]”, “[config24]”, “[config25]”, and “[config18]” are not descriptive. Link text must be meaningful out of context. Minimal fix: change link text to the referenced section names, e.g., “Param 20 and 21”, “Param 22 and 23”, “Param 24 and 25”, or “Param 18” while keeping the same anchors.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text

---

- [ ] **11. Large numerals should use thousands separators for readability**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/limits.mdx?plain=1#L24–33,39–47,53–58,62–70,76–81,87–113,121–123

Numbers ≥ 10,000 (e.g., 65535, 2,097,152, 67,043,328, 1,000,000) should include separators. Minimal fix: add commas in Values (and similar numeric cells) across the tables, for example: 65535 → 65,535; 2097152 → 2,097,152; 67043328 → 67,043,328; 1000000 → 1,000,000. Do not add separators to codes/IDs.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#14-1-numerals-and-separators

---

- [ ] **12. Unordered set formatted as an ordered list with HTML break**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/limits.mdx?plain=1#L10

The two-item set of sources is not a procedure but is formatted as an ordered list and uses a manual `<br/>`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists. Minimal fix: remove the `<br/>` and use a bulleted list:
- Blockchain config
- Node source code

---

- [ ] **13. Capitalize “TON Blockchain” consistently**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/limits.mdx?plain=1#L8

"TON blockchain" uses a lowercase "blockchain" but elsewhere in the docs the proper noun is capitalized as "TON Blockchain" (e.g., https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1). Change to: "TON Blockchain".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-4-ton-specific-examples

---

- [ ] **14. Define acronym on first use: LT (logical time)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/limits.mdx?plain=1#L68–70, 110–112

Units show "lt units" without defining the acronym. In the first occurrence within each section, write "logical time units (lt)", then keep subsequent rows as "lt units" for brevity.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **15. Align parameter name with reference: `ihr_price_factor`**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/limits.mdx?plain=1#L79

The name `ihr_factor` differs from the canonical name `ihr_price_factor` used in the reference page (https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1#L394). Rename to `ihr_price_factor` to match the reference. If applying MasterChain prefixes (`mc_`) elsewhere, a broader naming decision would be needed for consistency; this entry limits the fix to the generic row.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules

---

- [ ] **16. Internal anchors should include full slug**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/limits.mdx?plain=1#L41–47, 53–56, 62–70, 76–81, 89–97, 98–113, 121–123, 129

Internal links like `/ton/config#param-20-and-21` likely won’t resolve because the heading on the target page is "Param 20 and 21: gas prices" and standard slugging includes the trailing text (e.g., `#param-20-and-21-gas-prices`). Update each internal link to use the full, stable anchor (e.g., `/ton/config#param-20-and-21-gas-prices`, `/ton/config#param-22-and-23-block-limits`, `/ton/config#param-24-and-25-message-price`, `/ton/config#param-18-storage-prices`, `/ton/config#param-14-block-reward`, `/ton/config#param-28-catchain-config`). This relies on general Markdown anchor slugging rules; verify against the site generator and apply consistently.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format