### PR TITLE
[AI] fix: cookbook.mdx

### DIFF
--- a/language/func/cookbook.mdx
+++ b/language/func/cookbook.mdx
@@ -1,7 +1,7 @@
 ---
 title: "FunC cookbook"
 sidebarTitle: "Cookbook"
-noindex: "true"
+noindex: true
 ---
 
 import { Aside } from '/snippets/aside.jsx';
@@ -31,7 +31,7 @@ else {
 
 **Note:** The `==` operator is unnecessary, as `0` already evaluates to `false`, and any nonzero value is considered `true`.
 
-**Reference:** [`If statement` in docs](/language/func/statements#if-statements)
+**Reference:** [`if...else` statement](/language/func/statements#if-statements)
 
 ### How to write a repeat loop
 
@@ -74,7 +74,7 @@ while (msg.slice_refs_empty?() != -1) { ;; We should remind that -1 is true
 **References:**
 
 - [`While loop` in docs](/language/func/statements#while-loop)
-- [`Cell` in docs](/tvm/serialization/cells)
+- [Cells](/tvm/serialization/cells)
 - [`slice_refs_empty?()` in docs](/language/func/stdlib#slice_refs_empty)
 - [`store_ref()` in docs](/language/func/stdlib#store_ref)
 - [`begin_cell()` in docs](/language/func/stdlib#begin_cell)
@@ -93,7 +93,7 @@ do {
 } until (flag == -1); ;; -1 is true
 ```
 
-**Reference:** [`Until loop` in docs](/language/func/statements#until-loop)
+**Reference:** [`do...until` loop](/language/func/statements#until-loop)
 
 ### How to determine if slice is empty
 
@@ -277,8 +277,8 @@ else {
 **References:**
 
 - [`dict_empty?()` in docs](/language/func/stdlib#dict_empty)
-- [`new_dict()` in docs](/language/func/stdlib/#new_dict), creating an empty dict
-- [`dict_set()` in docs](/language/func/stdlib/#dict_set), adding some elements in dict `d` with function, so it is not empty
+- [`new_dict()` in docs](/language/func/stdlib#new_dict), creating an empty dict
+- [`dict_set()` in docs](/language/func/stdlib#dict_set), adding some elements in dict `d` with function, so it is not empty
 
 ### How to determine if a tuple is empty
 
@@ -303,12 +303,12 @@ When working with `tuples`, checking for existing values before extracting them 
 ```
 
 **Note:**
-We are defining the `tlen` assembly function. You can find more details [here](/language/func/functions#assembler-function-body-definition) and a see a [list of assembler commands](/tvm/instructions).
+We are defining the `tlen` assembly function. You can find more details [here](/language/func/functions#assembler-function-body-definition) and see a [list of assembler commands](/tvm/instructions).
 
 **References:**
 
 - [`empty_tuple?()` in docs](/language/func/stdlib#empty_tuple)
-- [`tpush()` in docs](/language/func/stdlib/#tpush)
+- [`tpush()` in docs](/language/func/stdlib#tpush)
 - [`Exit codes` in docs](/tvm/exit-codes)
 
 ### How to determine if a lisp-style list is empty
@@ -326,7 +326,7 @@ if (numbers.null?()) {
 }
 ```
 
-### How to determine a state of the contract is empty
+### How to determine if the contract state is empty
 
 Consider a smart contract with a `counter` that tracks the number of transactions. This variable does not exist in the contract state during the first transaction because it is empty.
 It is important to handle this scenario by checking if the state is empty and initializing the `counter` accordingly.
@@ -356,8 +356,8 @@ The contract state can be determined as empty by verifying whether the [cell is 
 **References:**
 
 - [`get_data()` in docs](/language/func/stdlib#get_data)
-- [`begin_parse()` in docs](/language/func/stdlib/#begin_parse)
-- [`slice_empty?()` in docs](/language/func/stdlib/#slice_empty)
+- [`begin_parse()` in docs](/language/func/stdlib#begin_parse)
+- [`slice_empty?()` in docs](/language/func/stdlib#slice_empty)
 - [`set_data()` in docs](/language/func/stdlib#set_data)
 
 ### How to build an internal message cell
@@ -385,7 +385,7 @@ send_raw_message(msg, 3); ;; mode 3 - pay fees separately and ignore errors
 **Note:**
 
 - In this example, we use the literal `a` to obtain an address. More details on string literals can be found in the [documentation](/language/func/literals#string-literals).
-- You can find more details in the [documentation](/ton/tblkch#3-1-7-message-layout). A direct link to the [layout](/ton/tblkch#3-1-7-message-layout) is also available.
+- You can find more details in the [documentation](/ton/tblkch#3-1-7-message-layout).
 
 **References:**
 
@@ -393,8 +393,8 @@ send_raw_message(msg, 3); ;; mode 3 - pay fees separately and ignore errors
 - [`store_uint()` in docs](/language/func/stdlib#store_uint)
 - [`store_slice()` in docs](/language/func/stdlib#store_slice)
 - [`store_coins()` in docs](/language/func/stdlib#store_coins)
-- [`end_cell()` in docs](/language/func/stdlib/#end_cell)
-- [`send_raw_message()` in docs](/language/func/stdlib/#send_raw_message)
+- [`end_cell()` in docs](/language/func/stdlib#end_cell)
+- [`send_raw_message()` in docs](/language/func/stdlib#send_raw_message)
 
 ### How to contain a body as a ref in an internal message cell
 
@@ -438,8 +438,8 @@ send_raw_message(msg, 3); ;; mode 3 - pay fees separately and ignore errors
 - [`store_uint()` in docs](/language/func/stdlib#store_uint)
 - [`store_slice()` in docs](/language/func/stdlib#store_slice)
 - [`store_coins()` in docs](/language/func/stdlib#store_coins)
-- [`end_cell()` in docs](/language/func/stdlib/#end_cell)
-- [`send_raw_message()` in docs](/language/func/stdlib/#send_raw_message)
+- [`end_cell()` in docs](/language/func/stdlib#end_cell)
+- [`send_raw_message()` in docs](/language/func/stdlib#send_raw_message)
 
 ### How to contain a body as a slice in an internal message cell
 
@@ -467,7 +467,7 @@ send_raw_message(msg, 3); ;; mode 3 - pay fees separately and ignore errors
 **Note:**
 
 - The literal `a` is used to obtain an address. See the [documentation](/language/func/literals#string-literals) for details on string literals.
-- The example uses `mode 3`, `mode 64`, and `mode 128`, as described above.
+- The example uses `mode 3`, `mode 64`, and `mode 128`. See [Message modes](/language/func/stdlib#send_raw_message).
 - The [message](/language/func/cookbook#how-to-build-an-internal-message-cell) is constructed with the body included as a slice.
 
 ### How to iterate tuples (both directions)
@@ -696,7 +696,7 @@ As an example, let’s say we need to perform the following calculation for all 
 
 `(xp + zp) * (xp - zp)`.
 
-Since these operations are commonly used in cryptography, we utilize the modulo operator for montgomery curves.
+Since these operations are commonly used in cryptography, we use the modulo operator for Montgomery curves.
 
 **Note:**
 Variable names like `xp+zp` are valid as long as there are no spaces between the operators.
@@ -819,7 +819,7 @@ int are_slices_equal_2? (slice a, slice b) asm "SDEQ";
 
 **References:**
 
-- [`slice_hash()` in docs](/language/func/stdlib/#slice_hash)
+- [`slice_hash()` in docs](/language/func/stdlib#slice_hash)
 - [`SDEQ` in docs](/tvm/instructions#C705)
 
 ### Determine if the cells are equal
@@ -844,7 +844,7 @@ int are_cells_equal? (cell a, cell b) {
 }
 ```
 
-**Reference:** [`cell_hash()` in docs](/language/func/stdlib/#cell_hash)
+**Reference:** [`cell_hash()` in docs](/language/func/stdlib#cell_hash)
 
 ### Determine if the tuples are equal
 
@@ -955,7 +955,7 @@ This function creates an internal address corresponding to the `MsgAddressInt` T
 
 **Note:** In this example, we use `workchain()` to retrieve the WorkChain ID. You can learn more about the WorkChain ID in [docs](/ton/addresses/addresses-general-info#workchain-id).
 
-**Reference:** [`cell_hash()` in docs](/language/func/stdlib/#cell_hash)
+**Reference:** [`cell_hash()` in docs](/language/func/stdlib#cell_hash)
 
 ### Generate an external address
 
@@ -1001,10 +1001,10 @@ set_data(begin_cell().store_dict(dictionary_cell).end_cell());
 
 **References:**
 
-- [`get_data()` in docs](/language/func/stdlib/#get_data)
-- [`new_dict()` in docs](/language/func/stdlib/#new_dict)
-- [`slice_empty?()` in docs](/language/func/stdlib/#slice_empty)
-- [`load_dict()` in docs](/language/func/stdlib/#load_dict)
+- [`get_data()` in docs](/language/func/stdlib#get_data)
+- [`new_dict()` in docs](/language/func/stdlib#new_dict)
+- [`slice_empty?()` in docs](/language/func/stdlib#slice_empty)
+- [`load_dict()` in docs](/language/func/stdlib#load_dict)
 - [`~` in docs](/language/func/statements#unary-operators)
 
 ### How to send a simple message
@@ -1054,7 +1054,7 @@ A proxy contract can facilitate secure message exchange if interaction between a
 **References:**
 
 - [`Message layout` in docs](/ton/messages/internal-messages)
-- [`load_msg_addr()` in docs](/language/func/stdlib/#load_msg_addr)
+- [`load_msg_addr()` in docs](/language/func/stdlib#load_msg_addr)
 
 ### How to send a message with the entire balance
 
@@ -1075,12 +1075,12 @@ send_raw_message(msg, 128); ;; mode = 128 is used for messages that are to carry
 **References:**
 
 - [`Message layout` in docs](/ton/messages/internal-messages)
-- [`Message modes` in docs](/language/func/stdlib/#send_raw_message)
+- [`Message modes` in docs](/language/func/stdlib#send_raw_message)
 
 ### How to send a message with a long text comment
 
 A `cell` can store up to 127 characters (`<1023 bits`).
-A sequence of linked cells ("snake cells") must be used if more space is required.
+A sequence of linked cells (snake cells) must be used if more space is required.
 
 ```func
 {-
@@ -1130,9 +1130,9 @@ slice s_only_data = s.preload_bits(s.slice_bits());
 
 **References:**
 
-- [`Slice primitives` in docs](/language/func/stdlib/#slice-primitives)
-- [`preload_bits()` in docs](/language/func/stdlib/#preload_bits)
-- [`slice_bits()` in docs](/language/func/stdlib/#slice_bits)
+- [`Slice primitives` in docs](/language/func/stdlib#slice-primitives)
+- [`preload_bits()` in docs](/language/func/stdlib#preload_bits)
+- [`slice_bits()` in docs](/language/func/stdlib#slice_bits)
 
 ### How to define a custom modifying method
 
@@ -1246,13 +1246,13 @@ while (flag) {
 
 **References:**
 
-- [`Dictonaries primitives` in docs](/language/func/stdlib/#dictionaries-primitives)
-- [`dict_get_max?()` in docs](/language/func/stdlib/#dict_get_max)
-- [`dict_get_min?()` in docs](/language/func/stdlib/#dict_get_min)
-- [`dict_get_next?()` in docs](/language/func/stdlib/#dict_get_next)
-- [`dict_set()` in docs](/language/func/stdlib/#dict_set)
+- [`Dictionaries primitives` in docs](/language/func/stdlib#dictionaries-primitives)
+- [`dict_get_max?()` in docs](/language/func/stdlib#dict_get_max)
+- [`dict_get_min?()` in docs](/language/func/stdlib#dict_get_min)
+- [`dict_get_next?()` in docs](/language/func/stdlib#dict_get_next)
+- [`dict_set()` in docs](/language/func/stdlib#dict_set)
 
-### How to delete value from dictionaries
+### How to delete a value from dictionaries
 
 ```func
 cell names = new_dict();
@@ -1313,9 +1313,9 @@ forall X -> (tuple, (X)) pop_back (tuple t) asm "UNCONS";
 
 **References:**
 
-- [`Lisp-style lists` in docs](/language/func/stdlib/#lisp-style-lists)
-- [`null()` in docs](/language/func/stdlib/#null)
-- [`slice_refs()` in docs](/language/func/stdlib/#slice_refs)
+- [`Lisp-style lists` in docs](/language/func/stdlib#lisp-style-lists)
+- [`null()` in docs](/language/func/stdlib#null)
+- [`slice_refs()` in docs](/language/func/stdlib#slice_refs)
 
 ### How to iterate through lisp-style list
 
@@ -1345,8 +1345,8 @@ forall X -> (tuple, (X)) pop_back (tuple t) asm "UNCONS";
 
 **References:**
 
-- [`Lisp-style lists` in docs](/language/func/stdlib/#lisp-style-lists)
-- [`null()` in docs](/language/func/stdlib/#null)
+- [`Lisp-style lists` in docs](/language/func/stdlib#lisp-style-lists)
+- [`null()` in docs](/language/func/stdlib#null)
 
 ### How to send a deploy message (with `StateInit` only, with `StateInit` and body)
 
@@ -1377,7 +1377,7 @@ forall X -> (tuple, (X)) pop_back (tuple t) asm "UNCONS";
 }
 ```
 
-### How to build a `StateInit` cell
+### How to build a StateInit cell
 
 ```func
 () build_stateinit(cell init_code, cell init_data) {
@@ -1393,7 +1393,7 @@ forall X -> (tuple, (X)) pop_back (tuple t) asm "UNCONS";
 }
 ```
 
-### How to calculate a contract address (using `StateInit`)
+### How to calculate a contract address (using StateInit)
 
 ```func
 () calc_address(cell state_init) {


### PR DESCRIPTION
- [ ] **1. Page title uses Title Case instead of sentence case**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L2

The `title` frontmatter is "FunC cookbook" (Title Case), but headings and titles must use sentence case. Minimal fix: change to "FunC cookbook" → "FunC cookbook" if "FunC" is a proper noun left as-is; otherwise ensure only the first word and proper nouns are capitalized. In this case, keep "FunC" as proper name and lowercase "cookbook": `title: "FunC cookbook"` is already correct; however, if treated as a heading style, confirm consistency with rule. If another capitalization variant is intended, set sentence case explicitly.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.1-case-and-form

---

- [ ] **2. Sidebar title should be sentence case**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L3

`sidebarTitle: "Cookbook"` uses Title Case. Headings must use sentence case; sidebar labels should follow the same rule for consistency. Minimal fix: change to `sidebarTitle: "Cookbook"` → `sidebarTitle: "Cookbook"` if treated as proper noun; otherwise use sentence case: `sidebarTitle: "Cookbook"`. Needs a decision whether "Cookbook" is a proper label; if not, use lowercase "Cookbook".

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.1-case-and-form

---

- [ ] **3. Duplicate and throat‑clearing intro sentences**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L9-L11

Two near-duplicate introductory sentences repeat the page purpose and contain meta phrasing. The guide forbids throat‑clearing and redundancy. Minimal fix: keep one concise purpose sentence and remove duplication, e.g., keep “This cookbook focuses on practical solutions to everyday FunC development tasks.” and remove the other.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **4. Heading case and form: task headings should be imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L15-L1385

Headings start with “How to …” or gerunds like “Reversing tuples.” Task headings must start with an imperative verb (e.g., “Write an if statement”, “Reverse tuples”, “Determine if a slice is empty”). Minimal fix: convert each task heading to an imperative sentence case form without “How to”. Example: `### How to write an if statement` → `### Write an if statement`; `### Reversing tuples` → `### Reverse tuples`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.1-case-and-form and #7.2-gerunds-and-labels

---

- [ ] **5. Reference anchor text not matching target anchor**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L34

Link text “If statement” points to `/language/func/statements#if-statements`, but the target section is titled “`if...else` statement”. Link text should be descriptive and match the target. Minimal fix: change link text to “`if...else` statement”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12.1-link-text

---

- [ ] **6. Inconsistent terminology for loops**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L84-L96

The page uses “do until” and “Until loop”, while the canonical section is “`do...until` loop” in `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/statements.mdx?plain=1`. Minimal fix: standardize to “`do...until` loop” in heading and reference text.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-terminology-and-naming

---

- [ ] **7. Mixed American vs international quote punctuation around links**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L700-L703(Note under Modulo operations), 1018, 1107

Quoted strings and punctuation should follow the house rule: punctuation outside the closing quotes unless part of the literal. Some notes and comments mix punctuation styles. Minimal fix: ensure punctuation characters are outside closing quotes unless part of the quoted string.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.2-quotation-marks-and-emphasis

---

- [ ] **8. Incorrect capitalization of units (nanotons)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L1018-L1107

Comments use “nanoTons” instead of “nanotons”. Use American English and consistent unit casing. Minimal fix: change “nanoTons” to “nanotons”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.6-spelling-and-contractions and #13.2-general-casing-rules

---

- [ ] **9. Ambiguous “we” voice in explanatory comments**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L367-L836

Comments like “we use literal `a`” address the author and reader collectively. The guide prefers direct, second‑person imperative or neutral statements. Minimal fix: replace with neutral phrasing: “Use the `a` literal …” or “This example uses the `a` literal …”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.1-voice-tense-and-person

---

- [ ] **10. Link to stub page as normative reference**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L410-L1122

Links to `/ton/messages/internal-messages` (title: “Internal Messages”) point to a stub. The style guide requires linking to canonical, non‑stub internal docs when used normatively. Minimal fix: either link to the specific canonical anchor when available or label as background if kept; otherwise remove normative phrasing until a valid internal target exists.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12.4-avoid-circularity-and-drift and #12.5-external-references

---

- [ ] **11. Inconsistent reference labels and anchors**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L149-L758

Several “Reference(s)” lists mix singular/plural and inconsistent backtick usage, and some anchors include a trailing slash that differs from the target headings (e.g., `/#begin_parse` vs `#begin_parse`). Minimal fix: standardize labels to “References:” or “Reference:” consistently; ensure each link text matches the target section name exactly and use consistent anchor hashes as rendered in `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/stdlib.mdx?plain=1`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12.1-link-text and #12.3-link-targets-and-format

---

- [ ] **12. Typo: “Dictonaries”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L1249

Misspelling in link text: “Dictonaries” → “Dictionaries”. Minimal fix: correct the link text.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.6-spelling-and-contractions

---

- [ ] **13. Typo: “substract”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L1144

Comment text uses “substract”; American English spelling is “subtract”. Minimal fix: change to “subtract”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.6-spelling-and-contractions

---

- [ ] **14. Missing language in code fence for JavaScript snippet**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L1130-L1136

The upgrade example uses JavaScript but is fenced as triple backticks without a confirmed language earlier. Ensure the fence language is `javascript` for correct tooling and highlighting. Minimal fix: verify and set code fence to ` ```javascript `.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10.1-general-rules

---

- [ ] **15. Mixed list punctuation and capitalization in bullets**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L432-L441(Note under body-as-ref), 1238-1244

Bullets combine sentence fragments and full sentences inconsistently and mix terminal punctuation. Minimal fix: make each bullet a sentence or fragment consistently and apply end punctuation uniformly per the guide’s readability norms.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#8.1-paragraphs-and-sentences

---

- [ ] **16. Inconsistent capitalization of “Montgomery”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L699-L706

Proper noun “Montgomery” should be capitalized. Minimal fix: “montgomery curves” → “Montgomery curves”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13.2-general-casing-rules

---

- [ ] **17. Heading casing for lisp-style list**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L306-L1268

Headings refer to “lisp-style” and “Lisp-style” inconsistently. Use sentence case and consistent hyphenation per terminology. Minimal fix: standardize to “lisp‑style list”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13.3-hyphenation-and-abbreviations and #7.1-case-and-form

---

- [ ] **18. Link text mismatch: “Cell” vs. page title**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L77

Link text “[`Cell` in docs](/tvm/serialization/cells)” uses singular capitalized “Cell”, while the target page is titled “Cells” within serialization. Minimal fix: change link text to “Cells serialization” or “Cells” to match the target. Keep sentence case.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12.1-link-text

---

- [ ] **19. Inline comments with uppercase NOT EQUAL**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L726

Comment uses “NOT EQUAL” in all caps. Avoid all caps for emphasis; use plain English. Minimal fix: change to “not equal”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.4-formatting-restrictions and #5.2-plain-precise-wording

---

- [ ] **20. Incomplete or unclear note phrasing**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L700-L703

Note begins with “Variable names like `xp+zp` are valid…”; better to remove hedging and clarify the condition. Minimal fix: “Identifiers may include `+` and `-` operators when used without spaces” — if and only if this reflects existing docs; otherwise mark for domain confirmation. Needs domain confirmation.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording

---

- [ ] **21. Capitalization of proper names in example strings**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L592-L597

Names appear in inconsistent order/casing. While examples can vary, the style prefers consistency. Minimal fix: use consistent casing for proper names; ensure American English spelling elsewhere.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.6-spelling-and-contractions

---

- [ ] **22. Comment tone and brevity in code blocks**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L1010-L1295

Some comments are long and narrative inside code blocks (e.g., multi-line descriptions). The guide recommends concise, actionable comments to keep snippets copy‑pasteable. Minimal fix: shorten comments to precise labels (e.g., “zero opcode — comment message”).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10.1-general-rules

---

- [ ] **23. Typo in narrative: “a see a”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L306

Reads “and a see a [list of assembler commands]”. Minimal fix: “and see a [list of assembler commands]”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.6-spelling-and-contractions

---

- [ ] **24. Inconsistent naming of dictionary primitives in links**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L1253

Link text “`dict_set()`” suggests slice-key variant, but code uses `udict_*` (unsigned int keys). Minimal fix: change link text to match the used variant (e.g., `` `udict_set` ``) or link to the dictionary primitives overview instead of a specific function.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12.1-link-text

---

- [ ] **25. Frontmatter `noindex` must be boolean**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1

The frontmatter sets `noindex: "true"` as a string. Use a boolean instead. Minimal fix: change to `noindex: true` (unquoted).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-file-navigation-and-frontmatter-conventions

---

- [ ] **26. Headings must not include code styling**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1

Headings include backticked code (e.g., “How to build a `StateInit` cell”, “How to calculate a contract address (using `StateInit`)”). Headings must not contain code styling except on reference pages. Minimal fix: remove backticks in headings (keep plain “StateInit”).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles

---

- [ ] **27. Replace bold “Note:” with `<Aside type="note">`**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1

Multiple bold “Note:” callouts (e.g., after the if statement, while loop, internal message examples) should use the standardized `<Aside>` component. Minimal fix: wrap each note in `<Aside type="note">…</Aside>` and remove bold labels.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout

---

- [ ] **28. Missing safety callouts for message‑sending examples**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1

Sections that construct and send internal messages (e.g., “Build an internal message cell”, “Include the body as a ref/slice…”, “Send a message with a long text comment”, “Send a deploy message …”) move funds. They require a Caution/Warning callout describing risk, scope, mitigation, and testnet labeling. Minimal fix: add an `<Aside type="caution" title="Transfers funds">` with required elements (risk, scope, rollback/mitigation, testnet‑first) above the sending code.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-1-when-a-safety-callout-is-required; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout

---

- [ ] **29. Redundant/throat‑clearing sentences and duplication**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1

Example (if‑statement section): “Let's say we want to check if any event is relevant.” followed by a duplicated explanation. Minimal fix: remove throat‑clearing and keep the direct instruction: “To check whether an event is relevant, use a flag variable. In FunC, `true` is `-1`; `false` is `0`.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **30. Word choice: prefer “use” over “utilize”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1

In “Modulo operations”: “we utilize the modulo operator” is needlessly formal. Minimal fix: “we use the modulo operator”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **31. Quotation marks used for emphasis around terms**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1

In “Send a message with a long text comment”: uses quotes for “snake cells” as emphasis. Quotation marks must be for literal UI/log strings, not emphasis. Minimal fix: remove quotes or define the term without quotes (e.g., snake cells).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **32. Syntactically invalid example: missing call parentheses**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L115

The snippet contains `.store_maybe_ref` without parentheses or an argument, making the example not copy‑pasteable. Minimal fix: replace with a valid call, e.g., `.store_ref(null())`, consistent with nearby examples in this page.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-3-code-styling; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles-reader-first-answer-first

---

- [ ] **33. Avoid “above/below” phrasing; deep‑link instead**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L470–471

Text says “as described above” regarding message modes. Minimal fix: link directly to the canonical anchor (e.g., “See [Message modes](/language/func/stdlib#send_raw_message)”).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-3-links-and-anchors

---

- [ ] **34. Ungrammatical section heading**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L329

“How to determine a state of the contract is empty” is ungrammatical. Minimal fix: “How to determine if the contract state is empty”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#15-1-language-and-reading

---

- [ ] **35. Banned filler word “just” in code comment**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L1278

Comment contains “just”, which the guide bans as filler. Minimal fix: remove “just” (e.g., “example cell”).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#b-banned-and-preferred-terms

---

- [ ] **36. Partial snippet not labeled as such**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L506–674, 925–1079 (contains “[... omitted …]” markers)

The code block includes omission markers, making it a partial, non‑runnable snippet. Minimal fix: label explicitly as a partial snippet (e.g., a brief preceding note via `<Aside type="note">Abbreviated snippet (non‑runnable)</Aside>`), or show the full runnable code.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#0-purpose-scope-and-normative-terms

---

- [ ] **37. Redundant Duplicate Link in Note (Same Target)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L385–392

The note repeats the same documentation link twice (“documentation” and “direct link to the layout”). Minimal fix: keep a single descriptive link to the specific anchor (`/ton/tblkch#3-1-7-message-layout`) and remove the duplicate. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not

---

- [ ] **38. Missing Article in Heading (“delete value from dictionaries”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L1255

Minimal fix: “Delete a value from a dictionary” (and remove “How to ” per Item 1). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **39. Grammar and precision in comments and prose**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L68-L184–187,367–373,405–413,449–454,1098,1105–1112

- Prefer precise, direct wording. Examples: “We should remind that -1 is true” → “In FunC, `-1` is `true`.” Remove duplicate lead‑in at 184–187 (keep one precise sentence). For repeated comments like “We use literal `a`…”, prefer “Use the `a` literal to parse an address string into a slice.” Apply consistently where repeated. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **40. Terminology capitalization: Lisp‑style lists**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/cookbook.mdx?plain=1#L314-L322–326,1320

Use the canonical term and capitalization from the reference (“Lisp‑style lists”). Also fix “list‑style list” to “Lisp‑style list” in prose. Minimal fixes: capitalize “Lisp‑style” and replace “list‑style” with “Lisp‑style”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms; see https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/stdlib.mdx?plain=1#lisp-style-lists