### PR TITLE
[AI] fix: writing-and-reading-addresses.mdx

### DIFF
--- a/ton/addresses/writing-and-reading-addresses.mdx
+++ b/ton/addresses/writing-and-reading-addresses.mdx
@@ -1,6 +1,6 @@
 title: "How to read and write TON addresses"
 sidebarTitle: "Read and write TON addresses"
----
+--------------------------------------------
 
 - how to create and parse
 - how to check the validity
@@ -8,34 +8,37 @@ sidebarTitle: "Read and write TON addresses"
 
 ## Use the online converter
 
-A user-friendly online parser and address converter on the TON Blockchain is the [TON Address tool](https://ton.org/address). 
-If you enter an address in any format, the tool provides all possible formats when the input is valid. 
+A user-friendly online parser and address converter on the TON Blockchain is the [TON Address tool](https://ton.org/address).
+If you enter an address in any format, the tool provides all possible formats when the input is valid.
 Otherwise, the tool displays a warning that the address is invalid.
 
 ![Example query in TON Address tool](/resources/images/ton-addresses.png)
 
-
 ## Use the SDK
 
 There are Software Development Kits (SDKs) for interacting with the TON Blockchain, written in:
+
 - [TypeScript](https://github.com/ton-org/ton)
 - [Java](https://github.com/neodix42/ton4j)
 - [Go](https://github.com/xssnick/tonutils-go)
 - [Python](https://github.com/nessshon/tonutils)
 
-You can use any of them, including for working with addresses. This guide focuses on the TypeScript SDK. 
+You can use any of them, including for working with addresses. This guide focuses on the TypeScript SDK.
 Namely, we examine [ton-core address module](https://github.com/ton-org/ton-core/tree/main/src/address).
 
 The internal addresses are represented as instances of the `Address` class. You can access it in your integrated development environment (IDE) using the following import.
 Not runnable
+
 ```typescript
 import { Address } from "@ton/core";
 
 readonly workChain: number;
 readonly hash: Buffer;
 ```
+
 As for the external addresses, they are represented as instances of the `ExternalAddress` class. Similarly, you can access it as follows.
 Not runnable
+
 ```typescript
 import { ExternalAddress } from "@ton/core";
 
@@ -43,18 +46,20 @@ readonly value: bigint;
 readonly bits: number;
 ```
 
- 
 ### Create, parse, and convert addresses
 
 Create addresses.
 Not runnable
+
 ```typescript
 // There is a hash validation check inside the Address constructor.
 const internalAddress = new Address(some_wc, some_valid_hash); 
 
 const externalAddress = new ExternalAddress(some_value, some_bits);
 ```
+
 You can parse an internal address string and then convert it from one format to another as follows.
+
 ```typescript
 const address1 = Address.parse('EQDKbjIcfM6ezt8KjKJJLshZJJSqX7XOA4ff-W72r5gqPrHF');
 const address2 = Address.parse('0:ca6e321c7cce9ecedf0a8ca2492ec8592494aa5fb5ce0387dff96ef6af982a3e');
@@ -91,7 +96,9 @@ console.log(address2.toRawString()); // 0:ca6e321c7cce9ecedf0a8ca2492ec8592494aa
 address2.toStringBuffer();
 
 ```
+
 If you are sure that your string accurately represents the address in raw or user-friendly format, you can also use the following methods.
+
 ```typescript
 const address1 = Address.parseFriendly('EQDKbjIcfM6ezt8KjKJJLshZJJSqX7XOA4ff-W72r5gqPrHF');
 const address2 = Address.parseRaw('0:ca6e321c7cce9ecedf0a8ca2492ec8592494aa5fb5ce0387dff96ef6af982a3e');


### PR DESCRIPTION
- [ ] **1. How-to title uses a colon and missing `sidebarTitle`**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/writing-and-reading-addresses.mdx?plain=1#L2

The how-to title should follow “How to X” without a colon, and how-to pages must set a concise `sidebarTitle`. Minimal fix: change `title: "How to: read and write TON addresses"` to `title: "How to read and write TON addresses"` and add `sidebarTitle: "Read and write TON addresses"` in frontmatter.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-1-files-and-titles; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#how-to-frontmatter-pattern

---

- [ ] **2. Throat-clearing opener before the intro list**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/writing-and-reading-addresses.mdx?plain=1#L5

Avoid meta text like “On this page…”. Minimal fix: delete the sentence and keep the list directly.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **3. Intro list: bold entire items and inconsistent punctuation**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/writing-and-reading-addresses.mdx?plain=1#L6

Do not bold whole list items and keep punctuation consistent for fragments. Minimal fix: remove `**` around each list item and drop trailing `;`/`.` so items read without terminal punctuation.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **4. Gerund in H2 “Using online converter”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/writing-and-reading-addresses.mdx?plain=1#L10

Task headings should be imperative, not gerunds. Minimal fix: change to `## Use the online converter`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-2-gerunds-and-labels; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form

---

- [ ] **5. Proper-noun casing and article: “in TON blockchain”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/writing-and-reading-addresses.mdx?plain=1#L12

Use the proper-noun form “TON Blockchain” and include the article for natural English. Minimal fix: “in the TON Blockchain”. (Article per general English grammar.)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-4-ton-specific-examples

---

- [ ] **6. SDK list: inconsistent terminal punctuation**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/writing-and-reading-addresses.mdx?plain=1#L22

List items that are fragments should omit terminal punctuation consistently. Minimal fix: remove trailing `;` from the first three items and the trailing `.` from the last item.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **7. Partial snippets not labeled (“Not runnable”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/writing-and-reading-addresses.mdx?plain=1#L31; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/writing-and-reading-addresses.mdx?plain=1#L38

Blocks showing `readonly` class fields without context are not runnable. Minimal fix: add a line `Not runnable` immediately above each of these TypeScript code fences.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **8. Fluff/boilerplate: “The creation is simple.”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/writing-and-reading-addresses.mdx?plain=1#L48

Remove filler and intensifiers. Minimal fix: delete the sentence or replace with an imperative like “Create addresses.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **9. Incorrect casing for testnet/mainnet in code comments**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/writing-and-reading-addresses.mdx?plain=1#L67

Use lowercase “testnet” and “mainnet” when used as common nouns. Minimal fix: in the `toString` argument comments, change “Testnet” → “testnet” and “Mainnet” → “mainnet”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-3-hyphenation-and-abbreviations

---

- [ ] **10. Full-sentence bolding for emphasis**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/writing-and-reading-addresses.mdx?plain=1#L98

Do not bold entire sentences. Minimal fix: remove `**` around the sentence. If emphasis is needed, use an `<Aside type="note">` instead.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#a-admonition-levels-and-usage

---

- [ ] **11. Moving-branch link to code (stability)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/writing-and-reading-addresses.mdx?plain=1#L28

For links to specific source paths, prefer a versioned/tagged permalink when precision matters; avoid `main` when the exact content is normative. Minimal fix: replace the `ton-core` link with a tag/commit permalink if this reference is meant to be stable.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references

---

- [ ] **12. Image alt text is vague**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/writing-and-reading-addresses.mdx?plain=1#L16

Alt text should describe the content for screen readers. Minimal fix: change to “Example query in TON Address tool” (or similar concise description of what the image shows).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#15-2-structure-and-tables

---

- [ ] **13. Marketing/superlative language**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/writing-and-reading-addresses.mdx?plain=1#L12

“The best user-friendly online parser…” is subjective marketing phrasing. Minimal fix: Remove “The best” and state the fact neutrally, e.g., “A user-friendly online parser and address converter is the TON Address tool…”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles

---

- [ ] **14. Casing and preposition for TON Blockchain**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/writing-and-reading-addresses.mdx?plain=1#L12-L21

Uses “TON blockchain” and “in TON blockchain”. Use the proper noun “TON Blockchain” and prefer “on” for consistency with nearby docs (see https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1). Minimal fix: “on the TON Blockchain”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-4-ton-specific-examples

---

- [ ] **15. SDK acronym not expanded on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/writing-and-reading-addresses.mdx?plain=1#L21

First use of “SDKs” is not expanded. Minimal fix: “Software Development Kit (SDK)” on first mention; use “SDK” thereafter.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **16. Hedging with “at least”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/writing-and-reading-addresses.mdx?plain=1#L21

“There are at least four SDKs…” is hedging. Minimal fix: remove “at least” or state neutrally: “There are SDKs for interacting with the TON Blockchain in:”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **17. Placeholder style inside code not neutral**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/writing-and-reading-addresses.mdx?plain=1#L51-L53

Placeholders like `some_wc`, `some_valid_hash`, `some_value`, `some_bits` are ad‑hoc. Inside language code, placeholders should use neutral UPPER_SNAKE (or define variables above). Minimal fix: use `SOME_WORKCHAIN`, `VALID_HASH`, `SOME_VALUE`, `SOME_BITS` or define real variables.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **18. Heading uses gerund; should be imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/writing-and-reading-addresses.mdx?plain=1#L19

“Using SDK” uses a gerund. Minimal fix: “Use the SDK” (or “Use an SDK” if multiple are covered).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-2-gerunds-and-labels

---

- [ ] **19. Glossary link on first useful mention of a core term**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/writing-and-reading-addresses.mdx?plain=1#L12

Core term “TON” appears without a Glossary link on first useful mention. Minimal fix: link “TON” to the Glossary on first use in body text.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not

---

- [ ] **20. Informal phrasing “favorite IDE”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/writing-and-reading-addresses.mdx?plain=1#L30

“in your favorite IDE” is casual phrasing. Minimal fix: “Import with:” or “Use the following import:”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-5-global-and-inclusive-language

---

- [ ] **21. Unexpanded acronym on first mention (“IDE”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/writing-and-reading-addresses.mdx?plain=1#L30

Spell out on first use. Minimal fix: “You can access it in your favorite integrated development environment (IDE) using the following import.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **22. First mention of TON not expanded**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/writing-and-reading-addresses.mdx?plain=1#L12

Spell out the term on first use. Minimal fix: “in The Open Network (TON) blockchain”. Optionally link TON to the Glossary on first useful mention.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **23. List introduction needs a complete clause before colon**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/writing-and-reading-addresses.mdx?plain=1#L21

The sentence introduces a list but should be a complete clause before the colon. Minimal fix: make it a complete clause and add a colon, for example: “There are SDKs for interacting with the TON blockchain, written in:”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **24. Partial code snippets not labeled “Not runnable”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/writing-and-reading-addresses.mdx?plain=1#L31

The following fenced blocks are partial (contain declarations or placeholders like `some_wc`) and are not runnable as shown: the `Address` import with fields (line 31), the `ExternalAddress` import with fields (line 38), and the “The creation is simple.” example (line 49). Minimal fix: add a “Not runnable” label line immediately above each of these code fences.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **25. Comparative claim about “most used”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/writing-and-reading-addresses.mdx?plain=1#L27

“we focus here on the most used one” is comparative/marketing phrasing. Minimal fix: make it neutral and task‑focused, e.g., “This guide focuses on the TypeScript SDK.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles-reader-first-answer-first

---

- [ ] **26. Passive voice and future tense in tool behavior**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/writing-and-reading-addresses.mdx?plain=1#L13

“If the address is entered…, the system will provide…” uses passive voice and future tense. Prefer active, present tense. Minimal fix: `If you enter an address in any format, the tool provides all possible formats when the input is valid.`
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#51-voice-tense-and-person (use active voice, present tense)

---

- [ ] **27. Passive/future tense for warning message**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/writing-and-reading-addresses.mdx?plain=1#L14

“a warning will be displayed” is passive and future tense. Minimal fix: `Otherwise, the tool displays a warning that the address is invalid.`
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#51-voice-tense-and-person (use active voice, present tense)

---

- [ ] **28. Grammar: “internal addresses string”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/writing-and-reading-addresses.mdx?plain=1#L55

Minor grammar issue that may confuse readers. Minimal fix: `You can parse an internal address string and then convert it from one format to another as follows.` (General English grammar guidance.)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-grammar-and-usage (clarity and readability)

---

- [ ] **29. Passive voice in validity explanation**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/writing-and-reading-addresses.mdx?plain=1#L102

“The validity of the address is checked at the time of its parsing. An attempt to parse an invalid address will result in an error.” uses passive and future tense. Minimal fix: `Parsing checks address validity. Parsing an invalid address results in an error.`
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#51-voice-tense-and-person (use active voice, present tense)