### PR TITLE
[AI] fix: simple-examples.mdx

### DIFF
--- a/language/TL-B/simple-examples.mdx
+++ b/language/TL-B/simple-examples.mdx
@@ -9,8 +9,8 @@ nothing$0 {X:Type} = Maybe X;
 just$1 {X:Type} value:X = Maybe X;
 ```
 
-The `Maybe` combinator is used to represent optional values. In this case, the first bit indicates a value.
-If the bit is `0`, the value is not serialized and skipped. If the bit is `1`, the value follows and is serialized.
+The `Maybe` combinator is used to represent optional values. The first bit indicates a value.
+If the bit is `0`, the value is not serialized. If the bit is `1`, the value follows and is serialized.
 
 ## Either
 
@@ -22,7 +22,7 @@ right$1 {X:Type} {Y:Type} value:Y = Either X Y;
 The `Either` type is used when one of two possible result types may be present.
 The choice of type depends on the prefix bit. If the prefix bit is `0`, then the left type is serialized. If it is `1`, the right type is serialized.
 
-This construct is used, for example, when serializing messages: where the body is either included directly
+This construct is used, for example, when serializing messages, where the body is either included directly
 in the main cell or stored in a separate referenced cell.
 
 ## Both
@@ -42,8 +42,8 @@ var_uint$_ {n:#} len:(#< n) value:(uint (len * 8)) = VarUInteger n;
 The combinator is parameterized by a natural number `n`, represented in curly brackets. For a given `n`, `VarUInteger n`
 describes the serialization of a natural number `m`, which in its binary representation contains no more than `n * 8` bits.
 
-First, the number of bytes required for writing `m`, that is called `len`, is serialized into $\lceil \log_{2}n \rceil$ bits as an unsigned
-big-endian integer. Then `m` itself is serialized as a `uint` on `len*8` bits. Thus, the size of the serialization of a particular `m` through the
+First, the number of bytes required for writing `m`, called `len`, is serialized into `ceil(log2 n)` bits as an unsigned
+big-endian integer. Then `m` itself is serialized as a `uint` of `len * 8` bits. Thus, the size of the serialization of a particular `m` through the
 combinator `VarUInteger n` depends on `m`.
 
-This type is used as the representation of an amount of toncoins stored on the account.
+This type is used as the representation of an amount of Toncoins stored on the account.


### PR DESCRIPTION
- [ ] **1. Remove pleonasm “not serialized and skipped”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/simple-examples.mdx?plain=1#L13

The phrase “not serialized and skipped” is redundant; “not serialized” already implies skipping. Replace with “not serialized” to remove duplication without changing meaning. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#57-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **2. Replace misused colon after “messages” with a comma**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/simple-examples.mdx?plain=1#L25

The colon in “This construct is used, for example, when serializing messages: where the body…” introduces a dependent clause, which conflicts with the rule for colons. Use a comma instead: “This construct is used, for example, when serializing messages, where the body …”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#61-commas-colons-semicolons

---

- [ ] **3. Tighten wording: “that is called `len`” → “called `len`”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/simple-examples.mdx?plain=1#L45

Streamline the clause and fix punctuation by removing the extra words/commas: “First, the number of bytes required for writing `m`, called `len`, is serialized …”. This improves clarity without altering content. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#52-plain-precise-wording

---

- [ ] **4. Fix preposition and operator spacing in “on `len*8` bits”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/simple-examples.mdx?plain=1#L46

Use “of” instead of “on” for bit width, and match spacing with earlier “n * 8” for consistency: “Then `m` itself is serialized as a `uint` of `len * 8` bits.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#52-plain-precise-wording. The guide is silent on operator spacing; apply local consistency within the page as a minimal fix.

---

- [ ] **5. Capitalize Toncoin and use mass‑noun form**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/simple-examples.mdx?plain=1#L49

Change “toncoins” to “Toncoins” to follow proper‑noun casing for the currency name. Minimal fix: “This type is used as the representation of an amount of Toncoins stored on the account.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#132-general-casing-rules. The guide is silent on mass‑noun vs. plural usage; keep the existing plural form for local consistency.

---

- [ ] **6. Capitalize Toncoin and use mass‑noun form**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/simple-examples.mdx?plain=1#L49

Change “toncoins” to “Toncoin” to follow proper‑noun casing and common currency style in the docs (e.g., “amount of Toncoin”). Minimal fix: “This type is used as the representation of an amount of Toncoin stored on the account.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#132-general-casing-rules

---

- [ ] **7. Remove filler “In this case,”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/simple-examples.mdx?plain=1#L12

Delete “In this case,” to avoid filler and keep the sentence direct: “The `Maybe` combinator is used to represent optional values. The first bit indicates a value.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#57-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **8. Inline LaTeX math may not render; prefer plain text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/simple-examples.mdx?plain=1#L45

Inline LaTeX delimiters `$…$` ("$\\lceil \\log_{2}n \\rceil$") are not used elsewhere in this section of the docs and may not render depending on site configuration. Prefer a plain, copyable text expression. Minimal fix: replace with `ceil(log2 n)` and keep surrounding sentence intact.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#8-1-paragraphs-and-sentences
Note: The guide is silent on math notation; this change follows consistency with nearby pages and improves scannability.

---

- [ ] **9. Relative clause wording ("that is called" → "which is called")**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/simple-examples.mdx?plain=1#L45

Minor grammar: use the nonrestrictive relative pronoun "which" for a clause set off by commas. Minimal fix: "the number of bytes required for writing `m`, which is called `len`, is serialized …".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording