### PR TITLE
[AI] fix: custom_overlays.mdx

### DIFF
--- a/ecosystem/node/mytonctrl/custom_overlays.mdx
+++ b/ecosystem/node/mytonctrl/custom_overlays.mdx
@@ -5,11 +5,11 @@ description: "Sets up a custom overlay to speed up synchronization for a group o
 
 ## Operational notes
 
-- Overlays require MyTonCtrl to run in `validator` mode with an accessible validator console; the commands rely on console RPCs (`addcustomoverlay`, `showcustomoverlays`, `delcustomoverlay`).
-- Keep ADNL IDs in the configuration consistent with the node’s current validator keys. The helper refuses to deploy static overlays when the node lacks the necessary IDs.
+- Overlays require MyTonCtrl to run in `validator` mode with an accessible validator console. The commands rely on console remote procedure calls (RPCs) (`addcustomoverlay`, `showcustomoverlays`, and `delcustomoverlay`).
+- Keep ADNL (Abstract Datagram Network Layer) IDs in the configuration consistent with the node’s current validator keys. The helper refuses to deploy static overlays when the node lacks the necessary IDs.
 - Dynamic overlays are re-evaluated each election. MyTonCtrl automatically removes stale overlays tied to old election IDs and creates new ones as rounds roll over.
 
-## add\_custom\_overlay
+## `add_custom_overlay`
 
 **Purpose:** Register a custom overlay configuration and deploy it to the validator console.
 
@@ -19,10 +19,13 @@ description: "Sets up a custom overlay to speed up synchronization for a group o
 add_custom_overlay <overlay-name> <path-to-config>
 ```
 
+<OVERLAY_NAME> — arbitrary overlay label.
+<CONFIG_PATH> — path to the overlay JSON file.
+
 **Behavior**
 
-- `<overlay-name>` is an arbitrary label used inside MyTonCtrl and as the validator-console overlay name.
-- `<path-to-config>` must point to a JSON file describing overlay nodes. Each key is an ADNL address (hex) and each value specifies whether the node is a `block_sender` or `msg_sender` (`msg_sender` entries may include a `msg_sender_priority`).
+- `<OVERLAY_NAME>` is an arbitrary label used inside MyTonCtrl and as the validator console overlay name.
+- `<CONFIG_PATH>` must point to a JSON file describing overlay nodes. Each key is an ADNL ID (hex) and each value specifies whether the node is a `block_sender` or `msg_sender` (`msg_sender` entries may include a `msg_sender_priority`).
 - Configuration files can include an `@validators` key to denote dynamic overlays. In that case, MyTonCtrl stores the config and schedules validator-console updates for the current and next election rounds.
 - Static overlays are converted immediately via `addcustomoverlay` and require that your node owns the listed ADNL IDs; otherwise the command prints an error.
 - MyTonCtrl caches the config in its database, so overlays persist across restarts.
@@ -43,11 +46,13 @@ add_custom_overlay telemetry-overlay /etc/mytonctrl/overlays/telemetry.json
 }
 ```
 
+IDs are truncated for brevity; use full values in your config.
+
 - Keys other than `@validators` must be ADNL IDs in hex form.
 - For `msg_sender` entries set `msg_sender` to `true` and optionally include `msg_sender_priority` (higher numbers mean higher priority).
 - Include `@validators` only when you want the overlay to track the current validator set automatically.
 
-## list\_custom\_overlays
+## `list_custom_overlays`
 
 **Purpose:** Inspect every overlay definition stored by MyTonCtrl.
 
@@ -63,7 +68,7 @@ list_custom_overlays
 - Highlights whether an overlay is dynamic (`@validators` present) or static.
 - Helpful for auditing definitions before deploying them on another node.
 
-## delete\_custom\_overlay
+## `delete_custom_overlay`
 
 **Purpose:** Remove a stored overlay and, when possible, detach it from the validator console.
 
@@ -75,9 +80,9 @@ delete_custom_overlay <overlay-name>
 
 **Behavior**
 
-- Deletes `<overlay-name>` from the MyTonCtrl database.
+- Deletes `<OVERLAY_NAME>` from the MyTonCtrl database.
 - If the overlay was dynamic (tracked via `@validators`), the validator console updates within \~1 minute to remove it automatically.
-- For static overlays MyTonCtrl issues `delcustomoverlay <overlay-name>` so the validator console stops broadcasting it immediately. If the console rejects the operation, the command reports an error so you can intervene manually.
+- For static overlays, MyTonCtrl issues `delcustomoverlay <overlay-name>` so the validator console stops broadcasting it immediately. If the console rejects the operation, the command reports an error so you can intervene manually.
 
 **Example**
 


### PR DESCRIPTION
- [ ] **1. Command headings should use code font (identifier)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/custom_overlays.mdx?plain=1#L12-L66

The command section headings use plain text with escaped underscores (e.g., "## add\_custom\_overlay"). On reference pages, identifiers in headings may use code font to preserve exact spelling/case and avoid escapes. Minimal fix: change to "## `add_custom_overlay`", "## `list_custom_overlays`", and "## `delete_custom_overlay`".

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles

---

- [ ] **2. Placeholder style not in <ANGLE_CASE>**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/custom_overlays.mdx?plain=1#L19-L78

Placeholders appear as `<overlay-name>` and `<path-to-config>` (kebab-case). Placeholders in commands and prose must use `<ANGLE_CASE>` with descriptive names. Minimal fix: replace with `<OVERLAY_NAME>` and `<CONFIG_PATH>` everywhere, including inline mentions and in the delete example.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-5-placeholder-names

---

- [ ] **3. Missing definitions for placeholders at first use**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/custom_overlays.mdx?plain=1#L18-L21

The first command block introduces placeholders but does not define them. Placeholders must be defined on first use. Minimal fix: immediately below the syntax block, add two lines defining them, for example: `<OVERLAY_NAME> — arbitrary overlay label.` and `<CONFIG_PATH> — path to the overlay JSON file.`

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **4. In-page inconsistency: “validator-console” vs “validator console”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/custom_overlays.mdx?plain=1#L8-L80

The page alternates between the hyphenated and spaced forms. Terminology must be consistent; when the guide is silent, prefer consistency with nearby pages. Minimal fix: standardize to “validator console” (spaced) across this page. For consistency reference, see https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/collator.mdx?plain=1#setup_collator where “validator console” is used in text.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-1-term-bank-canonical-source; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules

---

- [ ] **5. Safety callout missing for configuration/network-affecting operations [HIGH]**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/custom_overlays.mdx?plain=1#L12-L86

The page instructs adding and deleting overlays, which modify validator configuration/network behavior. Such steps require a Caution/Warning `<Aside>` with risk, scope, rollback/mitigation, and environment labeling. Minimal fix: add a Caution aside near the top (before commands) using `<Aside type="caution" title="Network configuration risk">` summarizing the risk and basic rollback (e.g., remove the overlay), and label environment (testnet/mainnet) as applicable. Content details may need confirmation from the domain owner.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-1-when-a-safety-callout-is-required; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#19-appendices (Admonition levels and usage)

---

- [ ] **6. Overused semicolon; prefer two sentences**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/custom_overlays.mdx?plain=1#L8

“Overlays require MyTonCtrl to run in `validator` mode with an accessible validator console; the commands rely on console RPCs …”. Semicolons should be rare; prefer shorter sentences. Minimal fix: replace the semicolon with a period: “… validator console. The commands rely on console RPCs …”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **7. Missing comma after introductory phrase**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/custom_overlays.mdx?plain=1#L80

“For static overlays MyTonCtrl issues `delcustomoverlay …`”. Add a comma after the introductory phrase for clarity: “For static overlays, MyTonCtrl issues …”. This is a basic grammar fix based on general English rules for introductory phrases.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons (general punctuation); General English grammar (introductory comma)

---

- [ ] **8. Truncated IDs in JSON example should use placeholders**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/custom_overlays.mdx?plain=1#L38-L48

The sample JSON uses truncated values like "3b53...d1" and "0a1f...bc". Replace such partial identifiers with explicit placeholders to avoid copy/paste ambiguity and comply with placeholder conventions. Minimal fix: use `<ADNL_HEX_1>`, `<VALIDATOR_ADNL_HEX_1>`, `<ADNL_HEX_2>` in the example, and adjust the bullets to refer to these placeholders. Optionally add one-line definitions beneath the block.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-5-placeholder-names; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#severity-model-release-blocking (silent truncation of IDs/addresses)

---

- [ ] **9. Missing conjunction and Oxford comma in three-item list**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/custom_overlays.mdx?plain=1#L8

The inline list of RPCs ends without a conjunction: "(`addcustomoverlay`, `showcustomoverlays`, `delcustomoverlay`)." Minimal fix: add the conjunction with the serial comma: "(`addcustomoverlay`, `showcustomoverlays`, and `delcustomoverlay`)."

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.1-commas-colons-semicolons

---

- [ ] **10. Acronym ADNL not expanded on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/custom_overlays.mdx?plain=1#L9

First use of ADNL lacks expansion. Minimal fix: expand on first mention, for example: "Keep ADNL (Abstract Datagram Network Layer) IDs …" (Subsequent uses can remain as ADNL.)

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms

---

- [ ] **11. Silent truncation of IDs in sample JSON**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/custom_overlays.mdx?plain=1#L38

Sample values like "3b53...d1", "0a1f...bc", and "7c9d...4e" are truncated without stating so. Minimal fix: add a short note immediately below the code block such as: "IDs are truncated for brevity; use full values in your config." (JSON cannot include comments.)

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#14.2-units-and-conventions

---

- [ ] **12. RPC acronym not expanded on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/custom_overlays.mdx?plain=1#L8

The page uses “RPCs” without expansion. Minimal fix: change “console RPCs” to “console remote procedure calls (RPCs)”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **13. Terminology consistency: “ADNL address” vs “ADNL ID”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/custom_overlays.mdx?plain=1#L25

The page alternates between “ADNL address” and “ADNL ID.” Within a single page, terminology should be consistent. Minimal fix: change “Each key is an ADNL address (hex)” to “Each key is an ADNL ID (hex),” matching lines 9 and 46 and usage across related pages.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **14. Sample JSON silently truncates IDs and lacks a “Not runnable” label**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/custom_overlays.mdx?plain=1#L38-L48

The example uses shortened IDs like `"3b53...d1"` and `"0a1f...bc"` without stating that they are abbreviated, which is a release‑blocking issue (silent truncation). The snippet is also not runnable and lacks the required label. Minimal fix: add a "Not runnable" label above the block and replace abbreviated values with explicit placeholders, for example:

Not runnable

```json
{
  "<ADNL_ID_HEX_1>": { "block_sender": true },
  "@validators": ["<VALIDATOR_ID_HEX_1>", "<VALIDATOR_ID_HEX_2>"],
  "<ADNL_ID_HEX_2>": { "msg_sender": true, "msg_sender_priority": 5 }
}
```

Then keep the bullets below to define constraints (hex form, etc.). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#severity-model-release-blocking; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#partial-snippets; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#code-and-command-examples