### PR TITLE
[AI] fix: how-to-get-wallet-data.mdx

### DIFF
--- a/standard/tokens/jettons/how-to-get-wallet-data.mdx
+++ b/standard/tokens/jettons/how-to-get-wallet-data.mdx
@@ -1,25 +1,17 @@
 ---
-title: "How to get Jetton wallet data"
-sidebarTitle: "Get Jetton wallet data"
+title: "How to get jetton wallet data"
+sidebarTitle: "Get jetton wallet data"
 ---
 
 import { Image } from '/snippets/image.jsx';
 
-To retrieve the Jetton wallet's account jetton amount, owner identification information, and other details related to a specific Jetton wallet contract,
-use the `get_wallet_data()` [get method](/guidebook/first-smart-contract#6-2-reading-contract-data-with-get-methods) within the Jetton wallet contract.
+To read a jetton wallet’s balance, owner, and related fields, call the [`get_wallet_data()`](/standard/tokens/jettons/API#get_wallet_data) [get method](guidebook/first-smart-contract#6-2-reading-contract-data-with-get-methods).
 
-This method returns the following data:
+See the [`get_wallet_data()` reference](/standard/tokens/jettons/API#get_wallet_data) for returned fields.
 
-| Name                    | Type             | Description                                    |
-| ----------------------- | ---------------- | ---------------------------------------------- |
-| `balance`               | `VarUInteger 16` | the amount of nano tokens on the Jetton wallet |
-| `owner`                 | `MsgAddress`     | the address of owner's regular wallet          |
-| `jetton_master_address` | `MsgAddress`     | the address of the Jetton master contract      |
-| `jetton_wallet_code`    | `Cell`           | a code of the Jetton wallet                    |
+You can call the `get_wallet_data()` method from your integrated development environment (IDE):
 
-You can call the `get_wallet_data()` method from your favorite IDE:
-
-```javascript
+```typescript
 import { Address, TonClient } from "@ton/ton";
 
 async function main() {
@@ -54,6 +46,8 @@ Or call it through a web service, such as [Tonviewer](https://tonviewer.com/EQDm
 <Image
   src="/resources/images/tonviewer/get-wallet-data.png"
   darkSrc="/resources/images/tonviewer/get-wallet-data-dark.png"
+  alt="Tonviewer get_wallet_data result"
+  darkAlt="Tonviewer get_wallet_data result (dark)"
 />
 
-Finally, you can get this information using the [API](https://toncenter.com/api/v3/jetton/wallets).
+Finally, you can get this information using [Toncenter](/ecosystem/rpc/toncenter) (see the [jetton wallets API](https://toncenter.com/api/v3/jetton/wallets)).


### PR DESCRIPTION
- [ ] **1. Title capitalization for generic term**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-find.mdx?plain=1#L2

The page title capitalizes a common noun mid‑sentence. Use sentence case and lowercase “jetton” per terminology. Minimal fix: change `title: "How to find Jetton wallet"` to `title: "How to find jetton wallet"`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-4-ton-specific-examples

---

- [ ] **2. Missing `sidebarTitle` for a How‑to page**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-find.mdx?plain=1#L1

How‑to pages must set a concise `sidebarTitle`. Minimal fix: add `sidebarTitle: "Find jetton wallet"` to frontmatter (keep sentence case).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-2-navigation-labels

---

- [ ] **3. Generic term casing inconsistent in body**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-find.mdx?plain=1#L5-L78

Generic concepts are capitalized mid‑sentence (e.g., “Jetton”, “Jetton Master”, “Basechain”). Use lowercase for common terms. Minimal fixes:
- L5: “Jetton Master” → “jetton master”
- L6: “Jetton” → “jetton” (twice)
- L8: “Jetton wallet” → “jetton wallet”
- L9: “Jetton master contract” → “jetton master contract”
- L34 (comment): “Jetton” → “jetton”
- L41–42: “Jetton wallet’s / Jetton wallet” → “jetton wallet’s / jetton wallet”
- L45: “Jetton wallet” → “jetton wallet”
- L78 (comment): “Basechain” → “basechain”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-4-ton-specific-examples

---

- [ ] **4. Method name formatting mixes identifier and signature**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-find.mdx?plain=1#L9

A single code span contains both the method name and parameter/type with an extra space: `` `get_wallet_address (slice owner_address)` ``. Keep identifiers exact in code font; describe parameters separately. Minimal fix: use `` `get_wallet_address` `` and mention `owner_address` (slice) in prose or separate code spans.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-3-code-styling

---

- [ ] **5. Placeholders not using required `<ANGLE_CASE>` format**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-find.mdx?plain=1#L19-L66

String literals instruct the reader instead of using placeholders (e.g., “put the Jetton master address in any format”, “an address in any format”). Minimal fix: replace with `<JETTON_MASTER_ADDR>` and `<OWNER_ADDR>` (angle‑case placeholders) and explain acceptable formats in prose if needed.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-5-placeholder-names

---

- [ ] **6. Example endpoint defaults to mainnet instead of testnet**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-find.mdx?plain=1#L16

Task pages should default to testnet and mention switching to mainnet explicitly. Minimal fix: change `https://toncenter.com/api/v2/jsonRPC` to `https://testnet.toncenter.com/api/v2/jsonRPC` and add a brief note about mainnet usage if applicable.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-3-safer-defaults

---

- [ ] **7. Admonition component uses unsupported `<Warning>` tag**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-find.mdx?plain=1#L44-L46

Safety callouts must use the `<Aside>` component with supported `type` values. Minimal fix: replace `<Warning>…</Warning>` with `<Aside type="danger">…</Aside>` to match “Warning → danger” mapping.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#19-appendices-a-admonition-levels-and-usage

---

- [ ] **8. Safety callout lacks required content fields**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-find.mdx?plain=1#L44-L46

Warning/Caution callouts must include risk, scope, rollback/mitigation, and an environment label (testnet/mainnet). The current text lacks all four. Minimal fix: add these fields, or, if not safety‑critical, downgrade to a Note. Domain owner confirmation required for precise risk/mitigation.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout

---

- [ ] **9. Typo in comment (“Thether” → “Tether”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-find.mdx?plain=1#L57

Correct the brand spelling in the comment. Minimal fix: “let’s choose Tether USDT as an example”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-6-spelling-and-contractions

---

- [ ] **10. Wordiness/grammar in opening sentences**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-find.mdx?plain=1#L5-L6

Phrasing is verbose and ungrammatical (“Some application… be able to discover…”, missing articles/commas). Use plain, precise wording and active voice. Minimal fix:
- L5: “Some applications may need to discover their own or other contract wallets for a specific jetton master.”
- L6: “For example, a contract may store its jetton wallet address for a specific jetton to handle transfer notifications in a specific way.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **11. Clarity/voice in Tonviewer instruction sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-find.mdx?plain=1#L86

Use direct, imperative phrasing. Minimal fix: “Enter the owner’s address in any format and execute the get method to obtain the jetton wallet address.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#4-voice-and-tone; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **12. Term casing inconsistency: “jetton wallet”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-find.mdx?plain=1#L6

Use the prevailing term casing “Jetton wallet” across the docs for this contract type (see https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-it-works.mdx?plain=1#jetton-wallet). Minimal fix: change “jetton wallet” → “Jetton wallet”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms.

---

- [ ] **13. Missing deep link to reference for get method**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-find.mdx?plain=1#L9

First useful mention of the get method should deep‑link to the canonical reference. Minimal fix: link `get_wallet_address` to https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/API.mdx?plain=1#get_wallet_address. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format.

---

- [ ] **14. Missing “Not runnable” label for partial snippet (snippet 1)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-find.mdx?plain=1#L11

The snippet cannot run as shown due to placeholder values; partial snippets must be labeled. Minimal fix: add a “Not runnable” line immediately above the fenced block. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets.

---

- [ ] **15. Missing articles and possessives in manual method intro**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-find.mdx?plain=1#L41

Add missing articles and correct possessives for clarity. Minimal fix: “If you are sure about the structure of the Jetton wallet’s initial persistent storage and know its code, you can manually create the Jetton wallet’s `StateInit` and calculate its address.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording.

---

- [ ] **16. Register name not in code font in Warning**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-find.mdx?plain=1#L45

Identifiers should use code formatting. Minimal fix: change “c4” → `c4` inside the admonition. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis.

---

- [ ] **17. Typo and acronym definition in comment (“Thether USDT”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-find.mdx?plain=1#L57

Correct the product name and define the acronym on first mention. Minimal fix: “Let’s choose Tether USD (USDT) as an example.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-6-spelling-and-contractions; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms.

---

- [ ] **18. Missing “Not runnable” label for partial snippet (snippet 2)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-find.mdx?plain=1#L48

The second snippet is not runnable as shown due to placeholders; label it as “Not runnable”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets.

---

- [ ] **19. Possessive agreement in “contract's get methods”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-find.mdx?plain=1#L84

Use singular possessive with an article or plural possessive. Minimal fix: “a contract’s get methods”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording. This relies on general English grammar for possessives.

---

- [ ] **20. Non‑descriptive link text (“built‑in APIs”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-find.mdx?plain=1#L90

Link text should be descriptive and match the target. Minimal fix: change “[built‑in APIs](/ecosystem/rpc/toncenter)” → “[Toncenter](/ecosystem/rpc/toncenter)”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text.

---

- [ ] **21. Title violates term casing and article usage**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-find.mdx?plain=1#L2

The page title capitalizes “Jetton,” which should be lower‑case per the term bank, and it omits the article. Minimal fix: change to `title: "How to find a jetton wallet"`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#b-banned-and-preferred-terms (TON‑specific casing)

---

- [ ] **22. Typos and casing in comments (“Thether”, “Jetton”, “Basechain”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-find.mdx?plain=1#L57-L78

Fix “Thether” → “Tether”. In comments, use lower‑case “jetton” and “basechain” per term bank. Minimal fixes:
- `// let's choose Tether USDT as an example`
- `// All jetton wallet contracts are located in basechain by default`
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-6-spelling-and-contractions (American English spelling)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#b-banned-and-preferred-terms (TON‑specific casing)

---

- [ ] **23. Undefined acronym/term “c4” in callout**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-find.mdx?plain=1#L45

Spell out or define “c4” at first mention so readers understand the constraint. If “c4” is a proper field name, keep exact casing and define it briefly; otherwise expand the term. Domain decision required for the precise definition. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **24. Inconsistent terminology: “Jetton Master” vs “Jetton master contract”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-find.mdx?plain=1#L5-L9

Use one form consistently across the page. Nearby page uses “Jetton master contract” (see https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-get-wallet-data.mdx?plain=1). Update line 5 to match that form. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **25. First mention of “get method” lacks canonical link**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-find.mdx?plain=1#L9

On first useful mention of a core term, link to the canonical reference anchor (as done on the sibling page). Link “get method” to `/guidebook/first-smart-contract#6-2-reading-contract-data-with-get-methods`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not

---

- [ ] **26. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-2-navigation-labels**

(path missing)

---

- [ ] **27. Inconsistent token name (USD vs USDT) on the same page**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-find.mdx?plain=1#L57-L88

The page mixes "Tether USDT" (comment and image alt) and "Tether USD" (link text). Minimal fix: standardize on a single form within the page, for example "Tether USDT", to keep terminology consistent.
Note: If the term bank is silent, prefer consistency with nearby pages.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-1-term-bank-canonical-source

---

- [ ] **28. Missing Aside import for callout**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-find.mdx?plain=1#L1

When switching to `<Aside>`, the component must be imported. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout (Example shows import). Minimal fix: add `import { Aside } from '/snippets/aside.jsx';` after frontmatter.

---

- [ ] **29. Avoid ambiguous “let’s”; use imperative voice**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-find.mdx?plain=1#L57

“let's choose … as an example” uses first‑person plural. Prefer direct, imperative instructions to the reader. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-voice-and-tone. Minimal fix: “Use Tether USDT as an example.”