### PR TITLE
[AI] fix: alerting.mdx

### DIFF
--- a/ecosystem/node/mytonctrl/alerting.mdx
+++ b/ecosystem/node/mytonctrl/alerting.mdx
@@ -1,16 +1,16 @@
 ---
-title: "Alerts"
+title: "Alerting commands"
 description: "The alert-bot module integrates with Telegram to notify operators about node issues. The commands below help you configure, inspect, and test alerts."
 ---
 
 ## Operational notes
 
-- Alerts cover wallet balance thresholds, database usage, validator efficiency/blocks, synchronization, ADNL health, stake acceptance, slashes, and other key metrics. Review the alert keys in `modules/alert_bot.py` to understand the available triggers.
+- Alerts cover wallet balance thresholds, database usage, validator efficiency/blocks, synchronization, Abstract Datagram Network Layer (ADNL) health, stake acceptance, slashes, and other key metrics. Review the alert keys in `modules/alert_bot.py` to understand the available triggers.
 - Each alert has an associated cooldown (`timeout`) to prevent spam. Info-level ok alerts reset state without sound notifications.
 - The bot requires network access to the Telegram API. Ensure outbound HTTPS is permitted from the server.
 - When validator mode is enabled, the alert bot automatically includes wallet and ADNL context in messages. In collator-only or other modes, some alerts may be skipped because prerequisites are missing.
 
-## setup\_alert\_bot
+## `setup_alert_bot`
 
 **Purpose:** Configure the alert bot with the Telegram bot token and chat ID, then start sending events.
 
@@ -23,10 +23,10 @@ setup_alert_bot
 **Behavior**
 
 - Launches the alert-bot configuration flow (interactive prompts) to store `BotToken` and `ChatId` in the local database.
-- Validates the token by sending test requests; fails fast if the bot or chat ID is incorrect.
+- Validates the token by sending test requests; fails immediately if the bot or chat ID is incorrect.
 - Should be run after enabling `alert-bot` mode so the background scheduler picks up the alerts.
 
-## list\_alerts
+## `list_alerts`
 
 **Purpose:** Show all predefined alerts and whether they are currently enabled.
 
@@ -38,10 +38,10 @@ list_alerts
 
 **Behavior**
 
-- Lists every alert key (for example: `low_wallet_balance`, `db_usage_80`, `out_of_sync`) along with the enabled flag and the UNIX timestamp when it was last sent.
+- Lists every alert key (for example: `low_wallet_balance`, `db_usage_80`, `out_of_sync`) along with the enabled flag and the Unix timestamp when it was last sent.
 - Helps you audit which alerts are muted and whether recent warnings have fired.
 
-## enable\_alert
+## `enable_alert`
 
 **Purpose:** Re-enable a previously muted alert.
 
@@ -50,6 +50,8 @@ list_alerts
 ```mytonctrl
 enable_alert <alert_name>
 ```
+
+`<ALERT_NAME>` — one of the alert keys listed under 'Available alert names'.
 
 **Behavior**
 
@@ -62,7 +64,7 @@ enable_alert <alert_name>
 enable_alert low_wallet_balance
 ```
 
-## disable\_alert
+## `disable_alert`
 
 **Purpose:** Temporarily suppress a specific alert.
 
@@ -72,10 +74,12 @@ enable_alert low_wallet_balance
 disable_alert <alert_name>
 ```
 
+`<ALERT_NAME>` — one of the alert keys listed under 'Available alert names'.
+
 **Behavior**
 
 - Marks the alert as disabled; the scheduler skips sending messages for it until re-enabled.
-- Use when you expect noisy conditions (e.g., during planned maintenance) but still want other alerts to deliver.
+- Use when you expect noisy conditions (for example, during planned maintenance) but still want other alerts to deliver.
 
 **Example**
 
@@ -83,7 +87,7 @@ disable_alert <alert_name>
 disable_alert service_down
 ```
 
-## test\_alert
+## `test_alert`
 
 **Purpose:** Send a simple message through the configured alert channel to verify connectivity.
 
@@ -96,9 +100,9 @@ test_alert
 **Behavior**
 
 - Requires successful initialization (bot token and chat ID saved). If initialization hasn’t run yet, the command triggers it.
-- Sends `Test alert` with `info` severity so you can confirm the chat receives notifications.
+- Sends "Test alert" with info severity so you can confirm the chat receives notifications.
 
-### Available alert names
+## Available alert names
 
 - `low_wallet_balance`: Validator wallet balance below 10 TON while the node is working and in sync.
 - `low_wallet_balance_ok`: Balance recovered to ≥10 TON after a low-balance alert.
@@ -112,7 +116,7 @@ test_alert
 - `service_down_ok`: Validator service resumed normal operation after downtime.
 - `adnl_connection_failed`: Remote ADNL connectivity checks failed for all probe hosts.
 - `adnl_connection_ok`: ADNL check succeeded again after a failure.
-- `zero_block_created`: No blocks produced in roughly the last half validation period (\~8h on mainnet).
+- `zero_block_created`: No blocks produced in roughly the last half validation period (\~8h on TON Mainnet).
 - `zero_block_created_ok`: Block production resumed after a zero-block alert.
 - `validator_slashed`: Validator was slashed in the previous validation round.
 - `stake_not_accepted`: Election stake submission was rejected (validator missing from current validator list).


### PR DESCRIPTION
- [ ] **1. Command headings not sentence case; format as code identifiers**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/alerting.mdx?plain=1#L13

Headings for commands use bare identifiers (e.g., "setup_alert_bot") which are not in sentence case. For reference pages, identifiers in headings should be formatted as code. Minimal fix: wrap each command name in code font in its heading (e.g., change "## setup_alert_bot" to "## `setup_alert_bot`"; likewise for `list_alerts`, `enable_alert`, `disable_alert`, and `test_alert`).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-4-formatting-restrictions

---

- [ ] **2. Placeholder style and definition missing for alert name**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/alerting.mdx?plain=1#L51

The placeholder uses `<alert_name>` (lowercase) and is not defined on first use. Minimal fix: use `<ALERT_NAME>` and add a one-line definition on first use (for example, below Syntax or in Behavior): “`<ALERT_NAME>` — one of the alert keys listed under ‘Available alert names’.” Apply the same change for `disable_alert` (line 72).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **3. UI/log message should be quoted, not code-formatted**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/alerting.mdx?plain=1#L99

The literal message `Test alert` is formatted as code. UI/log strings must appear in quotation marks. Minimal fix: replace backticks with quotes: Sends “Test alert” with info severity. Keep code font for tokens/flags only.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#error-and-log-style; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **4. Latinism “e.g.” in body text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/alerting.mdx?plain=1#L78

Use common words instead of Latinisms. Minimal fix: replace “(e.g., during planned maintenance)” with “(for example, during planned maintenance)”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **5. Acronym not defined on first mention (ADNL)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/alerting.mdx?plain=1#L8

On first mention, spell out the term and follow with the acronym. Minimal fix: “synchronization, Abstract Datagram Network Layer (ADNL) health, stake acceptance, …”. Subsequent mentions can use “ADNL”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **6. Improper casing for proper noun “Unix”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/alerting.mdx?plain=1#L41

The phrase “UNIX timestamp” should use the proper noun form “Unix timestamp.” Minimal fix: change “UNIX” to “Unix.” General knowledge: “Unix” is a proper name, not an acronym.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-6-spelling-and-contractions

---

- [ ] **7. Idiomatic phrasing “fails fast”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/alerting.mdx?plain=1

 In `setup_alert_bot` Behavior: “fails fast if the bot or chat ID is incorrect.” The phrase is idiomatic. Minimal fix: “fails immediately if the bot or chat ID is incorrect.”
 Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#global-and-inclusive-language

---

- [ ] **8. Casing of TON Mainnet**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/alerting.mdx?plain=1

 In “Available alert names,” the note reads “(~8h on mainnet).” Per TON-specific casing, use “TON Mainnet.” Minimal fix: “(~8h on TON Mainnet).”
 Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#hyphenation-and-abbreviations

---

- [ ] **9. Frontmatter title is too generic for context**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/alerting.mdx?plain=1#L2

The page title "Alerts" is a one-word generic label that isn’t self-describing out of context. Per title vs. sidebar semantics, page titles must be context-free and descriptive; generic one-word titles are discouraged except on top-level pages or proper names. Minimal fix: change `title: "Alerts"` to `title: "Alerting commands"` (or similar concise, descriptive phrasing that clarifies scope).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#title-vs-sidebar-semantics

---

- [ ] **10. Heading level for “Available alert names” is inconsistent**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/alerting.mdx?plain=1#L101

The section "Available alert names" is an H3 but functions as a top-level section alongside command sections (H2). Headings must form a coherent hierarchy starting at H2. Minimal fix: promote `### Available alert names` to `## Available alert names`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles