### PR TITLE
[AI] fix: complex-and-non-trivial-examples.mdx

### DIFF
--- a/language/TL-B/complex-and-non-trivial-examples.mdx
+++ b/language/TL-B/complex-and-non-trivial-examples.mdx
@@ -5,7 +5,7 @@ sidebarTitle: "Complex examples"
 
 ## Unary
 
-The `Unary` functional type is commonly used for dynamic sizing in structures such as [hml_short](https://github.com/ton-blockchain/ton/blob/master/crypto/block/block.tlb#L29).
+The `Unary` functional type is commonly used for dynamic sizing in structures such as [hml\_short](https://github.com/ton-blockchain/ton/blob/master/crypto/block/block.tlb#L29).
 
 Unary supports two main options:
 
@@ -37,34 +37,34 @@ This shows that the bitstring `110` corresponds to `Unary 2`.
 
 {/*## Snake
 
-The **Snake** functional type is used to store sequences of bits with a length that is not predetermined. It is often employed in transactions with long comment in them.
+  The **Snake** functional type is used to store sequences of bits with a length that is not predetermined. It is often employed in transactions with long comment in them.
 
-```tlb
-empty#_ b:bits = Snake ~0;
-cons#_ {n:#} b:bits next:^(Snake ~n) = Snake ~(n + 1);
-```
+  ```tlb
+  empty#_ b:bits = Snake ~0;
+  cons#_ {n:#} b:bits next:^(Snake ~n) = Snake ~(n + 1);
+  ```
 
-In this scenario, serialization continues until all links are assembled.
+  In this scenario, serialization continues until all links are assembled.
 
-The `empty` variation it just deserializes a string of bits and end the process if there is no any references to other cells.
+  The `empty` variation it just deserializes a string of bits and end the process if there is no any references to other cells.
 
-The `cons` variation deserializes a string of bits and then follows a reference to another cell, continuing the process until it reaches the `empty` variation. 
-The number of such recursive calls determines the final size of `n`.
+  The `cons` variation deserializes a string of bits and then follows a reference to another cell, continuing the process until it reaches the `empty` variation. 
+  The number of such recursive calls determines the final size of `n`.
 
-Consider the following tree of cells:
-```
-1[1] -> {
+  Consider the following tree of cells:
+  ```
+  1[1] -> {
   2[00] -> {
     7[1001000] -> {
       25[1010000010000001100001001]
     }
   }
-}
-```
+  }
+  ```
 
-In this example, the first cell contains a reference. So, `1` is read and then the reference is opened according to `cons` constructor.
-Next, the `00` is read and then the next reference is opened. This process continues until there are no links in the next cell. The next two bits, `00`, are part of the `b:bits` field. The remaining bits in this cell are used for the reference to the next cell.
-*/}
+  In this example, the first cell contains a reference. So, `1` is read and then the reference is opened according to `cons` constructor.
+  Next, the `00` is read and then the next reference is opened. This process continues until there are no links in the next cell. The next two bits, `00`, are part of the `b:bits` field. The remaining bits in this cell are used for the reference to the next cell.
+  */}
 
 ## Hashmap
 
@@ -132,6 +132,7 @@ Next, we can populate the structure variables with known values. The initial res
 `hme_root$1 {n:#} {X:Type} root:^(Hashmap 8 uint16) = HashmapE 8 uint16;`
 
 Here, the one-bit prefix is already read. The curly braces `{}` indicate conditions that need not be read. Specifically:
+
 - `{n:#}` indicates that `n` is any `uint32` number.
 - `{X:Type}` means that `X` can be any type.
 
@@ -160,7 +161,6 @@ Conditional variables `{l:#}` and `{m:#}` have appeared, but both values are unk
 
 To determine the value of `l`, we need to load the `label:(HmLabel ~l uint16)` sequence. Below, we outline the 3 basic structural options for `HmLabel`:
 
-
 ```tlb
 hml_short$0 {m:#} {n:#} len:(Unary ~n) {n <= m} s:(n * Bit) = HmLabel ~n m;
 hml_long$10 {m:#} n:(#<= m) s:(n * Bit) = HmLabel ~n m;
@@ -186,6 +186,7 @@ Now, we can complete the `hml_short` structure by using the calculated `n` value
 ```tlb
 hml_short$0 {m:#} {n:#} len:0 {n <= 8} s:(0 * Bit) = HmLabel 0 8
 ```
+
 We have an empty `HmLabel`, denoted by `s = 0`, which means there is nothing to load.
 
 Next, we complete our structure by incorporating the calculated value of `l`, as follows:
@@ -243,7 +244,9 @@ Next, the `HmLabel` response is loaded using the `HmLabel` variation, as the pre
 ```tlb
 hml_long$10 {m:#} n:(#<= m) s:(n * Bit) = HmLabel ~n m;
 ```
+
 Now, let's fill in the sequence:
+
 ```tlb
 hml_long$10 {m:#} n:(#<= 7) s:(n * Bit) = HmLabel ~n 7;
 ```
@@ -254,6 +257,7 @@ In binary, the number 7 is written as `111`, which means 3 bits are needed. Ther
 ```tlb
 hml_long$10 {m:#} n:(## 3) s:(n * Bit) = HmLabel ~n 7;
 ```
+
 Next, we load `n` into the sequence, which results in `111`. As noted earlier, this coincidentally equals 7. Then, we load `s` into the sequence, which consists of 7 bits: `0000000`. Remember, `s` is part of the key.
 
 Afterwards, we return to the top of the sequence and fill in the resulting `l`:
@@ -266,7 +270,6 @@ hm_edge#_ {n:#} {X:Type} {l:#} {m:#} label:(HmLabel 7 7)
 Then we calculate the value of `m`: `m = 7 - 7`, which gives us `m = 0`.
 Since `m = 0`, the structure is ideally suited for use with a `HashmapNode`:
 
-
 ```tlb
 hmn_leaf#_ {X:Type} value:X = HashmapNode 0 X;
 ```
@@ -277,11 +280,9 @@ Now, let's restore the key. We need to combine all the parts of the key that wer
 
 In this specific case, 7 bits are taken from the `HmLabel 0000000`, and a `1` bit is added before the sequence of zeros because the value was obtained from the right branch. The final result is 8 bits, or `10000000`, which means the key value equals `128`.
 
-
 ## Other Hashmap types
 
 The following sections explain additional Hashmap types.
-
 
 ### HashmapAugE
 
@@ -319,6 +320,7 @@ phme_empty$0 {n:#} {X:Type} = PfxHashmapE n X;
 phme_root$1 {n:#} {X:Type} root:^(PfxHashmap n X)
             = PfxHashmapE n X;
 ```
+
 The key difference between the `PfxHashmap` and the regular `Hashmap` lies in its ability to store keys of varying lengths due to the inclusion of the `phmn_leaf$0` and `phmn_fork$1` nodes.
 
 ### VarHashmap
@@ -365,11 +367,12 @@ vm_tuple_tcons$_ {n:#} head:(VmTupleRef n) tail:^VmStackValue = VmTuple (n + 1);
 vm_stk_tuple#07 len:(## 16) data:(VmTuple len) = VmStackValue;
 ```
 
-Tuple is a tuple of elements that is written in FunC as `[a, b, c]`. VmTuple is used internally in [VmStack](https://github.com/ton-blockchain/ton/blob/05bea13375448a401d8e07c6132b7f709f5e3a32/crypto/block/block.tlb#L862) 
+Tuple is a tuple of elements that is written in FunC as `[a, b, c]`. VmTuple is used internally in [VmStack](https://github.com/ton-blockchain/ton/blob/05bea13375448a401d8e07c6132b7f709f5e3a32/crypto/block/block.tlb#L862)
 for tuple serialization, which is output from a contract's methods.
 
-Let's consider a serialization of the following tuple: [44, `Cell{00B5BD3EB0}`, -1]. 
+Let's consider a serialization of the following tuple: \[44, `Cell{00B5BD3EB0}`, -1].
 When disassembled, it looks as follows:
+
 ```text
 [070003] -> {
    [] -> {
@@ -384,7 +387,7 @@ When disassembled, it looks as follows:
 
 The root cell will be parsed using the constructor `vm_stk_tuple`, since its prefix is `0x07`. The next 2 bytes are `len:(## 16)`, which equals `0003 == 3`.
 
-Next comes `data:(VmTuple 3)`. There are two variants of parsing of `VmTuple`: `VmTuple (n + 1)` and  `VmTuple 0`. Since `n > 0`, `VmTuple (n + 1)` is used. 
+Next comes `data:(VmTuple 3)`. There are two variants of parsing of `VmTuple`: `VmTuple (n + 1)` and  `VmTuple 0`. Since `n > 0`, `VmTuple (n + 1)` is used.
 
 The first field is `head:(VmTupleRef 2=(3-1))`. There are three variants of parsing: `0`, `1`, and `n+2`. Our `n` equals `2`, so the third variant is used.
 
@@ -393,7 +396,7 @@ The only field is `ref:^(VmTuple (n + 2))`, i.e., `ref:^(VmTuple 2)`.
 Our `n` equals `2`, so the variant `(n + 1)` is chosen. Next read `head:(VmTupleRef n)` -> `head:(VmTupleRef 1=(2-1))`. In `VmTupleRef 1` there is only one field: `entry:^VmStackValue`.
 Essentially, this field is the value, `01 000000000000002C`.
 
-We read the `head` and reached the end. Now we go in the opposite direction and read the `tail:^VmStackValue`. Going up, the first tail is `03` with a link to the cell. 
+We read the `head` and reached the end. Now we go in the opposite direction and read the `tail:^VmStackValue`. Going up, the first tail is `03` with a link to the cell.
 `0x03` on the stack means a cell, we just read this link and save it as the value, `00B5BD3EB0`. Then go up a level and read another `tail`. This is `01 FFFFFFFFFFFFFFFF`, i.e., an int equal to `-1`.
 
 After we reach the end, parsing is completed. We add all the received elements into the array in the order in which we received them.


### PR DESCRIPTION
- [ ] **1. Unlabeled fenced code block (add language tag)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/complex-and-non-trivial-examples.mdx?plain=1#L31

The fenced block showing the return path uses triple backticks without a language specifier. Add a language (for example, `text`) to satisfy the requirement and enable consistent rendering/tooling. Minimal fix: start the block with ```text.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-command-and-example-hygiene

---

- [ ] **2. Unlabeled fenced code block (add language tag)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/complex-and-non-trivial-examples.mdx?plain=1#L103

The cell diagram block is fenced without a language. Add `text` after the opening backticks for clarity and consistency. Minimal fix: start the block with ```text.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-command-and-example-hygiene

---

- [ ] **3. Unlabeled fenced code block (add language tag)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/complex-and-non-trivial-examples.mdx?plain=1#L119

The block listing key/value pairs (`1 = 777`, etc.) is fenced without a language. Add `text` as the language. Minimal fix: start the block with ```text.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-command-and-example-hygiene

---

- [ ] **4. Unlabeled fenced code block (add language tag)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/complex-and-non-trivial-examples.mdx?plain=1#L137

The follow-up cell diagram block is fenced without a language. Add `text` to the opening fence. Minimal fix: use ```text.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-command-and-example-hygiene

---

- [ ] **5. Unlabeled fenced code block (add language tag)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/complex-and-non-trivial-examples.mdx?plain=1#L371

The VmTuple disassembly diagram is fenced without a language. Add `text` to match the docs requirement. Minimal fix: change opening fence to ```text.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-command-and-example-hygiene

---

- [ ] **6. Colon after incomplete clause**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/complex-and-non-trivial-examples.mdx?plain=1#L70

"As a support structure we need:" is not a complete clause before a colon. Make the lead-in a complete clause. Minimal fix: "We need the following support structure:" (or "As a support structure, we need the following:").
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **7. Heading casing consistency for “Hashmap”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/complex-and-non-trivial-examples.mdx?plain=1#L278

Heading reads "Other hashmap types" (lowercase "hashmap") while earlier sections treat Hashmap as a type name. Align casing within the page. Minimal fix: "Other Hashmap types".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17-4-proofread

---

- [ ] **8. Heading casing consistency for “Hashmap”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/complex-and-non-trivial-examples.mdx?plain=1#L227

Subheading reads "Analyzing loaded hashmap values" (lowercase "hashmap"). Align with earlier use of "Hashmap" as a type name. Minimal fix: "Analyzing loaded Hashmap values".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17-4-proofread

---

- [ ] **9. Grammar: "Let's us" → "Let's/Let us"**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/complex-and-non-trivial-examples.mdx?plain=1#L368

"Let's us consider" is ungrammatical. Minimal fix: "Let's consider" (or "Let us consider"). This is a basic English grammar correction (general knowledge).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17-4-proofread

---

- [ ] **10. Grammar: plural agreement "variant" → "variants"**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/complex-and-non-trivial-examples.mdx?plain=1#L386

"There are three variant of parsing" should use the plural noun. Minimal fix: "There are three variants of parsing".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17-4-proofread

---

- [ ] **11. Comma splice (split into sentences)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/complex-and-non-trivial-examples.mdx?plain=1#L393

"We read the `head` and reached the end, now we go in the opposite direction…" contains a comma splice. Minimal fix: split into two sentences: "We read the `head` and reached the end. Now we go in the opposite direction…".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **12. Comma splice (split into sentences)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/complex-and-non-trivial-examples.mdx?plain=1#L396

"After we have reached the end, the parsing is completed, we add…" contains a comma splice. Minimal fix: "After we reach the end, parsing is completed. We add …" (or use a semicolon).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **13. Missing space after comma before code span**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/complex-and-non-trivial-examples.mdx?plain=1#L391

"…the value,`01 000000000000002C`." is missing a space after the comma. Minimal fix: add a space: "value, `01 000000000000002C`.".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **14. Missing comma after introductory clause**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/complex-and-non-trivial-examples.mdx?plain=1#L224

"Now that we know the formula obtaining the final result is straightforward." needs a comma after the introductory clause. Minimal fix: "Now that we know the formula, obtaining the final result is straightforward.".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **15. Remove intensifier and unnecessary italics**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/complex-and-non-trivial-examples.mdx?plain=1#L365

"Tuple is an _actual_ tuple…" uses an intensifier and italics for emphasis that add no meaning. Minimal fix: "Tuple is a tuple of elements…" (remove "actual" and italics) or rephrase concisely.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **16. Non-descriptive link text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/complex-and-non-trivial-examples.mdx?plain=1#L400

"Link to the original article" is generic. Use descriptive link text. Minimal fix: "Original TL‑B article by Oleg Baranov" (or similar specific wording).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text

---

- [ ] **17. Frontmatter title exceeds 30 characters without `sidebarTitle`**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/complex-and-non-trivial-examples.mdx?plain=1#L2

Frontmatter `title` (“Complex and non-trivial examples”) is over 30 characters, but no `sidebarTitle` is set. Minimal fix: add `sidebarTitle: "Complex examples"` (≤ 30 chars) or shorten the `title` to ≤ 30 chars.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-file-navigation-and-frontmatter-conventions

---

- [ ] **18. Sentence fragment (complete the predicate)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/complex-and-non-trivial-examples.mdx?plain=1#L249

"Therefore, the value for `n = 3`." is a fragment. Minimal fix: "Therefore, the value for `n` is `3`.".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17-4-proofread

---

- [ ] **19. Missing comma after “i.e.”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/complex-and-non-trivial-examples.mdx?plain=1#L388

"i.e. `ref:^(VmTuple 2)`" should include a comma after "i.e." Minimal fix: "i.e., `ref:^(VmTuple 2)`". This follows standard English punctuation (general knowledge).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17-4-proofread

---

- [ ] **20. Missing comma and article after “i.e.”; comma splice**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/complex-and-non-trivial-examples.mdx?plain=1#L395

"this is `01 FFFFFFFFFFFFFFFF`, i.e. int equal to `-1`." needs a comma after "i.e." and an article. Also consider breaking the preceding comma splice. Minimal fix: "This is `01 FFFFFFFFFFFFFFFF`, i.e., an int equal to `-1`." (and ensure the prior sentence ends with a period).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **21. Word choice: “outputted” → “output”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/complex-and-non-trivial-examples.mdx?plain=1#L365–366

"…which is outputted from a contract's methods." Prefer the standard form. Minimal fix: "…which is output from a contract's methods.".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17-4-proofread

---

- [ ] **22. Throat‑clearing transition (tighten wording)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/complex-and-non-trivial-examples.mdx?plain=1#L280

"Now that we have discussed Hashmaps and how to load the standardized Hashmap type, let's explain how the additional Hashmap types function." is meta/setup text. Minimal fix: "The following sections explain additional Hashmap types." (remove throat‑clearing).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **23. Bold used for token; use code font**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/complex-and-non-trivial-examples.mdx?plain=1#L7

The phrase "The **unary** functional type" uses bold to style a technical identifier. Tokens/identifiers must use code formatting, not bold. Minimal fix: replace "**unary**" with "`Unary`" (type name) without bolding.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **24. Non-restrictive clause needs comma and clearer wording**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/complex-and-non-trivial-examples.mdx?plain=1#L97

"This root structure is `HashmapE n X` that can be…" should use a non‑restrictive clause. Minimal fix: "This root structure is `HashmapE n X`, which can be in one of two states: either `hme_empty` or `hme_root`."

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **25. Agreement: plural subject with singular verb**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/complex-and-non-trivial-examples.mdx?plain=1#L382

"The next 2 bytes are `len:(## 16)` that equals `0003 == 3`." Use a clear relative clause that agrees with the referent. Minimal fix: "The next 2 bytes are `len:(## 16)`, which equals `0003 == 3`."

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **26. Avoid “above/below” references**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/complex-and-non-trivial-examples.mdx?plain=1#L156

"As shown above, …" uses a relative reference. The guide requires linking to exact anchors instead of referencing position. Minimal fix: remove the phrase or link to the specific section where the referenced structure appears.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **27. Code font for type token in prose**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/complex-and-non-trivial-examples.mdx?plain=1#L68

Type names in prose should use code font for precision and consistency. Minimal fix: change "The Hashmap complex type" to "The `Hashmap` complex type".

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-3-code-styling

---

- [ ] **28. Missing space before inline code after comma**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/complex-and-non-trivial-examples.mdx?plain=1#L391-L394

Punctuation is immediately followed by inline code without a space (e.g., "value,`01 …`", "value,`00B5BD3EB0`"). Minimal fix: insert a space after the comma: "value, `01 …`" and "value, `00B5BD3EB0`".

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-3-code-styling