### PR TITLE
[AI] fix: style-guide.mdx

### DIFF
--- a/contribute/style-guide.mdx
+++ b/contribute/style-guide.mdx
@@ -3,7 +3,7 @@ title: "Documentation style guide"
 sidebarTitle: "Style guide"
 ---
 
-This guide covers the basics: how to structure pages, write examples, and keep docs consistent and safe.
+Structure pages, write runnable examples, and keep docs consistent and safe.
 
 ## Write for the reader
 
@@ -15,8 +15,8 @@ This guide covers the basics: how to structure pages, write examples, and keep d
 
 ## Page types
 
-- Step-by-step guides — for beginners; handhold from zero to first success on one happy path; explain from scratch, define terms, and link out for depth.
-- How-tos — a focused recipe for a specific outcome; assume concepts known and show only what’s needed.
+- Step by step — for beginners; guide from zero to first success on one happy path; explain from scratch, define terms, and link out for depth.
+- How‑to guide — a focused recipe for a specific outcome; assume concepts known and show only what’s needed.
 - Explanation — concepts, architecture, and trade‑offs; clarify why and when, with minimal examples.
 - Reference — exact, complete facts (APIs, CLI, types, errors); stable anchors and minimal prose.
 - Don’t mix types on the same page.
@@ -39,7 +39,7 @@ This guide covers the basics: how to structure pages, write examples, and keep d
 - Make commands copy‑pasteable. Do not include shell prompts like `$` or `>`. Prompts break commands when pasted.
 - Separate command and output. Use two fenced blocks. Mixing them causes copy errors.
 - Use `<ANGLE_CASE>` placeholders in commands and prose and define each on first use (for example, `<RPC_URL>`). In code, use `UPPER_SNAKE` if `< >` clashes with syntax. One clear convention prevents hard‑coded values from slipping in.
-- Tag code fences with a language (`bash`, `json`, `rust`, and so on). This enables correct highlighting and tooling.
+- Tag code fences with a language (for example, `bash`, `json`, `rust`). This enables correct highlighting and tooling.
 - Prefer end‑to‑end examples on testnet by default. Safe defaults encourage trying the steps.
 - Label partial snippets as Not runnable and link to a full example.
 - Do not hard‑wrap long commands. Use soft wrap in the UI or safe continuation if the shell supports it. Hard wraps break execution.
@@ -66,15 +66,21 @@ Add a Caution or Warning when a step moves funds, changes fees or withdrawals, e
 
 Pattern
 
-> Warning — funds at risk
-> Running the next command on mainnet transfers funds irreversibly.
-> Safer first (testnet):
->
-> ```bash
-> jetton transfer --to <ADDR> --amount <AMOUNT> --network testnet
-> ```
->
-> If you must use mainnet: no rollback; on‑chain transfers are final.
+import { Aside } from '/snippets/aside.jsx';
+
+<Aside type="danger" title="Warning — funds at risk">
+Running the next command on mainnet transfers funds irreversibly.
+Safer first (testnet):
+
+```bash
+jetton transfer --to <ADDR> --amount <AMOUNT> --network testnet
+```
+
+If you must use mainnet: no rollback; on‑chain transfers are final.
+</Aside>
+
+`<ADDR>` — recipient address.
+`<AMOUNT>` — amount to transfer.
 
 Default to testnet in task pages. Make destructive flags opt‑in and document mitigations.
 
@@ -95,7 +101,7 @@ Each safety callout should briefly state the risk, scope, rollback/recovery (if 
 
 - Use sentence case. Keep headings concise and unique.
 - Use imperatives for tasks (“Deploy a validator”); nouns for concepts (“Validator architecture”). Titles should signal action vs. explanation.
-- Don’t style headings, except when an identifier needs code font.
+- Don’t style headings; on Reference pages only, identifiers may use code font.
 - Use clear section labels such as Verify, Troubleshoot, and See also.
 
 ## Link to details, don’t duplicate
@@ -109,14 +115,14 @@ Each safety callout should briefly state the risk, scope, rollback/recovery (if 
 ## Terminology and names
 
 - Use the project term bank for canonical spellings, casing, and preferred terms. One vocabulary prevents drift.
-  Examples: TON, jetton, smart contract, BoC (bag of cells), AccountChain, ShardChain, WorkChain, MasterChain, BaseChain.
+  Examples: TON, jetton, smart contract, bag of cells (BoC), accountchain, shardchain, workchain, masterchain, basechain.
 - Prefer allowlist and denylist over whitelist and blacklist. These are clearer and inclusive.
 - Use mainnet and testnet as common nouns. Use TON Mainnet and TON Testnet for the proper names. This distinguishes the generic type from the named network.
 
 ## Files, front matter, labels
 
 - Filenames use `kebab-case.md` or `kebab-case.mdx` (for example, `validator-setup.mdx`). This is readable and consistent across platforms.
-- Optional front matter can declare `doc_type`, `audience`, and `status` (experimental or deprecated). If deprecated, add an Important callout with the replacement and timeline.
+- Use only site‑supported front matter. Communicate status at the top of the page with an <Aside> (for example, title="Deprecated" or title="Experimental").
 - Keep sidebar labels short (2–4 words) and mirror in‑page headings.
 
 ## Accessibility


### PR DESCRIPTION
- [ ] **1. Lowercase TON chain terms (masterchain, shardchain, workchain, basechain)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/proofs/basic-proof-concepts.mdx?plain=1

Occurrences like “MasterChain”, “ShardChain”, “WorkChain”, and “BaseChain” appear mid‑sentence and in headings. These are common nouns and must be lowercase in prose and headings. Minimal fixes: “MasterChain blocks” → “masterchain blocks”; “ShardChain block, MasterChain block” → “shardchain block, masterchain block”; “For BaseChain transactions” → “For basechain transactions”. Apply consistently across the page.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-4-ton-specific-examples

---

- [ ] **2. Use imperative, second‑person steps (avoid “User provides”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/proofs/basic-proof-concepts.mdx?plain=1#L83

Make steps direct and consistent. Minimal fixes:
- “2. User provides a complete MasterChain block that should be validated against the trusted hash.” → “2. Provide a complete masterchain block and validate it against the trusted hash.”
- In the basechain section: “3. User provides the full ShardChain block … 4. Parse the ShardChain block …” → “3. Provide the full shardchain block … 4. Parse the shardchain block …”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#4-voice-and-tone; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles

---

- [ ] **3. Replace vague “described above” with a precise anchor**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/proofs/basic-proof-concepts.mdx?plain=1#L174

Avoid relative references. Replace “the proof composition technique described above” with “the proof composition technique in [Composing proofs](#composing-proofs)”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **4. American English: “backward‑compatible” (not “backwards‑compatible”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/proofs/basic-proof-concepts.mdx?plain=1#L20

Use American English spelling. Minimal fix: “backwards-compatible” → “backward‑compatible”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-6-spelling-and-contractions

---

- [ ] **5. Correct link text to match canonical term**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/proofs/basic-proof-concepts.mdx?plain=1#L11

Link text should use the canonical page/term name. Minimal fix: “[Exotic cells](/ton/cells/merkle-proof-cells)” → “[Merkle proof cells](/ton/cells/merkle-proof-cells)”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#15-1-language-and-reading; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-4-ton-specific-examples

---

- [ ] **6. Remove hedging/throat‑clearing; use direct, active phrasing**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/proofs/basic-proof-concepts.mdx?plain=1#L10

Replace hedges and indirect openers with direct statements. Minimal fix: “It is highly recommended to familiarize yourself … This article primarily covers … However, the same techniques can be used …” → “First, read [Merkle proof cells](/ton/cells/merkle-proof-cells). This page covers verifying proofs in smart contracts. The same techniques also work off‑chain.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#4-voice-and-tone; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **7. Code and identifier styling: use code font for types/fields; avoid code font for common nouns**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/proofs/basic-proof-concepts.mdx?plain=1#L46-L235

Apply code formatting to identifiers and remove it from common nouns. Minimal fixes:
- 46 “two ShardState hashes” → “two `ShardState` hashes”.
- 201 “ShardBlock” → “`ShardBlock`”.
- 235 “the **ShardDescr**” → “the `ShardDescr`”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-3-code-styling; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules

---

- [ ] **8. Label partial snippets as “Not runnable”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/proofs/basic-proof-concepts.mdx?plain=1#L182-L203

Both the TypeScript and Tact excerpts are partial. Add a label line immediately above each block: “Not runnable”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **9. Reduce unnecessary bold emphasis on common nouns**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/proofs/basic-proof-concepts.mdx?plain=1#L17

Bold should be sparse and not used to style common nouns. Minimal fix: remove bold from “blocks” and “state” in the bullet list; rely on clear wording.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **10. Consistent naming: prefer one form of hash function**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/proofs/basic-proof-concepts.mdx?plain=1#L142

The page uses both “hash0(…)” and “hash_0(…)”. Pick one consistent form; align with earlier bullets that use `hash0(cell)`. Minimal fix: change “$hash_0(v1) == hash_0(v2)$” to “`hash0(v1) == hash0(v2)`” or render with KaTeX using a single name.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-3-code-styling; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#14-4-magnitudes-and-math

---

- [ ] **11. Generic concept capitalized mid‑sentence: “Bag of Cells (BoC)”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/proofs/basic-proof-concepts.mdx?plain=1#L8

Generic concepts must not be capitalized mid‑sentence. Use “bag of cells (BoC)” as a common noun; keep the abbreviation “BoC”. Minimal fix: change “Bag of Cells (BoC)” → “bag of cells (BoC)”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13.2-general-casing-rules and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13.4-ton‑specific-examples

---

- [ ] **12. Ordered lists use explicit 1., 2., 3. instead of all `1.`**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/proofs/basic-proof-concepts.mdx?plain=1#L83-L101

Ordered lists must number every item as `1.` and let the renderer auto‑number. Minimal fix: change each list item marker in these sections to `1.`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.4-lists

---

- [ ] **13. Tense: future “We will save gas…” vs present**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/proofs/basic-proof-concepts.mdx?plain=1#L180-L181

Use present tense for general behavior/instructions. Minimal fix: “We save gas and improve parsing convenience by concatenating …”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.1-voice-tense-and-person

---

- [ ] **14. Internal-first link on first mention of TL‑B**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/proofs/basic-proof-concepts.mdx?plain=1#L20

When both internal and external sources exist, prefer linking an internal page by default. Minimal fix: on first useful mention of TL‑B, add an internal link to the TL‑B overview (e.g., “TL‑B” → [/language/TL-B/overview]) and retain the GitHub link as a secondary reference if needed. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12.2-what-to-link-and-what-not and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12.5-external-references

---

- [ ] **15. Inline math markers `$…$` used in MDX; use code font instead**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/proofs/basic-proof-concepts.mdx?plain=1#L150

The text uses `$hash_0(c1) = x$`. The docs do not render LaTeX math; use code font for inline expressions. Minimal fix: replace with `` `hash_0(c1) = x` ``. (General Markdown/MDX syntax knowledge applied.)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-3-code-styling

---

- [ ] **16. External explorer link used instead of internal canonical; link text not descriptive**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/proofs/basic-proof-concepts.mdx?plain=1#L75

Links should prefer internal docs when available and use descriptive link text. Minimal fix: change to an internal page such as “explorers overview” and make the text descriptive, for example: “See explorers overview” linking to `/ecosystem/explorers/overview` (or link a specific explorer page like `/ecosystem/explorers/tonviewer`).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text

---

- [ ] **17. First-person plural in narrative; prefer second person**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/proofs/basic-proof-concepts.mdx?plain=1#L169-L229

Occurrences of "Let’s consider…", "we want to…", "We will save gas…", and "we … are working…" use first-person plural. Prefer direct second person or imperative voice. Minimal fix examples: "Consider a scenario where you need to prove…"; "To save gas and simplify parsing, concatenate…"; "Retrieve the ShardDescr for WorkChain 0, as you are working in BaseChain."
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide.mdx?plain=1#write-for-the-reader

---

- [ ] **18. External TEP link without internal reference first**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/proofs/basic-proof-concepts.mdx?plain=1#L170

Links directly to TEP‑89. Prefer the internal docs first when available; `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/API.mdx?plain=1` includes a TEP‑89 section. Minimal fix: link to `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/API.mdx?plain=1#tep-0089` as the in-docs reference, optionally keeping the TEP as a secondary link.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references

---

- [ ] **19. Unpinned external code link (stability)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/proofs/basic-proof-concepts.mdx?plain=1#L172

The "full example" link points to the `main` branch, which can change. Minimal fix: pin to a specific commit permalink for reproducibility (replace `/blob/main/…` with `/blob/<COMMIT_SHA>/…`).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references

---

- [ ] **20. Internal links use root-absolute paths; prefer relative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/proofs/basic-proof-concepts.mdx?plain=1#L11-L174

Internal links use root-absolute paths (e.g., `/ton/cells/merkle-proof-cells`, `/ecosystem/node/overview`). The style guide recommends relative internal links. Minimal fix: change to `../cells/merkle-proof-cells` and `../../ecosystem/node/overview` respectively to keep links stable across domain/path changes.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-3-links-and-anchors

---

- [ ] **21. Moving-target GitHub link to TL‑B schemas**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/proofs/basic-proof-concepts.mdx?plain=1

Link points to `…/blob/master/crypto/block/block.tlb` (line 20). For precision-critical references, do not link to `master`/`main`; use a versioned commit/tag permalink, or prefer an internal reference page when available. Minimal fix: update to a commit/tag permalink or replace with an internal TL‑B reference page; needs owner to pick the exact target.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not

---

- [ ] **22. Capitalization of linked concept text (“Exotic cells”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/proofs/basic-proof-concepts.mdx?plain=1

Mid‑sentence link text “Exotic cells” (line 11) uses title case for a generic concept. Minimal fix: change to “exotic cells”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules

---

- [ ] **23. Acronym not expanded on first mention (TVM)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/proofs/basic-proof-concepts.mdx?plain=1#L83

Spell out on first mention and then use the acronym; link core term to Glossary. Minimal fix: “TON Virtual Machine (TVM) instructions” and link to Glossary: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#ton-virtual-machine-tvm.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#53-acronyms-and-terms

---

- [ ] **24. Acronym not expanded on first mention (TEP)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/proofs/basic-proof-concepts.mdx?plain=1#L170

Define the acronym at first mention and link to the canonical location. Minimal fix: “TON Enhancement Proposals (TEPs) — TEP‑89” and link to Glossary: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#ton-enhancement-proposals-teps.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#53-acronyms-and-terms

---

- [ ] **25. Unfenced code snippet renders as prose**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/proofs/basic-proof-concepts.mdx?plain=1

The snippet beginning with `let mcBlockExtra = McBlockExtra.fromCell(...)` (around line 222) is outside a fenced block, so it renders as body text. All examples must be fenced with a language. Minimal fix: wrap that snippet in a fenced block with the correct language tag (likely `tact` or `ts`). If it’s a partial snippet, label it accordingly per §10.2.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **26. Missing Glossary links on first useful mentions**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/proofs/basic-proof-concepts.mdx?plain=1

Core TON terms are introduced without Glossary links: “masterchain” (line 16) and “workchain” (line 33). Minimal fix: link the first useful mention to the Glossary: `/ton/glossary#masterchain` and `/ton/glossary#workchain`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not