### PR TITLE
[AI] fix: tooling.mdx

### DIFF
--- a/language/TL-B/tooling.mdx
+++ b/language/TL-B/tooling.mdx
@@ -1,17 +1,16 @@
-title: "TL-B tooling"
----
+## title: "TL-B tooling"
 
 ## Type Language Binary (TL-B) parsers
 
 Type Language Binary (TL-B) libraries provide serializers and parsers for basic [TL-B types](syntax-and-semantics#types) and can serialize to and deserialize from the corresponding binary format.
 
-| Language   | Software Development Kit (SDK)                                          | Social                                                 |
-|------------|-------------------------------------------------------------------------|--------------------------------------------------------|
-| Kotlin     | [ton-kotlin](https://github.com/ton-community/ton-kotlin/tree/main/tlb) | [tonkotlin](https://t.me/tonkotlin)                    |
-| Go         | [tonutils](https://github.com/xssnick/tonutils-go/tree/master/tlb)      | [tonutils](https://t.me/tonutils)                      |
-| Go         | [tongo](https://github.com/tonkeeper/tongo/tree/master/tlb)             | [tongo_lib](https://t.me/tongo_lib)                    |
-| TypeScript | [tlb-parser](https://github.com/ton-community/tlb-parser)               | -                                                      |
-| Python     | [tonpy](https://github.com/disintar/tonpy)                              | [dtontech](https://t.me/dtontech)                      |
+| Language   | Software Development Kit (SDK)                                          | Social                               |
+| ---------- | ----------------------------------------------------------------------- | ------------------------------------ |
+| Kotlin     | [ton-kotlin](https://github.com/ton-community/ton-kotlin/tree/main/tlb) | [tonkotlin](https://t.me/tonkotlin)  |
+| Go         | [tonutils](https://github.com/xssnick/tonutils-go/tree/master/tlb)      | [tonutils](https://t.me/tonutils)    |
+| Go         | [tongo](https://github.com/tonkeeper/tongo/tree/master/tlb)             | [tongo\_lib](https://t.me/tongo_lib) |
+| TypeScript | [tlb-parser](https://github.com/ton-community/tlb-parser)               | -                                    |
+| Python     | [tonpy](https://github.com/disintar/tonpy)                              | [dtontech](https://t.me/dtontech)    |
 
 ## TL-B generators
 


### PR DESCRIPTION
- [ ] **1. Expand TL-B on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/tooling.mdx?plain=1#L7

“TL-B” appears without expansion on first use in body text. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms. Minimal fix: change the first sentence to “Type Language Binary (TL-B) libraries provide serializers and parsers for basic TL-B types …”.

---

- [ ] **2. Expand SDK in table header**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/tooling.mdx?plain=1#L9

The acronym “SDK” is used without being spelled out on first mention on the page. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms. Minimal fix: in the table header, replace “SDK” with “Software Development Kit (SDK)”.

---

- [ ] **3. Remove subjective adjective “convenient”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/tooling.mdx?plain=1#L25

The phrase “The convenient TL-B online editor …” uses subjective/marketing language. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles (no marketing language in technical sections). Minimal fix: remove “convenient” → “The TL-B online editor allows you to write …”.

---

- [ ] **4. Heading pluralization mismatches content**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/tooling.mdx?plain=1#L23

The heading “TL-B online editors” implies multiple editors, but the section lists only one. This reduces clarity and violates heading self-descriptiveness. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles. Minimal fix: change the heading to the singular “TL-B online editor”.

---

- [ ] **5. One-word generic title violates title semantics**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/tooling.mdx?plain=1#L2

 The frontmatter `title` is a one-word generic (“Tooling”), which is not self‑describing out of context. One‑word generic titles MUST NOT be used except on top‑level pages or when the page is a proper name/term. Minimal fix: change to a descriptive, sentence‑case title, e.g., `title: "TL-B tooling"`. If “Tooling” is intended as a proper name, state that decision explicitly; otherwise, apply the rename.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-2-navigation-labels

---

- [ ] **6. Internal link should be relative and deep-linked**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/tooling.mdx?plain=1#L7

 The link `[TL-B types](/language/TL-B/syntax-and-semantics)` uses an absolute path and points to the page top. Internal links SHOULD be relative, and cross‑section links SHOULD target specific anchors. Minimal fix: update the target to `syntax-and-semantics#types` (relative path with a deep anchor that lands on the “Types” section).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-3-links-and-anchors

---

- [ ] **7. Unexpanded acronym 'TL-B' on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/tooling.mdx?plain=1#L5

 The page uses the acronym "TL-B" without expansion at its first mention (H2 heading). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#53-acronyms-and-terms. Minimal fix: change line 5 to "Type Language Binary (TL-B) parsers". After this expansion, later uses of "TL-B" may remain as the acronym. Reference expansion for consistency: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/TL-B/overview.mdx?plain=1#L5