### PR TITLE
[AI] fix: debug.mdx

### DIFF
--- a/guidebook/debug.mdx
+++ b/guidebook/debug.mdx
@@ -17,6 +17,7 @@ A straightforward and effective technique. The most common values to print are t
 There are helper functions that let you inspect transactions in a developer‑friendly way.
 
 Not runnable
+
 ```ts
 import { toNano } from '@ton/core';
 import { Blockchain } from '@ton/sandbox';
@@ -69,6 +70,7 @@ Availability depends on the language you use.
 ## Explore TVM logs
 
 Not runnable
+
 ```ts
 const blockchain = await Blockchain.create();
 blockchain.verbosity.vmLogs = "vm_logs";
@@ -125,13 +127,12 @@ However, the slice has only **725** bits and **711** bits were already read, as 
 
 You should locate the `load_uint(64)` call that causes the issue and ensure enough bits are available or adjust the read width.
 
- 
-
 ## Explore the transaction tree
 
 For simple transaction trees, print all transactions and inspect them.
 
 Not runnable
+
 ```ts
 const deployRes = await contract.send(owner.getSender(), { value: toNano(0.5), bounce: true }, null);
 for (const tx of deployRes.transactions) {


### PR DESCRIPTION
- [ ] **1. In-body H1 present (duplicate page title)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/debug.mdx?plain=1#L15

The page includes an in-body H1 `# Debugging smart contracts`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form
Minimal fix: remove line 15 entirely; the site title renders the H1. Do not add another H1 in the body.

---

- [ ] **2. Misused frontmatter encoded as a visible H2**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/debug.mdx?plain=1#L1–3

Line 1 renders `## title: "Hands-on debugging"` as a visible H2, and the `---` on line 3 is not valid frontmatter. Frontmatter must be YAML between `---` delimiters at the very top and use supported keys.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-2-navigation-labels
Minimal fix: delete line 1 and, if a custom title is needed, add proper YAML frontmatter:

```mdx

---

- [ ] **3. title: "Debugging smart contracts"**

(path missing)

---

- [ ] **4. ```**

(path missing)

---

- [ ] **5. Unsupported Aside type "warning"**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/debug.mdx?plain=1#L132–136

The `<Aside type="warning">` uses an unsupported type; only `note`, `tip`, `caution`, and `danger` are allowed. Use `type="danger"` for a “Warning” label.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout
Minimal fix: change to `<Aside type="danger" title="Warning">` to preserve the visible label.

---

- [ ] **6. Incomplete callout sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/debug.mdx?plain=1#L132–136

The callout text is truncated: "Note, that TVM debug output is limited to" (incomplete sentence and comma after “Note” is incorrect).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording
Minimal fix: either remove the incomplete Aside or replace its body with a complete sentence that states the limitation. Domain decision required to supply the exact limitation text.

---

- [ ] **7. Code fences use extra label after language (```ts TypeScript)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/debug.mdx?plain=1#L25-L142

Fenced blocks declare `ts` and add an extra token `TypeScript` on the same line (```ts TypeScript). Most Markdown renderers expect a single language identifier; extra tokens can break highlighting.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules
Minimal fix: use only the language tag: change all occurrences of ```ts TypeScript to ```ts.

---

- [ ] **8. Brand capitalization: GitHub**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/debug.mdx?plain=1#L12

"Github" should be "GitHub".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17-4-proofread
Minimal fix: replace "Github" with "GitHub".

---

- [ ] **9. Throat-clearing and awkward intro phrasing**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/debug.mdx?plain=1#L17

"It's a common situation when you encounter an error…" and "you will see that unexpected exit code is returned" are wordy and ungrammatical (should be "an unexpected exit code").
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references
Minimal fix: "When a contract returns an unexpected exit code, use these techniques to debug it." (Or split into two short sentences per §8.1.)

---

- [ ] **10. Tip Aside: grammar and malformed code spans/parentheses**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/debug.mdx?plain=1#L117–119

Issues: "Note, that …" (unnecessary comma), "it's" → "its", and malformed code spans/parentheses: ``(`preload\_uint`and`preload\_int`)``.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording
Minimal fix: "If you want to dive deeper into the error, search the TVM source for the `LDU` instruction. Some TVM instructions are implemented as groups—for example, [LDU](/tvm/instructions#d3-ldu) (`load_uint`) and [LDI](/tvm/instructions#d2-ldi) (`load_int`), and their preload versions (`preload_uint` and `preload_int`)."

---

- [ ] **11. Grammar: final sentence is ungrammatical**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/debug.mdx?plain=1#L156

"Also these tools allow you to explore each transaction separate logs."
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording
Minimal fix: "These tools also let you explore each transaction’s logs."

---

- [ ] **12. Safety callout lacks required details (risk/scope/mitigation)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/debug.mdx?plain=1#L68-L72

The Caution about debug instructions changing gas usage does not include scope and mitigation/rollback. Safety callouts must include risk, scope, and mitigation. Minimal fix: expand to note scope (e.g., affects gas measurement in local testing only), and mitigation (remove debug calls before measuring or deploying; compare gas without them).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11.2-how-to-write-the-callout

---

- [ ] **13. Import formatting inconsistent with repo convention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/debug.mdx?plain=1#L5

Import statement uses `import {Aside} from "/snippets/aside.jsx";` without spaces inside braces. Nearby pages use `import { Aside } from '/snippets/aside.jsx';`. Minimal fix: change to `import { Aside } from "/snippets/aside.jsx";` for consistency. The guide is silent on brace spacing; per the review instructions, prefer consistency with nearby pages (e.g., `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/exit-codes.mdx?plain=1#L8`).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#15.1-markdown-and-mdx-basics (consistency and readability; guide is otherwise silent; applying repo-consistent style)

---

- [ ] **14. Prefer stable permalink for examples repo link**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/debug.mdx?plain=1#L12

Link targets a moving branch (`.../tree/main/...`). For reproducibility, prefer a tag or commit permalink when referencing runnable examples. Minimal fix: pin to a versioned tag or commit URL.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references

---

- [ ] **15. Gerund in task heading; use imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/debug.mdx?plain=1#L15

Task/procedure headings should use imperative verbs and avoid gerunds. Replace `Debugging smart contracts` with `Debug smart contracts`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles

---

- [ ] **16. Partial snippet not labeled as not runnable**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/debug.mdx?plain=1#L25

The TypeScript example imports local files and is not runnable standalone. Partial snippets must be labeled clearly above the block. Minimal fix: insert a line above the fence: `Not runnable`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **17. Partial snippet not labeled as not runnable**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/debug.mdx?plain=1#L76

The short TypeScript fragment is not runnable by itself. Add a `Not runnable` label above the fence. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **18. Partial snippet not labeled as not runnable**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/debug.mdx?plain=1#L142

The deployment loop snippet is not runnable by itself. Add a `Not runnable` label above the fence. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **19. Define acronym on first use: GUI**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/debug.mdx?plain=1#L149

Acronyms must be spelled out on first use. Minimal fix: `For complex trees, use a graphical user interface (GUI) tool.` Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **20. Define acronym on first use: VM**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/debug.mdx?plain=1#L81

The text uses “VM logs” without defining VM. Minimal fix: `There are multiple verbosity levels; two virtual machine (VM) log levels are most useful:` or similar. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms