### PR TITLE
[AI] fix: types.mdx

### DIFF
--- a/language/func/types.mdx
+++ b/language/func/types.mdx
@@ -28,14 +28,15 @@ Each of these types occupies a single stack entry in the TVM stack.
 
 FunC does not have a dedicated boolean type.
 Instead, booleans are represented as integers:
+
 - `false` is `0`, `true` is `-1` (a 257-bit integer with all bits set to 1).
 - Logical operations use bitwise operators.
 - In conditional checks, any nonzero integer is treated as `true`.
 
 ### Null values
 
-In FunC, the `null` value of the TVM type `Null` represents the absence of a value for a given atomic type. 
-Any atomic type variable can have `null` to indicate absence of a value. 
+In FunC, the `null` value of the TVM type `Null` represents the absence of a value for a given atomic type.
+Any atomic type variable can have `null` to indicate absence of a value.
 
 For functions:
 
@@ -68,6 +69,7 @@ _ someFunction(int a) {
   return a + 1;
 }
 ```
+
 the type checker infers that `_` must have type `int`, since the type of the returned expression `a + 1` is `int`.
 
 ## Composite types
@@ -77,16 +79,19 @@ Types can be combined to form more complex structures.
 ### Functional type
 
 A functional type is written in the form `A → B`, where:
+
 - `A` is the input type, which is called the domain.
 - `B` is the output type, which is called the codomain.
 
 #### Example
+
 The type `int → cell` represents a function that:
+
 - Takes an integer as input.
 - Returns a TVM cell as output.
 
-As in functional programming, it is possible to declare functional types which have in their domain and codomain other functional types. 
-For example, `(int → int) → int` is a function with domain `int → int` and codomain `int`. 
+As in functional programming, it is possible to declare functional types which have in their domain and codomain other functional types.
+For example, `(int → int) → int` is a function with domain `int → int` and codomain `int`.
 Similarly, `int → (int → int)` is a function with domain `int` and codomain `int → int`.
 
 ### Tensor types
@@ -95,6 +100,7 @@ Tensor types represent ordered collections of values and are written in the form
 These types occupy multiple TVM stack entries, unlike atomic types, which use a single entry.
 
 #### Example
+
 If a function `foo` has the type `int → (int, int)`,
 it takes one integer as input and returns a pair of integers as output.
 A call to this function may look like: `(int a, int b) = foo(42);`.
@@ -104,25 +110,28 @@ Internally, the function consumes one stack entry and produces two.
 For instance, the following code **will not compile**:
 
 Not runnable
+
 ```func
 (int a, int b, int c) = (2, (3, 9));
 ```
+
 Since FunC strictly enforces type consistency, these structures cannot be mixed.
 
 <Aside type="note">
-
-A type of the form `(A)` is considered the same type as `A` by the type checker.
-
+  A type of the form `(A)` is considered the same type as `A` by the type checker.
 </Aside>
 
 #### Unit type ()
+
 The unit type `()` is used to indicate that:
+
 - A function does not return a value.
 - A function takes no arguments.
 
 The unit type `()` has a single value, also written as `()`, occupying **zero stack** entries.
 
 #### Examples
+
 - `print_int` has the type `int → ()`, meaning it takes an integer but returns nothing.
 - `random` has the type `() → int`, meaning it takes no arguments but returns an integer.
 
@@ -131,13 +140,14 @@ The unit type `()` has a single value, also written as `()`, occupying **zero st
 Tuple types in FunC are written in the form `[A, B, ...]` and represent TVM tuples with a fixed length and known component types at compile time.
 
 For example, `[int, cell]` defines a tuple with exactly two elements:
+
 - The first element is an integer.
 - The second element is a cell.
 
 The type `[]` represents an empty tuple with a unique value—the empty tuple itself.
 
 <Aside type="note">
-Unlike the unit type `()`, an empty tuple `[]` occupies one stack entry.
+  Unlike the unit type `()`, an empty tuple `[]` occupies one stack entry.
 </Aside>
 
 ## Polymorphism with type variables
@@ -146,14 +156,15 @@ FunC features a custom type system with support for polymorphic functions.
 For example, consider the following function:
 
 Not runnable
+
 ```func
 forall X -> (X, X) duplicate(X value) {
   return (value, value);
 }
 ```
 
-Here, `X` is a type variable that allows the function to operate on values of any type. Type variables are declared after `forall` and before `->`. 
-The function receives a value of type `X`, and duplicates this value to return a value of type `(X, X)`. 
+Here, `X` is a type variable that allows the function to operate on values of any type. Type variables are declared after `forall` and before `->`.
+The function receives a value of type `X`, and duplicates this value to return a value of type `(X, X)`.
 
 For example,
 
@@ -161,10 +172,8 @@ For example,
 - Calling `duplicate([])` produces two copies of an empty tuple: `([], [])`.
 
 <Aside type="note">
-
-Type variables in polymorphic functions cannot be instantiated with tensor types. 
-There is only one exception: the tensor type `(a)`, where `a` is not a tensor type itself, since the compiler treats `(a)` as if it was `a`.
-
+  Type variables in polymorphic functions cannot be instantiated with tensor types.
+  There is only one exception: the tensor type `(a)`, where `a` is not a tensor type itself, since the compiler treats `(a)` as if it was `a`.
 </Aside>
 
 For more details, see the [Polymorphism with forall](/language/func/functions#polymorphism-with-forall) section.
@@ -178,5 +187,5 @@ FunC does not support defining custom types beyond the type constructions descri
 Every value in FunC occupies a certain number of stack entries.
 If this number is consistent for all values of a given type, it is called the **type width**.
 
-For example, all [atomic types](#atomic-types) have a type width of 1, because all their values occupy a single stack entry. 
+For example, all [atomic types](#atomic-types) have a type width of 1, because all their values occupy a single stack entry.
 The tensor type `(int, int)` has type width 2, because all its values occupy 2 stack entries.


### PR DESCRIPTION
- [ ] **1. Broken internal link to Statements methods section**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/functions.mdx?plain=1#L42

The link text points to “Statements” with anchor `#methods-calls`, but `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/statements.mdx?plain=1` has no such anchor. Update the link to the canonical in-page section that actually explains this behavior: `/language/func/functions#function-calls`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-3-links-and-anchors

---

- [ ] **2. Avoid “as mentioned earlier” throat‑clearing**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/functions.mdx?plain=1#L34

The phrase “As mentioned earlier,” is banned. Remove the throat‑clearing and start the sentence directly: “Every function declaration or definition follows a common pattern. The general form is:”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **3. Missing space after period**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/functions.mdx?plain=1#L53

There is no space after the period in “recv_internal`.The”. Add a space: “recv_internal`. The”. This relies on general English grammar for punctuation spacing.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **4. Overuse of bold emphasis (≥ 4 words)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/functions.mdx?plain=1#L57

The span “an inbound internal message” is bolded. Reduce or remove emphasis (e.g., remove bold) to comply with limits on emphasis in body text.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **5. Awkward/incorrect phrasing about commas in arguments**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/functions.mdx?plain=1#L94

“In function arguments, commas separate it.” is ungrammatical. Use a precise construction: “In function declarations, arguments are separated by commas.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **6. Terminology consistency: “type-checker” → “type checker”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/functions.mdx?plain=1#L107

Use “type checker” (no hyphen) to match prevailing usage across docs (see `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/types.mdx?plain=1#L57` “The type checker determines…”). Replace “type-checker” with “type checker”. The guide is silent on this specific term; prefer consistency with nearby pages.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-3-hyphenation-and-abbreviations

---

- [ ] **7. Bold used as a pseudo‑heading**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/functions.mdx?plain=1#L117–120

“Argument tensor representation” is bolded as a section label. Use a proper heading instead: “#### Argument tensor representation”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#8-2-structure-for-scanning

---

- [ ] **8. Hyphenation inconsistency: “tensor-type” → “tensor type”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/functions.mdx?plain=1#L119

Use “tensor type” (no hyphen) to align with the Types page (“Tensor types”) and avoid unnecessary hyphenation. Also keep the existing link to `#tensor-types`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-3-hyphenation-and-abbreviations

---

- [ ] **9. Broken internal link to “Function application”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/functions.mdx?plain=1#L119

The link to `/language/func/statements#function-application` points to a missing anchor. Link to the relevant, existing section on this page instead: `/language/func/functions#function-calls`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-3-links-and-anchors

---

- [ ] **10. Comma splice/awkward clause**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/functions.mdx?plain=1#L137

“A function with at least one argument, it can be called a non‑modifying method.” Replace with “A function with at least one argument can be called a non‑modifying method.” to eliminate the comma splice.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **11. Redundant duplicate explanation before the chained call**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/functions.mdx?plain=1#L151–154

Two consecutive sentences restate the same idea. Remove the first (“So the first argument of a function… The code can be further simplified:”) and keep the second, more precise sentence.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **12. Bold used as a pseudo‑heading**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/functions.mdx?plain=1#L206

“Modifying methods with no return value” is bolded as a section label. Convert to a heading: “#### Modifying methods with no return value”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#8-2-structure-for-scanning

---

- [ ] **13. Code font inside heading not allowed here**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/functions.mdx?plain=1#L225

Heading “` . ` and ` ~ ` in function names” uses code styling inside a heading, which is disallowed except for identifiers on reference pages. Replace with plain text: “Dot and tilde in function names”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-4-formatting-restrictions

---

- [ ] **14. Bold used as a pseudo‑heading**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/functions.mdx?plain=1#L249

“How FunC resolves function calls” is bolded as a section label. Use a proper heading: “#### How FunC resolves function calls”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#8-2-structure-for-scanning

---

- [ ] **15. Avoid code font for non‑code term “ad‑hoc”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/functions.mdx?plain=1#L393–394

The phrase “`ad-hoc` polymorphism” uses code formatting for a non‑code term. Remove code formatting: “ad‑hoc polymorphism”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **16. Stray sentence fragment and duplication around assembler example**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/functions.mdx?plain=1#L406–409

There is a stray fragment starting with “– a function that increments…” and two adjacent “alternative” lines. Remove the fragment and keep a single, clear sentence: “When called, this function is translated into the two assembler commands, `INC` and `NEGATE`. Alternatively, you can write:”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **17. Redundant restatement after asm argument order example**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/functions.mdx?plain=1#L442–444

Two sentences restate the same point. Keep one: remove “This allows us to control the order in which arguments are passed to the assembler command.” since the prior sentence already explains this.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **18. Broken internal anchor for “Function application”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/functions.mdx?plain=1#L119

The link points to `/language/func/statements#function-application`, but the relevant section lives in `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/expressions.mdx?plain=1` under “Function call”. Replace with `/language/func/expressions#function-call`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format

---

- [ ] **19. Redundant duplicate lead-in in “Polymorphism with forall”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/functions.mdx?plain=1#L368–376

Two consecutive sentences introduce the same syntax. Keep the clearer sentence “A function definition can include a `forall` type variable declaration …” and remove the preceding duplicate.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **20. Word choice: “overwrite” → “override”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/functions.mdx?plain=1#L428

“To overwrite this behavior use …” is imprecise; “override” is the correct verb for altering behavior. Fix to: “To override this behavior, use …”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **21. Possible typo in example identifier (‘store_uint_quite’)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/functions.mdx?plain=1#L435-L456

The example function name appears as `store_uint_quite` four times; this looks like a typo of “quiet.” If the intended name is “quiet,” correct the identifier in all occurrences; otherwise confirm with the domain owner to avoid introducing an incorrect API name. This is a grammar/spelling issue; no domain behavior change is proposed.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-6-spelling-and-contractions

---

- [ ] **22. Token formatting: unit type should be code-styled**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/functions.mdx?plain=1#L208

“unit type ()” should render the token `()` in code font: “unit type `()`”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#62-quotation-marks-and-emphasis

---

- [ ] **23. Partial snippet not labeled as “Not runnable”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/functions.mdx?plain=1#L363–368

Example references `load_data()` and `ctx_counter` without defining them, so the snippet is not runnable standalone. Add a label line “Not runnable” above the block per partial snippet rules. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#102-partial-snippets

---

- [ ] **24. Wordy opener “So …” in explanatory sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/functions.mdx?plain=1#L442

“So you can indicate …” is throat‑clearing. Minimal fix: “You can indicate the required order of arguments after the `asm` keyword.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **25. Inconsistent code styling in specifier list**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/functions.mdx?plain=1#L258–260

List shows `inline`/ `inline_ref` with an extra space and inconsistent code spans. Minimal fix: render both in code font without the space: `` `inline`/`inline_ref` ``.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis