### PR TITLE
[AI] fix: init.mdx

### DIFF
--- a/ecosystem/ton-connect/walletkit/web/init.mdx
+++ b/ecosystem/ton-connect/walletkit/web/init.mdx
@@ -20,6 +20,7 @@ Alternatively, explore the complete demo wallet with WalletKit integration:
     arrow="true"
     href="https://walletkit-demo-wallet.vercel.app"
   />
+
   <Card
     title="Demo wallet, GitHub repository"
     icon="github"
@@ -69,8 +70,10 @@ const kit = new TonWalletKit({
 
 See also: [TON Connect wallet manifest](/ecosystem/ton-connect/manifest#wallet-manifest).
 
-<Aside type="caution" title="Web only!">
-
+<Aside
+  type="caution"
+  title="Web only!"
+>
   The given example must be invoked in **browser environments only**. To run it locally with Node.js or other JavaScript (JS) runtimes, set `storage.allowMemory` to `true`. It enables a built-in storage adapter for non-browser environments which do not have `localStorage` available.
 
   ```ts
@@ -82,7 +85,6 @@ See also: [TON Connect wallet manifest](/ecosystem/ton-connect/manifest#wallet-m
   ```
 
   Remember to disable this adapter in web environments or provide a dedicated [`storage` adapter](#param-storage) wrapper to switch between environments.
-
 </Aside>
 
 ## Initialize a TON wallet
@@ -96,10 +98,12 @@ You may load or create a new TON wallet using one of these options:
     title="Create a TON wallet from a mnemonic"
     href="#create-from-a-mnemonic"
   />
+
   <Card
     title="Create a TON wallet from a private key"
     href="#create-from-a-private-key"
   />
+
   <Card
     title="Create a TON wallet with a custom signer"
     href="#create-with-a-custom-signer"
@@ -119,15 +123,16 @@ await kit.addWallet(tonWalletConfigN);
 
 To initialize a TON wallet from an existing BIP-39 or TON-specific mnemonic seed phrase, use the `createWalletInitConfigMnemonic()` function of WalletKit.
 
-<Aside type="danger">
-
+<Aside
+  type="danger"
+>
   Never specify the mnemonic phrase directly in your code. It is a password to your wallet and all its funds.
 
   Instead, prefer sourcing the seed phrase from a secure storage, backend environment variables, or a special `.env` file that is Git-ignored and handled with care.
-
 </Aside>
 
 Not runnable
+
 ```ts
 import {
   CHAIN,
@@ -166,8 +171,9 @@ const walletConfig = createWalletInitConfigMnemonic({
 const wallet = await kit.addWallet(walletConfig);
 ```
 
-<Aside type="caution">
-
+<Aside
+  type="caution"
+>
   If you don't yet have a mnemonic for an existing TON wallet or you want to create a new one, you can generate a TON-specific mnemonic with the `CreateTonMnemonic()` function. However, it's crucial to use that function only **once per wallet** and then save it securely.
 
   You **must NOT** invoke this function amidst the rest of your project code.
@@ -179,15 +185,15 @@ const wallet = await kit.addWallet(walletConfig);
 
   console.log(await CreateTonMnemonic()); // word1, word2, ..., word24
   ```
-
 </Aside>
 
 ### Create from a private key
 
-<Aside type="danger" title="Private keys are sensitive data!">
-
+<Aside
+  type="danger"
+  title="Private keys are sensitive data!"
+>
   Handle private keys carefully. Use test keys, keep them in a secure keystore, and avoid logs or commits.
-
 </Aside>
 
 To initialize a TON wallet from an existing private key, use the `createWalletInitConfigPrivateKey()` function of WalletKit.
@@ -195,6 +201,7 @@ To initialize a TON wallet from an existing private key, use the `createWalletIn
 If there is a [mnemonic](#from-mnemonic), one can convert it to an Ed25519 key pair with a public and a private key by using the `MnemonicToKeyPair()`.
 
 Not runnable
+
 ```ts
 import {
   CHAIN,
@@ -244,6 +251,7 @@ In that case, you would need to pass a public key and your custom signing functi
 This approach is useful if you want to maintain full control over the signing process, such as when using a hardware wallet or signing data on the backend.
 
 Not runnable
+
 ```ts
 import {
   CHAIN,
@@ -284,8 +292,11 @@ const wallet = await kit.addWallet(walletConfig);
 
 ### Required
 
-<ParamField path="network" type="CHAIN.TESTNET | CHAIN.MAINNET" required>
-
+<ParamField
+  path="network"
+  type="CHAIN.TESTNET | CHAIN.MAINNET"
+  required
+>
   The TON network to use.
 
   ```ts
@@ -297,11 +308,13 @@ const wallet = await kit.addWallet(walletConfig);
   // Production network of TON Blockchain. All contracts and funds are real.
   CHAIN.MAINNET; // "-239"
   ```
-
 </ParamField>
 
-<ParamField path="deviceInfo" type="DeviceInfo" required>
-
+<ParamField
+  path="deviceInfo"
+  type="DeviceInfo"
+  required
+>
   Core information and constraints of the given wallet.
 
   ```ts
@@ -358,14 +371,17 @@ const wallet = await kit.addWallet(walletConfig);
   The `maxMessages` number depends on the TON wallet used, because different kinds can handle different number of messages.
 
   For example,
+
   - Ledger wallet would only handle 1 message per transaction
   - Wallet `v4r2` handles up to 4 messages
   - Wallet `v5r1` handles up to 255 messages
-
 </ParamField>
 
-<ParamField path="walletManifest" type="WalletInfo" required>
-
+<ParamField
+  path="walletManifest"
+  type="WalletInfo"
+  required
+>
   How your wallet interacts with the TON Connect. This field is closely related to the [corresponding JSON manifest file](/ecosystem/ton-connect/manifest#wallet-manifest).
 
   ```ts expandable
@@ -438,13 +454,14 @@ const wallet = await kit.addWallet(walletConfig);
     embedded: boolean;
   }
   ```
-
 </ParamField>
 
 ### Optional
 
-<ParamField path="apiClient" type="object | ApiClient">
-
+<ParamField
+  path="apiClient"
+  type="object | ApiClient"
+>
   Which API or RPC provider to use to interact with TON Blockchain.
 
   ```ts
@@ -458,11 +475,12 @@ const wallet = await kit.addWallet(walletConfig);
   }
   // Or a complete ApiClient interface implementation.
   ```
-
 </ParamField>
 
-<ParamField path="bridge" type="BridgeConfig">
-
+<ParamField
+  path="bridge"
+  type="BridgeConfig"
+>
   Connectivity options: either an HTTP or JavaScript bridge setup. The former's `bridgeUrl` points to the publicly exposed bridge URL, while the latter's `jsBridgeKey` points to the property name within the `window` object on the same web page.
 
   ```ts
@@ -482,11 +500,12 @@ const wallet = await kit.addWallet(walletConfig);
     maxReconnectAttempts?: number;
   }
   ```
-
 </ParamField>
 
-<ParamField path="storage" type="object | StorageAdapter">
-
+<ParamField
+  path="storage"
+  type="object | StorageAdapter"
+>
   How to store intermediate events.
 
   ```ts
@@ -499,11 +518,12 @@ const wallet = await kit.addWallet(walletConfig);
   }
   // Or a complete StorageAdapter interface implementation.
   ```
-
 </ParamField>
 
-<ParamField path="validation" type="object">
-
+<ParamField
+  path="validation"
+  type="object"
+>
   Strictness and wallet checks.
 
   ```ts
@@ -512,11 +532,12 @@ const wallet = await kit.addWallet(walletConfig);
     allowUnknownWalletVersions?: boolean,
   }
   ```
-
 </ParamField>
 
-<ParamField path="eventProcessor" type="EventProcessorConfig">
-
+<ParamField
+  path="eventProcessor"
+  type="EventProcessorConfig"
+>
   How TON Connect events are processed.
 
   ```ts
@@ -524,11 +545,12 @@ const wallet = await kit.addWallet(walletConfig);
     disableEvents?: boolean;
   }
   ```
-
 </ParamField>
 
-<ParamField path="analytics" type="AnalyticsConfig">
-
+<ParamField
+  path="analytics"
+  type="AnalyticsConfig"
+>
   Collect analytical data.
 
   ```ts
@@ -539,7 +561,6 @@ const wallet = await kit.addWallet(walletConfig);
     endpoint?: string;
   }
   ```
-
 </ParamField>
 
 ## Next steps
@@ -556,12 +577,14 @@ const wallet = await kit.addWallet(walletConfig);
     title="WalletKit overview"
     href="/ecosystem/ton-connect/walletkit"
   />
+
   <Card
     title="TON Connect wallet manifest"
     href="/ecosystem/ton-connect/manifest#wallet-manifest"
   />
+
   <Card
     title="TON Connect overview"
     href="/ecosystem/ton-connect"
   />
- </Columns>
+</Columns>


### PR DESCRIPTION
- [ ] **1. Title uses possessive and non-canonical naming**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/web/init.mdx?plain=1#L2

The frontmatter title uses “TON Connect's WalletKit”, which is inconsistent with usage elsewhere (use “TON Connect WalletKit” without a possessive). Minimal fix: “How to initialize TON Connect WalletKit on the web platform”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **2. Title capitalizes “Web” — should be sentence case**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/web/init.mdx?plain=1#L2

Headings and titles must use sentence case. Change “Web platform” to “web platform”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles

---

- [ ] **3. H2 “Initialization” should be imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/web/init.mdx?plain=1#L31

Task/procedure headings must start with an imperative verb. Replace “Initialization” with “Initialize WalletKit” (or “Initialize the kit” to mirror the sidebar).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles

---

- [ ] **4. H2 “TON wallet initialization” should be imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/web/init.mdx?plain=1#L88

Use an imperative task heading. Minimal fix: “Initialize a TON wallet”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles

---

- [ ] **5. H3 subsection headings are not imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/web/init.mdx?plain=1#L118-L236

“From mnemonic”, “From private key”, and “From signer” are prepositional phrases. Use imperative forms such as “Create from a mnemonic”, “Create from a private key”, and “Create with a custom signer”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles

---

- [ ] **6. Quotation marks used for emphasis**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/web/init.mdx?plain=1#L124

Quotes must be reserved for literal UI/log strings, not emphasis. Change “It is a "password" to your wallet…” to “It is a password to your wallet…”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **7. Missing Oxford comma in a three-item list (comment)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/web/init.mdx?plain=1#L291-L294

Use the serial comma: “For experiments, beta tests, and feature previews.” (Applies inside comments as user-facing prose.)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **8. Acronym casing “URL” in prose and field docs**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/web/init.mdx?plain=1#L65-L416

Use standard acronym casing. Replace “url/Url” with “URL” (e.g., “its icon image URL”; “URL to the icon of the wallet”; “universal URL”; “deep link URL”; “URL of the wallet’s HTTP bridge”).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **9. Placeholder uses “...” instead of angle-case placeholder**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/web/init.mdx?plain=1#L254

Placeholders must use <ANGLE_CASE> and be defined on first use. Replace `publicKey: "..." as Hash` with `publicKey: "<PUBLIC_KEY_HEX>" as Hash` and add a one-line definition above the block.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **10. Partial snippets not labeled “Not runnable”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/web/init.mdx?plain=1#L136-L278

These code blocks depend on prior context (e.g., `kit`) and environment variables, so they are partial. Label them “Not runnable” per the rule or provide a complete runnable example. Minimal fix: add a “Not runnable” label above each affected block.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **11. Article before “Uint8Array”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/web/init.mdx?plain=1#L240-L242

Grammar: use “a Uint8Array” (pronounced “yoo‑nit…”), not “an Uint8Array”. Minimal fix: “produce a Uint8Array signature.” This relies on general English grammar.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **12. Self-referential “Next steps” link**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/web/init.mdx?plain=1#L545-L548

Card title says “Handle connection requests” but `href` points back to this same page. Update `href` to the correct target (precise page/anchor). If the target page does not exist yet, remove the card until it does. Domain decision required.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format

---

- [ ] **13. Uncertain internal anchor “#param-storage”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/web/init.mdx?plain=1#L84

The link references `#param-storage`, but the page does not expose a visible anchor with that exact ID. Confirm the generated anchor for `<ParamField path="storage" …>` and update the link to the precise, resolving anchor. Domain decision required.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format

---

- [ ] **14. Overlong reference blocks in a how‑to page**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/web/init.mdx?plain=1#L300-L520(representative ranges)

How‑to pages should not duplicate reference tables/interfaces. Replace long interface definitions (e.g., `DeviceInfo`, `Feature`, `WalletInfo`, `BridgeConfig`) with brief summaries and deep links to canonical reference anchors. If the canonical reference is not yet published, note the exception and plan to migrate once available. Domain decision required.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-1-sidebar-groups-and-ordering

---

- [ ] **15. Possessive in link text “TON Connect's wallet manifest”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/web/init.mdx?plain=1#L70-L559

Use the non‑possessive form for canonical names: “TON Connect wallet manifest”. Update both the inline “See also” link and the card title for consistency.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **16. Term casing: use “dApp”, not “dapp”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/web/init.mdx?plain=1#L433

This page uses "dapp" while other TON Connect pages use "dApp" (for example, https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/manifest.mdx?plain=1#L10). Prefer consistent terminology. Minimal fix: change "dapp" → "dApp" where referring to decentralized application. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules

---

- [ ] **17. Safety callouts missing required elements**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/web/init.mdx?plain=1#L122

The Warning about mnemonic handling lacks the required elements (explicit risk, scope, rollback/mitigation, and environment label). Minimal fix: expand the `<Aside type="danger">` to specify (a) risk: funds theft if exposed, (b) scope: this wallet instance/keys, (c) mitigation: store in secure secrets manager and rotate/revoke as needed, (d) environment label: prefer testnet for examples. Apply similarly to the private key Warning at line 186. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout; Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-1-when-a-safety-callout-is-required

---

- [ ] **18. Tautology in analytics description**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/web/init.mdx?plain=1#L529

“Collect and gather analytical data.” duplicates meaning. Minimal fix: “Collect analytical data.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **19. External links should prefer internal docs and stable targets**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/web/init.mdx?plain=1#L406

Links in code comments point to GitHub `main` branch and to a non-preferred repo path; prefer internal docs when available and use stable/permalinked targets for normative references. Minimal fix: link an internal page covering the Bridge API, or pin to a versioned/permalinked commit URL. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references

---

- [ ] **20. Wordy opening; collapse boilerplate**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/web/init.mdx?plain=1#L33

The sentence is verbose and indirect: “The basic kit initialization consists of creating a corresponding object by passing it a minimal set of necessary arguments.” Minimal fix: “Initialize the kit by creating a `TonWalletKit` with the required arguments: choose a network, set device info, and a wallet manifest.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references; Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **21. Command fence language tag should be bash**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/web/init.mdx?plain=1#L10-L12

For shell commands, prefer `bash` for correct highlighting/tooling. Change the code fence from `shell` to `bash`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **22. Sidebar label does not follow How‑to pattern and uses ambiguous “kit”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/web/init.mdx?plain=1#L3

How‑to pages must set `sidebarTitle: "X"` where X mirrors the task and uses correct product naming. “Initialize the kit” is ambiguous and downgrades the proper noun. Minimal fix: sidebarTitle: "Initialize WalletKit on the web" (≤ 30 chars and mirrors the title). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-2-navigation-labels

---

- [ ] **23. Title likely exceeds practical length norm**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/web/init.mdx?plain=1#L2

The page title appears to exceed the ~60‑character norm, which harms scannability. Minimal fix: shorten to "How to initialize WalletKit on the web" while preserving meaning. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-5-practical-length-norms

---

- [ ] **24. Non‑canonical possessive “TON Connect's” in body text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/web/init.mdx?plain=1#L8-L557

Use the canonical term without possessive. Minimal fixes:
- L8: “Before initializing TON Connect WalletKit, …”
- L62: “Specify the TON Connect wallet manifest.”
- L70: “See also: TON Connect wallet manifest” (link text)
- L557: Card title: “TON Connect wallet manifest”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **25. Grammar: article usage in key pair sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/web/init.mdx?plain=1#L194

“with public and private key” should include both articles. Minimal fix: “with a public and a private key”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording (clarity); relied on general grammar norms.

---

- [ ] **26. Use “web page” (two words), not “webpage”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/web/init.mdx?plain=1#L428

Prefer standard form for clarity and consistency with nearby pages (e.g., https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/manifest.mdx?plain=1 uses “web page”). Minimal fix: “web page”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording; evidence: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/manifest.mdx?plain=1#L123

---

- [ ] **27. Undefined acronym on first use (“JS runtimes”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/web/init.mdx?plain=1#L74

Spell out the term on first mention, then use the acronym. Minimal fix: “JavaScript (JS) runtimes”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **28. Proper noun capitalization (“Ledger wallet”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/web/init.mdx?plain=1#L337

“ledger wallet” should capitalize the brand name for consistency with later bullets (L358). Minimal fix: “Ledger wallet would only handle 1 message per transaction”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms (terminology discipline)