### PR TITLE
[AI] fix: how-it-works.mdx

### DIFF
--- a/standard/wallets/how-it-works.mdx
+++ b/standard/wallets/how-it-works.mdx
@@ -8,6 +8,7 @@ import { Aside } from '/snippets/aside.jsx';
 [Wallets](/ton/glossary#wallet) are often the entry point for transactions in The Open Network (TON). See [external messages](../../ton/ton#2-4-6-external-messages%2C-or-messages-from-nowhere).
 
 ## General principle
+
 A wallet smart contract stores two critical variables — the public key and the sequence number (`seqno`). Together they secure the wallet.
 
 Using the public key, the contract verifies that the request comes from the wallet owner; using `seqno`, it protects against replayed transactions (see [How replay protection works](#how-replay-protection-works)).
@@ -25,21 +26,27 @@ Remote procedure call (RPC) and blockchain explorers expose the balance as part 
 Wallet contracts use the Ed25519 signature scheme.
 You generate a private key (keep it safe) and a public key (stored in the contract; readable by anyone).
 
-<Aside type="note" title="Important">
-The public key is not the wallet address. The address is derived from the contract’s `StateInit` and other parameters. See [address formats](../../ton/addresses/address-formats).
+<Aside
+  type="note"
+  title="Important"
+>
+  The public key is not the wallet address. The address is derived from the contract’s `StateInit` and other parameters. See [address formats](../../ton/addresses/address-formats).
 </Aside>
 
 An external message to the contract contains a 512‑bit signature and the desired payload. Ed25519 verifies the provided signature against the message hash.
 
 ## Replay protection
 
-<Aside type="note" title="Why do we need replay protection?">
-Imagine Alice has 100 TON. Alice sends 10 TON to Bob as a gift. Bob forwards the exact same message to Alice's wallet and receives another 10 TON — unless the wallet prevents replays.
+<Aside
+  type="note"
+  title="Why do we need replay protection?"
+>
+  Imagine Alice has 100 TON. Alice sends 10 TON to Bob as a gift. Bob forwards the exact same message to Alice's wallet and receives another 10 TON — unless the wallet prevents replays.
 </Aside>
 
 Each transaction carries a counter value (in our case, `seqno`) that must be unique and strictly increasing for every outgoing transaction. Because `seqno` changes, the message hash changes as well, making it impossible to reuse a previous signature.
 
-### Role of valid_until
+### Role of valid\_until
 
 `valid_until` is a Unix timestamp embedded into the wallet’s signing message. The wallet rejects any external message if the current time exceeds this value. This limits the lifetime of a signature and prevents an attacker from replaying a captured message indefinitely.
 
@@ -51,6 +58,9 @@ It also makes retries safe: a client may resend the same signed message until th
 
 By varying `subwallet_id`, you can deploy multiple independent wallet contracts controlled by the same public key, each with its own address and `seqno`. This is useful for separating accounts, environments, or business lines while keeping a single key pair.
 
-<Aside type="note" title="Important">
-Changing `subwallet_id` creates a different wallet address. Funds are not shared across subwallets even if they use the same public key.
+<Aside
+  type="note"
+  title="Important"
+>
+  Changing `subwallet_id` creates a different wallet address. Funds are not shared across subwallets even if they use the same public key.
 </Aside>


### PR DESCRIPTION
- [ ] **1. Throat-clearing opener in first sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L5

The sentence “This article describes …” is throat‑clearing and adds no reader value. Replace with a direct, content‑forward opening. Minimal fix: “Jettons on TON are implemented as …” (or similar direct statement) without the meta preface.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **2. Colloquial “aka” in intro**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L5

Avoid slang; use a neutral phrase. Minimal fix: replace “aka” with “also known as”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#4-voice-and-tone; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **3. Parallelism and Oxford comma in Jetton master description**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L20-L23

Ensure parallel verb forms and use the Oxford comma in a 3+ item list. Minimal fix: “..., and the code of the standard jetton‑wallet smart contract for this jetton. They also have an owner (admin) who, by sending suitable messages to them, mints new tokens, closes minting, changes metadata, or transfers admin rights to another contract.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-1-voice-tense-and-person

---

- [ ] **4. Grammar: plural/singular mismatch for “regular wallets smart contract”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L38-L41

Subject–verb agreement is incorrect. Minimal fix: “Regular wallet smart contracts are designed for off‑chain interaction with their owner.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-1-voice-tense-and-person

---

- [ ] **5. Missing Oxford comma in three‑item series**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L43-L45

Add a comma before the final conjunction in a list of three items. Minimal fix: “… from the Jetton master, another Jetton wallet, or their owner's regular wallet smart contracts.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **6. Mixed and inconsistent list punctuation**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L51-L54

The list uses semicolons for the first three items and a period for the last. Prefer periods for full‑sentence list items; avoid semicolons. Minimal fix: end each bullet with a period.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **7. Admonition wording and grammar (“query id”, “protocols itself”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L56-L59

Improve grammar and precision; use the exact identifier name. Minimal fix: “In all schemes below, you will see the `query_id` field. The field is largely deprecated, and the protocol itself does not need it. It is mostly used for easier off‑chain parsing and other Web2 processing.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-1-voice-tense-and-person; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **8. Article before “Transfer message”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L65

Add the definite article for clarity. Minimal fix: “The _Transfer_ message contains the following data:”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **9. Subject–verb agreement: “that meet TL‑B scheme” → “meets the TL‑B scheme”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L79-L165

The relative clause should agree with the (singular) “message”. Minimal fix at each occurrence: “that meets the TL‑B scheme specified in TEP‑0074 …”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-1-voice-tense-and-person

---

- [ ] **10. Grammar: “amount were transferred”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L93-L98

Use singular verb with “amount”. Minimal fix: “The total jetton amount was transferred.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-1-voice-tense-and-person

---

- [ ] **11. Minting warning: missing verb**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L121-L128

Add the missing auxiliary verb. Minimal fix: “The structure of the Mint message is not specified in any TEPs and is left to the developer’s choice.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-1-voice-tense-and-person

---

- [ ] **12. “described above” reference — link to anchor instead**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L136-L137

Avoid “as mentioned above/below”; link to the exact section. Minimal fix: “See Token transfer” with an in‑page anchor link to `#token-transfer`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **13. Gerund in section heading**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L192

For procedural sections, avoid gerunds; use an imperative or concise noun phrase. Minimal fix: change “Wallet address providing” to “Provide wallet address” (imperative) or “Wallet address provision” (noun phrase).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-2-gerunds-and-labels

---

- [ ] **14. Throat‑clearing filler: “This process is very simple.”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L194

Remove filler; it doesn’t inform the reader. Minimal fix: delete the sentence.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **15. Missing article before message name**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L194-L195

Add the article for readability. Minimal fix: “sends … a `provide_wallet_address` message that contains …”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **16. UI actions list: mixed forms and punctuation**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L222-L226

Use parallel imperative forms and consistent punctuation. Minimal fix: “Get wallet balance.”, “Transfer jettons.”, “Index available jettons.” (each as a bullet ending with a period).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-2-gerunds-and-labels; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **17. Grammar: missing article “a new jetton”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L230-L234

Add the article. Minimal fix: “When the user receives a new jetton for the first time, …”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-1-voice-tense-and-person

---

- [ ] **18. Possessive form for “applications database”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L232

Use possessive for clarity. Minimal fix: “the application’s database”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **19. Wordy boilerplate: “In order for a user to …”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L236-L237

Collapse to a direct form. Minimal fix: “To transfer a given amount of a token to another user, the user only needs to fill in the `destination` and `amount` fields …”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **20. Terminology: “toncoins or TONs” vs glossary “Toncoin”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L41

Align with glossary term. Minimal fix: replace “toncoins or TONs” with “Toncoin”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#toncoin

---

- [ ] **21. Use <Aside> component instead of <Warning>**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L56-L142

The page uses `<Warning>` callouts, which violates the callout component rule and allowed types. Replace both with `<Aside>` using a supported `type` (these are informational notes, not safety warnings). Minimal fix:
- Line 56–59: change `<Warning>…</Warning>` to `<Aside type="note">…</Aside>`.
- Line 142–144: change `<Warning>…</Warning>` to `<Aside type="note">…</Aside>`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11.2; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#19-a-admonition-levels-and-usage

---

- [ ] **22. Mid‑sentence capitalization of “Jetton” (common noun)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L31-L175

Per the term bank, “jetton”, “jetton wallet”, and “jetton master” are common nouns and must be lowercase mid‑sentence. Minimal fixes (examples):
- Line 31: “address of jetton master contract …”
- Line 36: “…regular wallets and jetton wallets…”
- Line 43: “On the other hand, jetton wallet smart contracts …”
- Line 65: “actor A jetton wallet”
- Line 175: “Actor A jetton wallet -> jetton master contract”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13.4-ton‑specific-examples

---

- [ ] **23. Type names in tables should use code formatting**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L67–74,146–150,160–165,177–182,196–200,204–208

Type identifiers like `uint64`, `VarUInteger 16`, `MsgAddress`, `Cell`, and `Maybe ^Cell` should be rendered in code font in tables. Minimal fix: wrap all Type column values in backticks across these tables.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.3-code-styling

---

- [ ] **24. Trailing punctuation in bulleted lists (use none for fragments)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L51–54,224–226

Bulleted list items that are fragments should omit terminal punctuation consistently. Minimal fixes:
- Lines 51–54: remove trailing semicolons from each bullet.
- Lines 224–226: remove trailing semicolons/period; keep all three items without terminal punctuation.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.4-lists

---

- [ ] **25. Hyphenation inconsistency: “jetton-wallet” vs “jetton wallet”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L21-L237

This page and nearby jetton pages use “jetton wallet” (no hyphen). Minimal fixes:
- Line 21: “standard jetton wallet smart contract”
- Line 237: “…send it to the jetton wallet smart contract …”
Note: The style guide is silent on this compound; aligning with nearby pages keeps terminology consistent (see `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-transfer.mdx?plain=1`).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13.1-term-bank-canonical-source

---

- [ ] **26. Remove terminal punctuation from short list items**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L13-L14

The two bullet items under “smart contracts, including:” end with semicolons. For non‑sentence list items, omit terminal punctuation consistently. Minimal fix: remove the trailing semicolons in both bullets.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **27. Expand acronym on first use (“UI”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L220-L223

“UI” appears without being defined. On first mention, spell out the term then the acronym. Minimal fix: change heading to “Interaction from the user interface (UI)” and first sentence to “There are three actions that can be performed through the user interface (UI):”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **28. Use consistent arrow notation in actor labels**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L65-L194

The page mixes ASCII arrows (`->`) and a Unicode arrow (`→`) in actor lines (e.g., line 107). The guide is silent on arrow glyphs; prefer consistency with nearby usage. Minimal fix: change the Unicode arrow on line 107 to `->` to match the rest of the page. If a different house preference exists, apply it uniformly.
Rule: Guide is silent; prefer intra‑page consistency (per integrator instructions).

---

- [ ] **29. Standardize Tonkeeper casing**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L230

Brand casing is inconsistent: “TonKeeper”. Elsewhere in the docs and accepted vocabulary use “Tonkeeper” (see https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L46). Minimal fix: change link text to “Tonkeeper”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **30. Grammar: “Jetton wallets smart contracts”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L43-L45

Awkward noun order; use “Jetton wallet smart contracts”. Minimal fix: “On the other hand, Jetton wallet smart contracts are designed only for storing and processing tokens.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **31. Unstable TEP links to moving “master”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L9-L218

Links to TEPs use the “master” branch (moving target). Use a versioned/permalink or, where appropriate, link to the internal standard page first. Minimal fix: replace TEP URLs with commit permalinks (as in https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/overview.mdx?plain=1) or internal docs, and deep-link to the exact section.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references

---

- [ ] **32. Inclusive language in table (“himself”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L200

Avoid gendered language. Minimal fix: “Whether to include the actor’s address in the output message.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-5-global-and-inclusive-language

---

- [ ] **33. Wordy phrasing “that is also called”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L13

Collapse boilerplate: “(that is also called …)” → “(also called …)”. Suggested: “(also called _Jetton minter_)”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#57-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **34. Filler “It is important to keep in mind that”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L16

Remove throat‑clearing filler to tighten the sentence. Example: “Jetton standards define a general interaction scheme; specific contract implementations are up to developers.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#57-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **35. Non-parallel list items under “Message layouts”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L51-L54

Make the four bullets parallel and consistent in form. Suggested: “transferring tokens; minting tokens; burning tokens; providing a wallet address.” Also use consistent end punctuation (either none or periods).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#52-plain-precise-wording

---

- [ ] **36. Concision/grammar in excess message description**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L124

“if there are remaining Toncoin after paying the fees” → “if any Toncoin remains after paying fees”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#52-plain-precise-wording

---

- [ ] **37. Article/case and idiom in minting warning**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L142-L144

Use “the mint message” (not capitalized mid‑sentence) and prefer the standard idiom “left to the developer’s choice.” Suggested: “The following layout is one example. The structure of the mint message is not specified in any TEP and is left to the developer’s choice.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#52-plain-precise-wording

---

- [ ] **38. Possessive form in address description**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L149

“The address of the actor A regular wallet.” → “The address of actor A’s regular wallet.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#52-plain-precise-wording

---

- [ ] **39. Relative clause and inclusive phrasing**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L199-L201

“the actor which Jetton wallet address is needed” → “the actor whose Jetton wallet address is needed”. Also, “the address of the actor himself” → “the actor’s own address” or “their own address”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#55-global-and-inclusive-language

---

- [ ] **40. Heading wording**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#L216

Prefer a natural noun phrase for a concept section. “Interaction from UI” → “UI interactions”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#71-case-and-form