### PR TITLE
[AI] fix: managing-integration.mdx

### DIFF
--- a/ecosystem/tma/analytics/managing-integration.mdx
+++ b/ecosystem/tma/analytics/managing-integration.mdx
@@ -1,11 +1,11 @@
+title: "How to manage integration"
+sidebarTitle: "Manage integration"
 ---
-title: "Managing integration"
----
 
-[TON Builders](https://builders.ton.org) helps you to manage your SDK keys and participate in various support programs from TON Foundation.
+[TON Builders](https://builders.ton.org) helps you manage your software development kit (SDK) keys and participate in various support programs from TON Foundation.
 
-Register your project and go to the **Analytics** tab.
+Register your project and go to the "Analytics" tab.
 
-![](/resources/images/tma-analytics/analytics-preparations-1.png)
+![TON Builders — Analytics tab screenshot](/resources/images/tma-analytics/analytics-preparations-1.png)
 
-Enter your Telegram Bot URL and mini app domain to receive an **API key** for SDK initialization. You can also manage your existing keys from the same section. Enter your Telegram Bot URL and mini app domain to receive a token for SDK initialization.
+Enter your "Telegram bot URL" (Uniform Resource Locator (URL), <TELEGRAM_BOT_URL>) and "Mini App domain" (<MINI_APP_DOMAIN>) to receive an access token for SDK initialization. You can also manage your existing keys from the same section.


### PR DESCRIPTION
- [ ] **1. Title uses gerund; use imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/managing-integration.mdx?plain=1#L2

The page title "Managing integration" uses a gerund. For task/procedure pages, prefer an imperative verb in headings and titles. Minimal fix: change to "Manage integration" (or, if this page is a how‑to, "How to manage integration" per the how‑to pattern).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#headings-and-titles

---

- [ ] **2. UI label styled with bold; use quotation marks**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/managing-integration.mdx?plain=1#L7

"Analytics" is a UI tab label and is styled in bold. UI/log messages must appear verbatim in quotation marks and must not be bolded. Minimal fix: Register your project and go to the "Analytics" tab.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#quotation-marks-and-emphasis

---

- [ ] **3. Unexpanded acronyms on first mention (SDK, API, URL)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/managing-integration.mdx?plain=1#L5-L11

The acronyms "SDK", "API", and "URL" appear without being spelled out on first mention. Expand once, then use the acronym thereafter. Minimal fixes: "software development kit (SDK)", "application programming interface (API)", and "Uniform Resource Locator (URL)". This relies on general knowledge for standard acronym expansions.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#acronyms-and-terms

---

- [ ] **4. Redundant, conflicting duplicate sentence (API key vs token)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/managing-integration.mdx?plain=1#L11

The sentence "Enter your Telegram Bot URL and mini app domain to receive an API key for SDK initialization." is immediately followed by duplicate guidance ending with "…receive a token for SDK initialization." This is redundant and introduces inconsistent terminology (API key vs token). Minimal fix: remove the final duplicate sentence. If both terms are intended, a domain decision is required to standardize one term across the docs.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **5. Image without alt text; add brief descriptive alt**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/managing-integration.mdx?plain=1#L9

The image has empty alt text `![](...)`. Provide a concise text alternative. Minimal fix: `![TON Builders — Analytics tab screenshot](/resources/images/tma-analytics/analytics-preparations-1.png)`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#structure-and-tables

---

- [ ] **6. UI field names not quoted; quote literal labels**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/managing-integration.mdx?plain=1#L11

Field labels "Telegram Bot URL" and "mini app domain" appear as prose. Literal UI text must be quoted. Minimal fix: Enter your "Telegram Bot URL" and "mini app domain" to receive an API key for SDK initialization.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#quotation-marks-and-emphasis

---

- [ ] **7. Wordy phrasing; simplify to plain wording**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/managing-integration.mdx?plain=1#L5

"helps you to manage" is wordy. Prefer concise phrasing. Minimal fix: "helps you manage".

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#plain-precise-wording

---

- [ ] **8. Inconsistent capitalization: “mini app” should be “Mini App”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/managing-integration.mdx?plain=1#L11

Use the project’s canonical term and casing for the platform name. Fix: `mini app domain` → `Mini App domain`. For consistency, see usage in the Telegram Mini Apps overview: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/overview.mdx?plain=1.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#53-acronyms-and-terms

---

- [ ] **9. Inconsistent capitalization: “Telegram Bot URL”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/managing-integration.mdx?plain=1#L11

Follow consistent casing for generic nouns; elsewhere the docs use “Telegram bot …” (see https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/alerting.mdx?plain=1). Fix: `Telegram Bot URL` → `Telegram bot URL`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#53-acronyms-and-terms

---

- [ ] **10. Missing `sidebarTitle` for how-to page**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/managing-integration.mdx?plain=1#L2

How-to pages must define a concise `sidebarTitle`. Minimal fix: add `sidebarTitle: "Manage integration"` to the frontmatter (sentence case).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#how-to-frontmatter-pattern

---

- [ ] **11. Placeholders not formatted in <ANGLE_CASE>**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/managing-integration.mdx?plain=1#L11

Values the reader must supply (Telegram bot URL, mini app domain) are referenced in prose without placeholder formatting. Minimal fix: use `<TELEGRAM_BOT_URL>` and `<MINI_APP_DOMAIN>` in prose, and define them on first use.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#135-placeholder-names

---

- [ ] **12. Title violates How-to pattern and uses a gerund**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/managing-integration.mdx?plain=1#L2

The page reads like a short task/how-to but the frontmatter title uses a gerund and does not follow the required How-to pattern. Minimal fix: change `title: "Managing integration"` to `title: "How to manage integration"` and add `sidebarTitle: "Manage integration"`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#how-to-frontmatter-pattern

---

- [ ] **13. Terminology inconsistency: “API key” vs “token”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/managing-integration.mdx?plain=1#L11

Use one canonical term across Analytics pages. The overview uses “access token” (see https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/analytics.mdx?plain=1#installation). Minimal fix: replace “API key” with “access token” (or confirm canonical term) and keep it consistent throughout the sentence.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms