### PR TITLE
[AI] fix: dictionaries.mdx

### DIFF
--- a/language/func/dictionaries.mdx
+++ b/language/func/dictionaries.mdx
@@ -8,8 +8,9 @@ import { Aside } from '/snippets/aside.jsx';
 
 Smart contracts in The Open Network (TON) can use dictionaries structured as ordered key-value mappings. Internally, these dictionaries are represented as tree-like structures composed of cells.
 
-<Aside type="caution">
-
+<Aside
+  type="caution"
+>
   Handling potentially large trees of cells in TON introduces several important considerations:
 
   - Gas consumption for updates
@@ -22,7 +23,6 @@ Smart contracts in The Open Network (TON) can use dictionaries structured as ord
     - Since smart contract storage in TON is capped at 65,536 unique cells, the maximum number of dictionary entries is approximately 32,768. This limit may be slightly higher if some cells are reused within the structure.
 
   Limit dictionary updates per transaction; continue via a follow-up message.
-
 </Aside>
 
 ## Dictionary kinds
@@ -36,6 +36,7 @@ Hashmaps map fixed-length keys, which are defined as an argument to all function
 An empty hashmap is represented as `null` in TVM, meaning it is not stored as a cell. A single bit is first saved to store a dictionary in a cell (0 for empty, 1 otherwise), followed by a reference if the hashmap is not empty. This makes `store_maybe_ref` and `store_dict` interchangeable. Some smart contract developers use `load_dict` to load a `Maybe ^Cell` from an incoming message or storage.
 
 #### Available hashmap operations
+
 - Load from a slice, store to a builder
 - Get/Set/Delete a value by key
 - Replace a value (update an existing key) or add a new value (if the key is absent)
@@ -46,9 +47,7 @@ An empty hashmap is represented as `null` in TVM, meaning it is not stored as a 
 To prevent gas exhaustion, smart contracts should limit the number of dictionary updates per transaction. If a contract's balance is used to maintain the hashmap under specific conditions, it can send itself a message to continue processing in another transaction.
 
 <Aside type="note">
-
   TVM provides instructions for retrieving a sub-dictionary — a subset of entries within a given key range. These operations (`SUBDICTGET` and similar) are untested and can only be explored at the TVM assembly level.
-
 </Aside>
 
 #### Hashmap examples
@@ -94,7 +93,5 @@ Augmented maps with additional data in each node are used internally by TON vali
 ### Prefix dictionary
 
 <Aside type="note">
-
   Testing shows that documentation on prefix dictionaries is insufficient. Avoid using them in production contracts unless you fully understand how the relevant opcodes, such as `PFXDICTSET`, work.
-
 </Aside>


### PR DESCRIPTION
- [ ] **1. Heading includes quotation marks (not allowed)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/dictionaries.mdx?plain=1#L28

The H3 heading reads `### "Hash" map`, which uses quotation marks for emphasis inside a heading. Headings must not contain quotes, and quotation marks are reserved for literal UI/log strings, not emphasis. Minimal fix: rename the heading to `### Hashmap` (sentence case, no quotes) to align with term usage elsewhere on the page.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.-headings-and-titles; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.2-quotation-marks-and-emphasis

---

- [ ] **2. Banned term “utilize” in lead sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/dictionaries.mdx?plain=1#L9

“Smart contracts in TON can utilize dictionaries…” uses “utilize,” which the guide flags. Minimal fix: replace with “use”: “Smart contracts in TON can use dictionaries…”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#b.-banned-and-preferred-terms

---

- [ ] **3. List item punctuation inconsistent with list rules**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/dictionaries.mdx?plain=1#L36

Items under “Available hashmap operations” are fragments but end with semicolons (and one period), violating the rule to omit terminal punctuation for non‑sentence list items. Minimal fix: remove the trailing `;` and `.` from all bullets in this list so none end with terminal punctuation.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.4-lists

---

- [ ] **4. Unlabeled code fence lacks language**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/dictionaries.mdx?plain=1#L71

The tree output block uses a bare triple‑backtick fence without a language. Fenced code blocks must specify a language for proper rendering/tooling. Minimal fix: change the opening fence to ```text.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10.1-general-rules

---

- [ ] **5. Broken internal link anchor**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/dictionaries.mdx?plain=1#L86

Link text “examples of hashmap parsing” points to `/language/TL-B/overview#hashmap-parsing-example`, but that anchor does not exist on the TL‑B Overview page; the actual anchor is on `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/complex-and-non-trivial-examples.mdx?plain=1`. Minimal fix: update the link to `/language/TL-B/complex-and-non-trivial-examples#hashmap-parsing-example`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16.3-links-and-anchors (also see “Global overrides” for broken/missing anchors)

---

- [ ] **6. Time‑relative word “currently” (not timeless)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/dictionaries.mdx?plain=1#L48

The sentence “These operations … are currently untested …” uses “currently,” which the guide discourages for timelessness. Minimal fix: remove the time‑relative word: “These operations … are untested …”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17.2-timelessness

---

- [ ] **7. Overuse of bold in a single paragraph**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/dictionaries.mdx?plain=1#L18

The same list item bolds two separate proper‑name spans (“Wallet bot” and “highload‑v2 wallet”). The guide advises at most one short bold span per paragraph. Minimal fix: remove bold styling from both names (plain text) or keep one and drop the other.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.2-quotation-marks-and-emphasis

---

- [ ] **8. Missing explicit `<Aside>` type (in two places)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/dictionaries.mdx?plain=1#L46-L94

Two callouts use `<Aside>` without a `type`. To ensure consistent rendering and severity mapping, set an explicit supported type (e.g., `type="note"`). Minimal fix: add `type="note"` to both `<Aside>` instances.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11.2-how-to-write-the-callout; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#appendix-a-admonition-levels-and-usage

---

- [ ] **9. Awkward phrasing in caution example (grammar)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/dictionaries.mdx?plain=1#L18

“Each iteration’s unbounded loop and expensive dictionary updates led to gas depletion” is grammatically awkward (“each iteration’s unbounded loop”). Minimal fix: “An unbounded loop and expensive dictionary updates led to gas depletion…”. This is a grammar cleanup; it does not change meaning.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.-tone-and-clarity (clarity and concision); general grammar best practice

---

- [ ] **10. Banned term “utilize” instead of “use”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/dictionaries.mdx?plain=1#L9-L32

“Utilize” appears twice in reader-facing prose. The style guide prefers simple, clear verbs. Replace “utilize” with “use” in both locations.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#b-banned-and-preferred-terms

---

- [ ] **11. Scare quotes used for emphasis around a term**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/dictionaries.mdx?plain=1#L32

Text uses quotation marks for emphasis (“the "hash" in its name”). Quotation marks must be reserved for literal UI/log strings or actual quotations. Minimal fix: remove quotes: “Despite the hash in its name,”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#62-quotation-marks-and-emphasis

---

- [ ] **12. Bold pseudo‑heading used instead of a real heading**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/dictionaries.mdx?plain=1#L36

The line `**Available hashmap operations:**` bolds a whole sentence to label a list. Do not use bold to simulate headings. Minimal fix: convert to an H4 heading: `#### Available hashmap operations` (no trailing colon) or make the label plain text without bold.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#62-quotation-marks-and-emphasis

---

- [ ] **13. Bolded list item labels in callout**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/dictionaries.mdx?plain=1#L15

The list item label is bolded: `- **Gas consumption for updates**` (similarly for “Storage limitation”). You must not bold whole list items; use structure (headings, callouts) instead, and keep bold spans short and sparing. Minimal fix: remove bold from these labels (e.g., `- Gas consumption for updates`) or convert them into subheadings if stronger structure is needed.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **14. Acronyms not defined on first use (TON, TVM, SDK)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/dictionaries.mdx?plain=1#L9-L56

Acronyms must be expanded on first mention. Minimal fixes: at first use write “The Open Network (TON)” instead of “TON”; “TON Virtual Machine (TVM)” instead of “TVM”; and “software development kit (SDK)” instead of “SDK”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **15. Frontmatter `noindex` should be boolean, not string**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/dictionaries.mdx?plain=1#L4

`noindex` is set to a quoted string (`"true"`). Per the style guide, use supported metadata keys and set `noindex: true` (boolean) without quotes. Minimal fix: change to `noindex: true`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-2-navigation-labels; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-4-status-labels

---

- [ ] **16. Caution callout lacks required mitigation**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/dictionaries.mdx?plain=1#L11

The Caution Aside describes risks (gas exhaustion, storage limits) but does not include mitigation/rollback inside the callout. Minimal fix: add one concise mitigation sentence (e.g., “Limit dictionary updates per transaction; continue via a follow‑up message.”) or move the existing mitigation sentence from line 44 into this Aside.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#a-admonition-levels-and-usage

---

- [ ] **17. Prefer deep link to dictionary ops anchor**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/dictionaries.mdx?plain=1#L30

The reference `(see TVM instructions - Dictionary manipulation)` points to the page top instead of a specific anchor. Style prefers deep links to the exact section. Minimal fix: change the link to a specific instruction anchor (e.g., LDDICT/DICTGET); domain owner must select the canonical target.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-3-links-and-anchors