### PR TITLE
[AI] fix: changelog.mdx

### DIFF
--- a/language/func/changelog.mdx
+++ b/language/func/changelog.mdx
@@ -14,12 +14,14 @@ We refer to the May 2020 release as the initial version.
 Released in [2022-05](https://github.com/ton-blockchain/ton/releases/tag/v2022.05/).
 
 ### New features
+
 - [Constants](literals#constants)
 - [Compile-time built-ins](literals#compile-time-built-ins)
 - [`#pragma` version](compiler-directives#pragma-version)
 - [Includes](compiler-directives#%23include)
 
 ### Fixes
+
 - Resolved rare bugs in `Asm.fif`.
 
 ## Version 0.2.0
@@ -27,9 +29,11 @@ Released in [2022-05](https://github.com/ton-blockchain/ton/releases/tag/v2022.0
 Released in [2022-08](https://github.com/ton-blockchain/ton/releases/tag/v2022.08/).
 
 ### New features
+
 - Unbalanced `if/else` branches, where some branches return a value while others do not
 
 ### Fixes
+
 - FunC incorrectly handles `while(false)` loops [(issue #377)](https://github.com/ton-blockchain/ton/issues/377/).
 - FunC generates incorrect code for `if/else` branches [(issue #374)](https://github.com/ton-blockchain/ton/issues/374/).
 - FunC incorrectly returns from conditions in inline functions [(issue #370)](https://github.com/ton-blockchain/ton/issues/370/).
@@ -40,6 +44,7 @@ Released in [2022-08](https://github.com/ton-blockchain/ton/releases/tag/v2022.0
 Released in [2022-10](https://github.com/ton-blockchain/ton/releases/tag/v2022.10/).
 
 ### New features
+
 - Support for [multi-line `asm` statements](functions#multi-line-asms)
 - Allow duplicate definitions of identical constants and `asm` statements
 - Enable bitwise operations for constants
@@ -49,11 +54,13 @@ Released in [2022-10](https://github.com/ton-blockchain/ton/releases/tag/v2022.1
 Released in [2023-01](https://github.com/ton-blockchain/ton/releases/tag/v2023.01/).
 
 ### New features
+
 - [`try/catch` statements](statements#try%E2%80%A6catch-statement)
 - [`throw_arg` functions](built-ins#throw-arg)
 - Support for in-place modification and mass assignment of global variables, e.g., `a~inc()` and `(a, b) = (3, 5)`, where `a` is global
 
 ### Fixes
+
 - Disallowed ambiguous modification of local variables after their use in the same expression. For example, `var x = (ds, ds~load_uint(32), ds~load_uint(64));` is forbidden, while `var x = (ds~load_uint(32), ds~load_uint(64), ds);` is allowed.
 - Allowed empty inline functions.
 - Fixed a rare optimization bug in `while` loops.


### PR DESCRIPTION
- [ ] **1. Bold labels used instead of proper headings**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/changelog.mdx?plain=1

The page uses bold label lines for sectioning (e.g., "**New features:**" and "**Fixes:**" at lines 16, 22, 29, 32, 42, 51, 56). The style guide forbids bolding whole lines/paragraphs and recommends using structure instead. Minimal fix: replace each bold label with a heading at the next level, for example, change "**New features:**" to "### New features" and "**Fixes:**" to "### Fixes".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **2. Quotation marks used for emphasis**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/changelog.mdx?plain=1

Line 10 uses quotes for emphasis: “the "initial" version.” Quotes must be reserved for literal UI/log text, not emphasis. Minimal fix: remove the quotes: “the initial version.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **3. Incorrect anchor for “Includes” link**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/changelog.mdx?plain=1

At line 20, link text “Includes” points to `/language/func/compiler-directives#%23pragma-version` instead of the `#include` section. Minimal fix: change the target to `/language/func/compiler-directives#%23include`. Broken/mismatched anchors are release‑blocking.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#severity-model-release‑blocking; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-links-and-cross‑references

---

- [ ] **4. Broken anchor: multiline asm link**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/changelog.mdx?plain=1

At line 43, “multiline `asm` statements” links to `/language/func/functions#multiline-asms`, but the target heading is “### Multi-line asms” (hyphenated). Minimal fix: change the link to `/language/func/functions#multi-line-asms`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-links-and-cross‑references

---

- [ ] **5. Broken anchor: try/catch statements link**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/changelog.mdx?plain=1

At line 52, the link points to `/language/func/statements#try-catch-statements` (plural, hyphenated). The actual heading is “## `try...catch` statement”, whose anchor uses the ellipsis. Minimal fix: change to `/language/func/statements#try%E2%80%A6catch-statement`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-links-and-cross‑references

---

- [ ] **6. Incorrect anchor: throw_arg link**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/changelog.mdx?plain=1

At line 53, the link points to `/language/func/built-ins#throwing-exceptions`, which does not exist. The canonical anchor is “#### `throw_arg`” → `/language/func/built-ins#throw-arg`. Minimal fix: update the link to `/language/func/built-ins#throw-arg`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-links-and-cross‑references

---

- [ ] **7. Non-canonical term in link text: “Semver pragmas”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/changelog.mdx?plain=1

At line 19, link text “Semver pragmas” diverges from the canonical term used on the target page (“`#pragma` version” and “semantic versioning (semver)”). Minimal fix: change link text to “`#pragma` version” (or “Pragma version (semver)”) to align with the reference.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text

---

- [ ] **8. Link text mismatches canonical heading: “Extended string literals”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/changelog.mdx?plain=1

At line 18, the link text says “Extended string literals” but targets the “Compile-time built-ins” section. Minimal fix: change link text to “Compile-time built-ins” to match the referenced heading `/language/func/literals#compile-time-built-ins`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **9. Non-descriptive link text for issue references**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/changelog.mdx?plain=1

Lines 33–36 use link text like “(#377)”. Link text must be descriptive; bare numbers are ambiguous out of context. Minimal fix: change to “(issue #377)”, “(issue #374)”, “(issue #370)”, and “(issue #375)” respectively, preserving the same URLs.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text

---

- [ ] **10. Changelog dates not in ISO format**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/changelog.mdx?plain=1

Release dates are formatted as “May 2022”, “Aug 2022”, “Oct 2022”, “Jan 2023” (lines 14, 27, 40, 49). Changelogs should use ISO format for dates. Minimal fix: change link text to ISO months, e.g., “2022-05”, “2022-08”, “2022-10”, “2023-01” (keep the same URLs).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#14-numbers-units-date-and-time

---

- [ ] **11. Typo in function name: load_unit → load_uint**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/changelog.mdx?plain=1

Line 57 cites `load_unit(64)` twice; the correct built-in is `load_uint`. Minimal fix: replace both instances with `load_uint(64)`. Cross-doc evidence: `load_uint` is documented while `load_unit` is not (see https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/built-ins.mdx?plain=1#built-ins-with-non-symbolic-names). This is an obvious typo based on identifier consistency.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles-reader‑first-answer‑first

---

- [ ] **12. Prefer plain word “use” over “usage”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/changelog.mdx?plain=1

Line 57: “after their usage” uses a less common noun form. The guide prefers common words. Minimal fix: change to “after their use”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **13. Broken link and inconsistent term for `#pragma` version**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/changelog.mdx?plain=1#L19

The link text "Semver pragmas" doesn’t match the target section and the anchor is percent‑encoded (`#%23pragma-version`), which doesn’t resolve. Use the target section’s actual anchor and align the term with the heading. Minimal fix: change to [`#pragma` version](/language/func/compiler-directives#pragma-version).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16.3 Links and anchors; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3 Acronyms and terms

---

- [ ] **14. Non-sentence list items end with periods**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/changelog.mdx?plain=1#L29-L42–45,52–54

Bulleted “New features” items are fragments but end with periods, while earlier list items (lines 17–20) omit terminal punctuation. Minimal fix: remove the trailing periods from these fragment bullets for consistency.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **15. Frontmatter boolean quoted as string**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/changelog.mdx?plain=1#L4

`noindex` is set as a quoted string (`"true"`). The style guide uses boolean form (`noindex: true`). Minimal fix: change to `noindex: true`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-2-navigation-labels

---

- [ ] **16. Internal links should be relative, not site-absolute**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/changelog.mdx?plain=1#L17-L53

Internal links use root-absolute paths (`/language/…`). The guide prefers relative links to avoid domain/path coupling. Minimal fix: drop the leading `/language/func/` where applicable, e.g., change `/language/func/literals#constants` → `literals#constants`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-3-links-and-anchors

---

- [ ] **17. Terminology hyphenation mismatch (“multiline” → “multi-line”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/changelog.mdx?plain=1#L43

Visible text says “multiline `asm` statements” while the target section and prevailing usage use “multi-line”. Minimal fix: change the text to “multi-line `asm` statements”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#terminology-and-naming

---

- [ ] **18. Incorrect capitalization of “semver” mid-sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/changelog.mdx?plain=1#L19

Generic concept “semver” is capitalized mid-sentence. Minimal fix: change link text to “semver pragmas”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#general-casing-rules