### PR TITLE
[AI] fix: pyth.mdx

### DIFF
--- a/ecosystem/interoperability/oracles/pyth.mdx
+++ b/ecosystem/interoperability/oracles/pyth.mdx
@@ -1,33 +1,30 @@
 ---
-title: "Pyth oracle"
+title: "How to use the Pyth oracle"
+sidebarTitle: "Use Pyth oracle"
 ---
 
-## How to use real-time data in TON contracts
+## Use real-time data in The Open Network ([TON](/ton/glossary)) contracts
 
-Pyth is a pull oracle. Pyth price feeds on TON are managed through the main TON Pyth smart
-contract, enabling seamless interaction with on-chain data. In TON,
-these interactions are facilitated by specific functions within the
-Pyth TON contract. This contract acts as an interface to Pyth
-price feeds, handling the retrieval and updating of price data.
+Pyth is a pull oracle. The TON Pyth smart contract manages Pyth price feeds on TON. Specific functions in the Pyth TON contract let you retrieve and update price data.
 
-## Install the Pyth SDK
+## Install the Pyth software development kit (SDK)
 
-Install the Pyth TON SDK and other necessary dependencies using npm or yarn:
+Install the Pyth TON SDK and other necessary dependencies using npm:
 
 ```bash
 npm install @pythnetwork/pyth-ton-js @pythnetwork/hermes-client @ton/core @ton/ton @ton/crypto
 ```
 
-## Write code to interact with oracle
+## Interact with the oracle in code
 
-### Off-chain data fetch and update
+### Fetch and update off-chain data
 
 The following code snippet demonstrates how to fetch price updates, interact with the Pyth contract on TON, and update price feeds:
 
 - TON Mainnet: [`EQBU6k8HH6yX4Jf3d18swWbnYr31D3PJI7PgjXT-flsKHqql`](https://docs.pyth.network/price-feeds/contract-addresses/ton)
 - TON Testnet: [`EQB4ZnrI5qsP_IUJgVJNwEGKLzZWsQOFhiaqDbD7pTt_f9oU`](https://docs.pyth.network/price-feeds/contract-addresses/ton)
 
-The following example uses the testnet contract. For mainnet usage, change the `PYTH_CONTRACT_ADDRESS_TESTNET` to `PYTH_CONTRACT_ADDRESS_MAINNET` accordingly.
+The following example uses the testnet contract. For mainnet usage, change the `PYTH_CONTRACT_ADDRESS_TESTNET` to `PYTH_CONTRACT_ADDRESS_MAINNET` accordingly. This example uses testnet. To use mainnet, set `PYTH_CONTRACT_ADDRESS_MAINNET` and a mainnet RPC endpoint.
 
 ```ts expandable
 import { TonClient, Address, WalletContractV4 } from "@ton/ton";
@@ -103,23 +100,18 @@ async function main() {
 main().catch(console.error);
 ```
 
-### On-chain data verification
-
-TODO
-
 This code snippet does the following:
 
 1. Initializes a `TonClient` and creates a `PythContract` instance.
-2. Retrieves the current guardian set index and BTC price from the TON contract.
-3. Fetches the latest price updates from Hermes.
-4. Prepares the update data and calculates the update fee.
-5. Updates the price feeds on the TON contract.
+1. Retrieves the current guardian set index and Bitcoin (BTC) price from the TON contract.
+1. Fetches the latest price updates from Hermes.
+1. Prepares the update data and calculates the update fee.
+1. Updates the price feeds on the TON contract.
 
 ## Additional resources
 
-You may find these additional resources helpful for developing your TON application:
+Additional resources for developing TON applications:
 
 - [Pyth price feed IDs](https://pyth.network/developers/price-feed-ids)
-- [Pyth TON contract](https://github.com/pyth-network/pyth-crosschain/tree/main/target_chains/ton/contracts)
 - [Pyth TON SDK](https://github.com/pyth-network/pyth-crosschain/tree/main/target_chains/ton/sdk)
 - [Pyth TON example](https://github.com/pyth-network/pyth-examples/tree/main/price_feeds/ton/sdk_js_usage)


### PR DESCRIPTION
- [ ] **1. Title does not follow how-to pattern**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/pyth.mdx?plain=1#L2

The page reads like a how-to, but the frontmatter title is a noun phrase ("Pyth oracle"). Minimal fix: change to `title: "How to use the Pyth oracle"` (sentence case) to follow the how-to pattern. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form

---

- [ ] **2. Procedural H2 uses “How to …” instead of imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/pyth.mdx?plain=1#L5

Task headings must start with an imperative verb and use sentence case. Minimal fix: change `## How to use real-time data in TON contracts` to `## Use real-time data in TON contracts`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form

---

- [ ] **3. First mention of TON does not expand the acronym**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/pyth.mdx?plain=1#L5

On first use, spell out the term and follow with the acronym. Minimal fix: `Use real-time data in The Open Network (TON) contracts`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **4. Marketing/weasel word in introduction (“seamless”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/pyth.mdx?plain=1#L7

Technical sections must avoid marketing language. Minimal fix: remove “seamless” and keep neutral phrasing, e.g., “enabling interaction with on-chain data.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#4-voice-and-tone

---

- [ ] **5. Subsection heading not imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/pyth.mdx?plain=1#L23

Procedural H3 should be imperative. Minimal fix: change `### Off-chain data fetch and update` to `### Fetch and update off-chain data`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form

---

- [ ] **6. Acronym “SDK” not expanded on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/pyth.mdx?plain=1#L13-L15

On first mention, expand the acronym. Minimal fix: change the first instance to “Install the Pyth software development kit (SDK)”, and then use “SDK” thereafter. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **7. Placeholders not in required format and not defined on first use**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/pyth.mdx?plain=1#L50-L87

Examples must use `<ANGLE_CASE>` placeholders in prose/commands, and placeholders must be defined on first use. Minimal fix: replace `"your-api-key-here"` with `"<TONCENTER_API_KEY>"` and `"your mnemonic here"` with `"<WALLET_MNEMONIC>"`; add a short list immediately below the code block: “Define placeholders (first use): `<TONCENTER_API_KEY>` — your TON Center API key; `<WALLET_MNEMONIC>` — your wallet recovery phrase (use testnet).” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-5-placeholder-names

---

- [ ] **8. Missing safety callout for mnemonic/key handling and on-chain send**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/pyth.mdx?plain=1#L85-L99

Pages that expose or transmit private keys/mnemonics or move funds must include a safety callout. Minimal fix: insert an `<Aside type="danger" title="Funds and keys at risk">` before the “Update price feeds” step with risk, scope, rollback/mitigation, and environment label (testnet first; mainnet explicitly labeled). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-1-when-a-safety-callout-is-required; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-4-key-handling-and-storage

---

- [ ] **9. Incomplete section with “TODO” visible to readers**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/pyth.mdx?plain=1#L108

Pages must be complete and answer-first; visible TODOs block task success. Minimal fix: remove the unfinished `### On-chain data verification` section until content is ready, or replace “TODO” with completed instructions. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles-reader-first-answer-first

---

- [ ] **10. First useful mention of TON should link to the Glossary**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/pyth.mdx?plain=1#L5

Link core TON terms to the Glossary on first useful mention unless defined on the page. Minimal fix: link the first `TON` mention to `/ton/glossary`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not

---

- [ ] **11. Passive voice in introduction**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/pyth.mdx?plain=1#L7-L11

Use active voice by default. Minimal fix: rephrase to active, for example: “The TON Pyth smart contract manages Pyth price feeds on TON. Specific functions in the Pyth TON contract let you retrieve and update price data.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#4-voice-and-tone

---

- [ ] **12. Acronym “BTC” not expanded on first mention in body text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/pyth.mdx?plain=1#L113

On first use in prose, spell out the term and follow with the acronym. Minimal fix: change to “Retrieves the current guardian set index and Bitcoin (BTC) price from the TON contract.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **13. How‑to frontmatter pattern not used**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/pyth.mdx?plain=1#L1

The page reads as a how‑to but the frontmatter `title` does not follow the required “How to X” pattern, and there is no `sidebarTitle`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-2-navigation-labels. Minimal fix: set `title: "How to use Pyth oracle"` and add `sidebarTitle: "Use Pyth oracle"`.

---

- [ ] **14. Ordered list numbers not using `1.` auto-numbering**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/pyth.mdx?plain=1#L112

Ordered lists must use `1.` for every item to enable auto‑numbering. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists. Minimal fix: change items 1–5 at lines 112–116 to all start with `1.`.

---

- [ ] **15. External Telegram handle instead of internal canonical link**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/pyth.mdx?plain=1#L50

Prefer internal docs when available. The comment references `@tonapibot` and a Telegram URL; an internal page exists for obtaining a TON Center API key. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not. Minimal fix: replace the comment with `// Get your TON Center API key: see /ecosystem/rpc/get-api-key` and remove the external handle/URL from the snippet.

---

- [ ] **16. See also section exceeds recommended 1–3 links**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/pyth.mdx?plain=1#L122

See also/Additional resources sections should include 1–3 essential links. There are four items. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format. Minimal fix: keep the top 1–3 most relevant links (for example, IDs, SDK, and example) and remove the rest or consolidate inline earlier.

---

- [ ] **17. Procedural headings should be imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/pyth.mdx?plain=1

Task section headings must start with an imperative verb. "Off-chain data fetch and update" and "On-chain data verification" are noun phrases. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-2-gerunds-and-labels. Minimal fix: change to "Fetch and update off-chain data" and "Verify on-chain data".

---

- [ ] **18. Package manager mismatch (mentions yarn but shows npm only)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/pyth.mdx?plain=1#L15-L19

The text says “using npm or yarn” but only provides an npm command. Either provide a Yarn equivalent or constrain the text to npm. The guide is silent on package‑manager variants; applying the variants rule by analogy, state the limitation when only one is provided. Minimal fix: change line 15 to “Install the Pyth TON SDK and other necessary dependencies using npm:”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#os-and-language-variants

---

- [ ] **19. Inline secrets in code; use env vars and defined placeholders**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/pyth.mdx?plain=1#L50-L86

The example inlines `apiKey: "your-api-key-here"` and `const mnemonic = "your mnemonic here";`. Secrets must not appear inline; use environment variables and define placeholders on first use. Minimal fixes: (a) change line 50 to `apiKey: process.env.TONCENTER_API_KEY, // Set TONCENTER_API_KEY in your environment (optional)`; (b) change line 86 to `const mnemonic = process.env.TON_MNEMONIC;`; (c) after the code block, add definitions: `TONCENTER_API_KEY` — TON Center API key (optional). `TON_MNEMONIC` — testnet mnemonic phrase for the wallet you control. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#safety-and-secrets-in-code; Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#key-handling-and-storage; Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#general-rules

---

- [ ] **20. Hedging in “Additional resources” lead-in**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/pyth.mdx?plain=1#L120

“You may find these additional resources helpful …” uses a hedge. Prefer direct, concise phrasing. Minimal fix: change to “Additional resources for developing TON applications:”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **21. Heading case should be sentence case**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/pyth.mdx?plain=1#L5-L118

Headings use Title Case (e.g., "How to use real-time data in TON contracts", "Install the Pyth SDK", "Write code to interact with oracle", "Off-chain data fetch and update", "On-chain data verification", "Additional resources"). Headings must use sentence case. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#L322. Minimal fix: change to sentence case: "How to use real-time data in TON contracts", "Install the Pyth SDK" → "Install the Pyth SDK" is already sentence-like but initial caps on every major word should be lowered: "Install the Pyth SDK" → "Install the Pyth SDK"; "Write code to interact with oracle" → "Write code to interact with the oracle" (also clarity); "Off-chain data fetch and update" → "Fetch and update off-chain data"; "On-chain data verification" → "Verify on-chain data"; "Additional resources" → "Additional resources" (already sentence case).

---

- [ ] **22. Use `-` for unordered lists; ensure consistent end punctuation**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/pyth.mdx?plain=1#L27-L28

List items use hyphens (good), but they end with nothing while adjacent ordered list uses full sentences with periods later. For unordered lists, omit terminal punctuation if fragments; for full sentences, use periods consistently. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#L288-L295. Minimal fix: ensure items are fragments without trailing periods (current state is fine); no change required if kept as fragments. If treating as sentences, add periods to both items consistently.

---

- [ ] **23. External links should be deep and authoritative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/pyth.mdx?plain=1#L27-L125

Where possible, prefer internal docs first; external links should deep link to exact sections. The addresses link looks acceptable, but confirm that an internal TON docs page doesn’t already cover these. If internal exists, link internally first. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#L583-L591 and #L600-L610. Minimal fix: If internal canonical pages exist for Pyth TON integration, update links to those; otherwise, keep external but ensure anchors are precise.

---

- [ ] **24. Consistency: testnet default and mainnet switch note**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/pyth.mdx?plain=1#L30-L66

Guides should default to testnet and explicitly mention how to switch to mainnet. The page mentions changing constants but could include a brief note/callout making the default and switch explicit. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#L547-L555. Minimal fix: add a short sentence: "This example uses testnet. To use mainnet, set `PYTH_CONTRACT_ADDRESS_MAINNET` and a mainnet RPC endpoint."

---

- [ ] **25. Use angle-bracket placeholders for endpoints and IDs**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/pyth.mdx?plain=1#L49-L66

Endpoints like `https://testnet.toncenter.com/api/v2/jsonRPC` and `https://hermes.pyth.network` should use placeholders or label them clearly as examples if copy/paste is expected. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#L645-L649 and #L433-L444 (general snippet rules). Minimal fix: either prefix a comment "// Example endpoint" or use `<TON_RPC_URL_TESTNET>` and `<HERMES_URL>` placeholders.

---

- [ ] **26. Console/log strings: quotation punctuation outside**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/pyth.mdx?plain=1#L59-L100

Quoted UI/log strings should keep punctuation outside quotes unless part of the string. Current usage logs include commas outside quotes (OK), but ensure consistency and avoid quoting for emphasis. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#L254-L266. Minimal fix: confirm quotes are for exact strings printed; otherwise, use code font or plain text. No code change needed if the strings match the literal `console.log` output.

---

- [ ] **27. Heading uniqueness and clarity**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/pyth.mdx?plain=1#L21-L23

The H2 "Write code to interact with oracle" followed by H3 "Off-chain data fetch and update" could be clearer and more unique. Headings must be unique and self-descriptive. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#L338-L344. Minimal fix: adjust H2 to "Interact with the oracle in code" (sentence case and clearer article) and H3 to "Fetch and update off-chain data" (imperative), ensuring they are distinct.

---

- [ ] **28. Use of proper articles and casing for proper nouns**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/pyth.mdx?plain=1#L7-L15

Ensure proper nouns (TON, Pyth, Hermes, Mainnet/Testnet when proper names) follow casing rules, and generic terms (smart contract, oracle) are lowercase mid-sentence. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#L622-L633. Minimal fix: "Pyth TON contract" → keep exact proper noun casing; "smart contract" should be lowercase; "TON Mainnet" and "TON Testnet" when referring to the named networks.