### PR TITLE
[AI] fix: global-variables.mdx

### DIFF
--- a/language/func/global-variables.mdx
+++ b/language/func/global-variables.mdx
@@ -4,14 +4,16 @@ sidebarTitle: "Global variables"
 noindex: true
 ---
 
-A FunC program primarily consists of function declarations and definitions and global variable declarations. 
+A FunC program primarily consists of function declarations and definitions and global variable declarations.
 
 **A global variable** is declared using the `global` keyword, followed by the variable's type and name. For example:
 
 Not runnable
+
 ```func
 global ((int, int) -> int) op;
 ```
+
 Here's a simple program demonstrating how to use a global functional variable:
 
 ```func
@@ -29,9 +31,8 @@ In this example, the global variable `op` is assigned the addition operator `_+_
 
 Internally, global variables in FunC are stored in the `c7` control register of the TON Virtual Machine (TVM), with a maximum of 31 variables.
 
-
-In FunC, you can _omit the type_ of a global variable. 
-In this case, the compiler determines the type based on how the variable is used. 
+In FunC, you can _omit the type_ of a global variable.
+In this case, the compiler determines the type based on how the variable is used.
 For example, you can rewrite the previous program like this:
 
 ```func
@@ -49,16 +50,19 @@ int main() {
 
 ## Declaring multiple global variables
 
-You can declare multiple global variables using a single `global` keyword. 
+You can declare multiple global variables using a single `global` keyword.
 The following examples are equivalent:
 
 Not runnable
+
 ```func
 global int A;
 global cell B;
 global C;
 ```
+
 Not runnable
+
 ```func
 global int A, cell B, C;
 ```
@@ -68,6 +72,7 @@ global int A, cell B, C;
 A local variable **cannot** have the same name as a previously declared global variable. The following example is invalid and will not compile:
 
 Not runnable
+
 ```func
 global cell C;
 
@@ -76,6 +81,7 @@ int main() {
   return C;
 }
 ```
+
 However, the following example is valid:
 
 ```func
@@ -87,6 +93,6 @@ int main() {
 }
 ```
 
-In this case, `int C = 3;` is not declaring a new local variable 
-but instead assigning the value `3` to the global variable `C`. 
+In this case, `int C = 3;` is not declaring a new local variable
+but instead assigning the value `3` to the global variable `C`.
 This behavior is explained in more detail in the section on [variable declaration](./expressions#variable-declaration).


### PR DESCRIPTION
- [ ] **1. Bold text used as headings instead of H2**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/global-variables.mdx?plain=1#L50-L64

Sections are introduced with bold text ("**Declaring multiple global variables**", "**Restrictions on global and local variable names**") rather than proper headings. Minimal fix: convert each to `##` headings (H2) in sentence case. This also ensures the first visible heading in the page is an H2. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.2-emphasis-bold-and-italics; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.1-case-and-form

---

- [ ] **2. Broken internal link and non‑relative path**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/global-variables.mdx?plain=1#L89

The link `[statements](/language/func/statements#variable-declaration)` targets a missing anchor (no `#variable-declaration` in `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/statements.mdx?plain=1`). Minimal fix: point to the canonical section and make it relative: `[variable declaration](./expressions#variable-declaration)`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16.3-links-and-anchors

---

- [ ] **3. Idiom "Under the hood" in explanatory prose**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/global-variables.mdx?plain=1#L30

"Under the hood" is an idiom; the guide requires plain, international English. Minimal fix: replace with "Internally," or rephrase to "Global variables in FunC are stored in the `c7` control register…". Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.5-global-and-inclusive-language

---

- [ ] **4. Prefer second person over "users"**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/global-variables.mdx?plain=1#L52-L53

"FunC allows users to declare…" should address the reader directly. Minimal fix: "You can declare multiple global variables using a single `global` keyword." Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#4-voice-and-tone

---

- [ ] **5. Frontmatter `noindex` should be a boolean, not a string**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/global-variables.mdx?plain=1#L4

Frontmatter shows `noindex: "true"`; the guide specifies `noindex: true`. Minimal fix: remove quotes so the value is a boolean. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16.2-navigation-labels

---

- [ ] **6. Throat‑clearing sentence in opening**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/global-variables.mdx?plain=1#L8

"This section focuses on the latter." is meta/throat‑clearing and does not aid the task. Minimal fix: remove the sentence. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **7. Missing article in phrase "assigning value `3`"**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/global-variables.mdx?plain=1#L88

Minor grammar: add the definite article for clarity. Minimal fix: change to "assigning the value `3` to the global variable `C`." This relies on general English grammar for article usage. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-grammar-and-usage

---

- [ ] **8. Acronym not expanded on first mention (TVM)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/global-variables.mdx?plain=1#L30

Uses “TVM” without expanding on first mention. Minimal fix: “...the TON Virtual Machine (TVM)...”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **9. Pleonasm “maximum limit”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/global-variables.mdx?plain=1#L30

Tautological phrasing (“maximum limit”) violates brevity. Minimal fix: “…with a maximum of 31 variables.” (or “…with a limit of 31 variables.”).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **10. Slash construction reduces clarity**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/global-variables.mdx?plain=1#L7

“function declarations/definitions” uses a slash, which can be ambiguous. Minimal fix: “function declarations and definitions”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **11. Missing article in sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/global-variables.mdx?plain=1#L33

“omit the type of global variable” is missing an article. Minimal fix: “omit the type of a global variable”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **12. Partial snippets missing “Not runnable” label**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/global-variables.mdx?plain=1

Several examples are focused excerpts and not runnable on their own (e.g., single declarations at lines 12–14 and 55–62; the intentionally invalid compile example at 68–75). Partial snippets MUST be labeled. Minimal fix: add a short line “Not runnable” above each partial snippet.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets