### PR TITLE
[AI] fix: how-to-deploy.mdx

### DIFF
--- a/standard/tokens/jettons/mintless/how-to-deploy.mdx
+++ b/standard/tokens/jettons/mintless/how-to-deploy.mdx
@@ -1,21 +1,25 @@
 ---
-title: "How to deploy mintless Jetton"
-sidebarTitle: "Deploy mintless Jetton"
+title: "How to deploy Mintless Jetton"
+sidebarTitle: "Deploy Mintless Jetton"
 ---
 
 import { Aside } from "/snippets/aside.jsx"
 
-## Introduction
-
-Mintless jettons represent a revolutionary approach to token distribution on the TON blockchain. This guide provides a comprehensive walkthrough for deploying mintless jettons, from initial setup to production deployment and ongoing maintenance.
-
-<Aside>
-  Before deploying a mintless jetton, ensure you understand the [basic concepts](/standard/tokens/jettons/mintless) and have experience with standard jetton deployment.
+<Aside type="danger" title="Warning — funds at risk">
+  Deploying contracts and sending on-chain messages can move funds and create irreversible state. Validate each step, understand scope and rollback limits, and use testnet before mainnet deployment.
 </Aside>
 
-**Prerequisites**
+## Goal
 
-Before starting the deployment process, ensure you have:
+Mintless jettons are a token distribution method on The Open Network (TON) blockchain. This guide provides a walkthrough for deploying mintless jettons, from initial setup to production deployment and ongoing maintenance.
+
+<Aside>
+  Before deploying a mintless jetton, ensure you understand the [Mintless Jetton overview](./overview) and have experience with standard jetton deployment.
+</Aside>
+
+## Prerequisites
+
+You need:
 
 - A TON wallet with sufficient funds for deployment
 - Understanding of Merkle trees and cryptographic proofs
@@ -23,23 +27,23 @@ Before starting the deployment process, ensure you have:
 - List of airdrop recipients with their allocated amounts
 - Development environment set up for TON smart contracts
 
-## Step-by-Step Deployment Guide
+## Step-by-step deployment guide
 
 Deploying a mintless jetton involves several critical steps:
 
-### 1. Prepare the Merkle Tree
+### 1. Prepare the Merkle tree
 
 The foundation of any mintless jetton is a properly constructed Merkle tree containing all airdrop data.
 
-#### Data Collection
+#### Data collection
 
 - **Compile recipient list**: Gather all wallet addresses eligible for the airdrop
 - **Determine allocations**: Assign token amounts to each recipient based on your distribution criteria
 - **Set time constraints**: Define `start_from` and `expired_at` timestamps for claim availability
 
-#### Tree Generation Process
+#### Tree generation process
 
-```
+```text
 AirdropItem Structure:
 - amount: Coins (allocated tokens)
 - start_from: uint48 (Unix timestamp for claim start)
@@ -50,61 +54,61 @@ AirdropItem Structure:
 - Each leaf contains an `AirdropItem` with amount, start time, and expiry
 - Compute the root `merkle_hash` that will be stored on-chain
 
-#### Best Practices
+#### Best practices
 
 - **Validate addresses**: Ensure all recipient addresses are valid TON addresses
 - **Check allocations**: Verify total allocation doesn't exceed intended supply
 - **Test tree generation**: Use small datasets first to validate your tree construction process
 
-### 2. Deploy the Jetton Master Contract
+### 2. Deploy the Jetton master contract
 
 The jetton master contract must be extended to support mintless functionality.
 
-#### Contract Requirements
+#### Contract requirements
 
 - Include the `merkle_hash` in the contract's storage
 - Implement the `get_mintless_airdrop_hashmap_root` get-method
-- Ensure compatibility with [TEP-177](https://github.com/ton-blockchain/TEPs/pull/177) standard
+- Ensure compatibility with the [Mintless Jetton overview](/standard/tokens/jettons/mintless/overview) and [TEP-177](https://github.com/ton-blockchain/TEPs/pull/177) standard
 - Use the [mintless jetton standard implementation](https://github.com/ton-community/mintless-jetton) as reference
 
-#### Storage Extensions
+#### Storage extensions
 
-```
+```text
 Standard jetton storage + {
   merkle_hash: uint256  // Root hash of the Merkle tree
 }
 ```
 
-#### Deployment Checklist
+#### Deployment checklist
 
-- [ ] Contract includes merkle\_hash in storage
+- [ ] Contract includes `merkle_hash` in storage
 - [ ] All standard jetton methods are implemented
 - [ ] Mintless-specific get-methods are available
 - [ ] Contract has been thoroughly tested
 - [ ] Deployment transaction has sufficient gas
 
-### 3. Set Up Off-Chain Infrastructure
+### 3. Set up off-chain infrastructure
 
 Mintless jettons require robust off-chain infrastructure to serve Merkle proofs and tree data.
 
-#### Merkle Tree Hosting
+#### Merkle tree hosting
 
 - **Storage options**: TON Storage, IPFS, AWS S3, or other reliable hosting
-- **File format**: Store complete tree as BoC (Bag of Cells) file
+- **File format**: Store complete tree as BoC (bag of cells) file
 - **Accessibility**: Ensure high availability and fast access times
 - **Redundancy**: Consider multiple hosting locations for reliability
 
-#### Custom Payload API Implementation
+#### Custom payload API implementation
 
-Implement an API endpoint that provides:
+Implement an application programming interface (API) endpoint that provides:
 
 - Individual Merkle proofs for specific addresses
 - Initialization data for jetton wallet deployment
 - Verification of claim eligibility
 
-**API Endpoints:**
+##### API endpoints
 
-```
+```text
 GET /api/v1/proof/{address}
 Response: {
   "proof": "base64_encoded_merkle_proof",
@@ -115,19 +119,21 @@ Response: {
 }
 ```
 
-#### Performance Considerations
+<small><ADDRESS> — target TON account address.</small>
+
+#### Performance considerations
 
 - **Caching**: Implement aggressive caching for frequently requested proofs
-- **Load balancing**: Use CDN or load balancers for high-traffic scenarios
+- **Load balancing**: Use content delivery network (CDN) or load balancers for high-traffic scenarios
 - **Rate limiting**: Protect against abuse while ensuring legitimate access
 
-### 4. Configure Metadata
+### 4. Configure metadata
 
 Update your jetton's metadata to include mintless-specific fields.
 
-#### Required Metadata Fields
+#### Required metadata fields
 
-According to the [metadata standard](https://github.com/ton-blockchain/TEPs/blob/master/text/0064-token-data-standard.md):
+According to the [metadata standard](/standard/tokens/metadata):
 
 ```json
 {
@@ -141,14 +147,14 @@ According to the [metadata standard](https://github.com/ton-blockchain/TEPs/blob
 }
 ```
 
-#### Key Considerations
+#### Key considerations
 
-- **mintless\_merkle\_dump\_uri**: Direct link to the complete Merkle tree data
-- **custom\_payload\_api\_uri**: Base URL for the custom payload API
+- `mintless_merkle_dump_uri`: Direct link to the complete Merkle tree data
+- `custom_payload_api_uri`: Base URL for the custom payload API
 - **Hosting reliability**: Ensure these URIs remain accessible long-term
 - **HTTPS requirement**: Use secure connections for all external resources
 
-## Development Tools and Utilities
+## Development tools and utilities
 
 Several specialized tools can assist with mintless jetton development and auditing.
 
@@ -156,7 +162,7 @@ Several specialized tools can assist with mintless jetton development and auditi
 
 Official utility from the TON blockchain core team for Merkle proof generation and verification.
 
-#### Installation
+#### Installation (TON Core)
 
 1. **Clone and build**:
 
@@ -171,9 +177,9 @@ make mintless-proof-generator
 
 The compiled utility is located at `build/crypto/mintless-proof-generator`.
 
-#### Usage
+#### Usage (TON Core)
 
-**Parse and verify Merkle tree:**
+#### Parse and verify Merkle tree
 
 ```bash
 build/crypto/mintless-proof-generator parse <input-boc> <output-file>
@@ -185,7 +191,11 @@ This command:
 - Stores the airdrop list in `<output-file>`
 - Format: `<address> <amount> <start_from> <expired_at>` (one per line)
 
-**Generate all Merkle proofs:**
+<small>
+  <input-boc> — path to the input BoC file; <output-file> — path to the output file.
+</small>
+
+#### Generate all Merkle proofs
 
 ```bash
 build/crypto/mintless-proof-generator make_all_proofs <input-boc> <output-file>
@@ -197,7 +207,7 @@ Use this for creating the complete proof set needed for `custom_payload_api_uri`
 
 Community-developed utility from the Tonkeeper team with additional features.
 
-#### Installation
+#### Installation (Tonkeeper)
 
 ```bash
 git clone https://github.com/tonkeeper/mintless-toolbox.git
@@ -205,9 +215,9 @@ cd mintless-toolbox
 make
 ```
 
-#### Usage
+#### Usage (Tonkeeper)
 
-**Dump airdrop data:**
+#### Dump airdrop data
 
 ```bash
 ./bin/mintless-cli dump <airdrop-filename>
@@ -218,3 +228,7 @@ This utility:
 - Reads airdrop files in various formats
 - Outputs data in CSV format: `address,amount,start_from,expired_at`
 - Provides additional validation and formatting options
+
+<small>
+  <airdrop-filename> — path to the airdrop file.
+</small>


### PR DESCRIPTION
- [ ] **1. Avoid generic “Introduction” heading; use task-specific label**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/how-to-deploy.mdx?plain=1#L8

“Introduction” is discouraged; headings should be unique and descriptive. For how‑to pages, prefer specific labels like “Goal” or “Overview.” Replace `## Introduction` with `## Goal` (or `## Overview`).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.3-uniqueness-and-linkability; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#9.2-how-to-guides-goal-oriented-procedures

---

- [ ] **2. Replace bold “Prerequisites” label with a proper heading**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/how-to-deploy.mdx?plain=1#L16

Use structure (headings) instead of bold for section labels. Change `**Prerequisites**` to a heading `## Prerequisites` to match the recommended how‑to structure.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.2-quotation-marks-and-emphasis; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#9.2-how-to-guides-goal-oriented-procedures

---

- [ ] **3. Heading uses Title Case; enforce sentence case**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/how-to-deploy.mdx?plain=1#L26

Headings must use sentence case. Change `## Step-by-Step Deployment Guide` to `## Step-by-step deployment guide`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.1-case-and-form

---

- [ ] **4. Heading capitalization: “Merkle Tree” → “Merkle tree”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/how-to-deploy.mdx?plain=1#L30

Apply sentence case in headings. Change `### 1. Prepare the Merkle Tree` to `### 1. Prepare the Merkle tree`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.1-case-and-form

---

- [ ] **5. Heading capitalization: “Data Collection” → “Data collection”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/how-to-deploy.mdx?plain=1#L34

Apply sentence case in headings. Change `#### Data Collection` to `#### Data collection`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.1-case-and-form

---

- [ ] **6. Heading capitalization: “Tree Generation Process” → “Tree generation process”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/how-to-deploy.mdx?plain=1#L40

Apply sentence case in headings. Change `#### Tree Generation Process` to `#### Tree generation process`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.1-case-and-form

---

- [ ] **7. Heading capitalization: “Best Practices” → “Best practices”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/how-to-deploy.mdx?plain=1#L53

Apply sentence case in headings. Change `#### Best Practices` to `#### Best practices`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.1-case-and-form

---

- [ ] **8. Heading capitalization: “Jetton Master Contract” → sentence case**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/how-to-deploy.mdx?plain=1#L59

Use sentence case with proper nouns only. Change `### 2. Deploy the Jetton Master Contract` to `### 2. Deploy the Jetton master contract`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.1-case-and-form

---

- [ ] **9. Multiple headings in Title Case; convert to sentence case**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/how-to-deploy.mdx?plain=1#L63-L151

Convert the following to sentence case:
- `#### Contract Requirements` → `#### Contract requirements`
- `#### Storage Extensions` → `#### Storage extensions`
- `#### Deployment Checklist` → `#### Deployment checklist`
- `### 3. Set Up Off-Chain Infrastructure` → `### 3. Set up off-chain infrastructure`
- `#### Merkle Tree Hosting` → `#### Merkle tree hosting`
- `#### Custom Payload API Implementation` → `#### Custom payload API implementation`
- `#### Performance Considerations` → `#### Performance considerations`
- `### 4. Configure Metadata` → `### 4. Configure metadata`
- `#### Required Metadata Fields` → `#### Required metadata fields`
- `#### Key Considerations` → `#### Key considerations`
- `## Development Tools and Utilities` → `## Development tools and utilities`
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.1-case-and-form

---

- [ ] **10. Duplicate H4 headings; make them unique and linkable**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/how-to-deploy.mdx?plain=1#L159-L208

Avoid repeated headings at the same nesting level to improve TOC/linkability. Rename to be specific:
- `#### Installation` (TON Core section) → `#### Installation (TON Core)`
- `#### Usage` (TON Core section) → `#### Usage (TON Core)`
- `#### Installation` (Tonkeeper section) → `#### Installation (Tonkeeper)`
- `#### Usage` (Tonkeeper section) → `#### Usage (Tonkeeper)`
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.3-uniqueness-and-linkability

---

- [ ] **11. Missing language tags on fenced code blocks**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/how-to-deploy.mdx?plain=1#L42-L107

All fenced blocks must specify a language. Add language tags:
- At 42–47, use ` ```text ` for the AirdropItem structure.
- At 72–76, use ` ```text ` for the storage schema.
- At 107–116, use ` ```text ` for the mixed endpoint/response example (or split into `http` + `json`).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10.1-general-rules

---

- [ ] **12. Placeholder style in commands must use <ANGLE_CASE> and be defined**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/how-to-deploy.mdx?plain=1#L179-L213

Placeholders in commands must use `<ANGLE_CASE>` and be defined on first use. Update and define:
- `parse <input-boc> <output-file>` → `parse <INPUT_BOC> <OUTPUT_FILE>`; then add definitions: `<INPUT_BOC>` — path to the input BoC file; `<OUTPUT_FILE>` — path to the output file.
- `make_all_proofs <input-boc> <output-file>` → `make_all_proofs <INPUT_BOC> <OUTPUT_FILE>`; definitions as above.
- `./bin/mintless-cli dump <airdrop-filename>` → `./bin/mintless-cli dump <AIRDROP_FILENAME>`; then define `<AIRDROP_FILENAME>` — path to the airdrop file.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10.1-general-rules

---

- [ ] **13. Acronyms not expanded on first mention (TON, API, CDN)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/how-to-deploy.mdx?plain=1#L10-L121

Spell out on first use, then use the acronym. Examples:
- Line 10: “TON blockchain” → “The Open Network (TON) blockchain”.
- Line 99: “API endpoint” → “application programming interface (API) endpoint”.
- Line 121: “CDN” → “content delivery network (CDN)”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms

---

- [ ] **14. Marketing/subjective phrasing in technical introduction**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/how-to-deploy.mdx?plain=1#L10

Technical sections must avoid marketing language. Replace “represent a revolutionary approach” and “comprehensive walkthrough” with neutral, task‑focused wording (e.g., “are a token distribution method” and “this guide provides a walkthrough”).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles-reader-first-answer-first

---

- [ ] **15. Code token not formatted as code in checklist**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/how-to-deploy.mdx?plain=1#L80

Tokens/identifiers must use code formatting. Change `merkle\_hash` to `` `merkle_hash` `` (no escape needed inside code font).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.3-code-styling

---

- [ ] **16. Internal link should be relative and target a stable page**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/how-to-deploy.mdx?plain=1#L13

Internal links should be relative and point to the specific page. Change `[basic concepts](/standard/tokens/jettons/mintless)` to `[basic concepts](./overview)` to link directly to the overview page within the same folder.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16.3-links-and-anchors

---

- [ ] **17. Prefer a heading over bold label for “API Endpoints”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/how-to-deploy.mdx?plain=1#L105

Use structure instead of emphasis for section labels. Replace `**API Endpoints:**` with a heading `#### API endpoints`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.2-quotation-marks-and-emphasis; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.1-case-and-form

---

- [ ] **18. Placeholder style must use <ANGLE_CASE> and be defined on first use**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/how-to-deploy.mdx?plain=1#L107-L212

The endpoint uses "{address}"; placeholders must use angle brackets. Change to "GET /api/v1/proof/<ADDRESS>" and add a short definition (e.g., "<ADDRESS> — target TON account address") immediately after the block. Also define placeholders used in commands on first use: "<input-boc>", "<output-file>" (after line 178), and "<airdrop-filename>" (after line 212). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#severity-model-release-blocking; Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#101-general-rules.

---

- [ ] **19. Convert bold labels to subheadings (prefer structure over emphasis)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/how-to-deploy.mdx?plain=1#L105-L210

Bold label lines with colons should be headings for navigability and consistency. Minimal fixes:
- 105: "**API Endpoints:**" → "##### API endpoints"
- 176: "**Parse and verify Merkle tree:**" → "#### Parse and verify Merkle tree"
- 188: "**Generate all Merkle proofs:**" → "#### Generate all Merkle proofs"
- 210: "**Dump airdrop data:**" → "#### Dump airdrop data"
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#62-quotation-marks-and-emphasis; Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#71-case-and-form.

---

- [ ] **20. How‑to frontmatter titles must use sentence case**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/how-to-deploy.mdx?plain=1#L2-L3

For How‑to pages, set `title: "How to X"` and `sidebarTitle: "X"`, where X is sentence case. Change to `title: "How to deploy mintless jetton"` and `sidebarTitle: "Deploy mintless jetton"` (unless "Jetton" is a proper noun here, but usage across pages favors lowercase). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#162-navigation-labels.

---

- [ ] **21. Field names bolded instead of code font**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/how-to-deploy.mdx?plain=1

Tokens/identifiers must not be bolded. Minimal fix in “Key considerations”: use code font for field names: `mintless_merkle_dump_uri`, `custom_payload_api_uri`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **22. Acronym order reversed: “BoC (Bag of Cells)”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/how-to-deploy.mdx?plain=1

On first mention, spell out the term, then the acronym in parentheses. Minimal fix: “Bag of Cells (BoC) file”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **23. Casing of “bag of cells” expansion**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/how-to-deploy.mdx?plain=1#L93

Use the project’s preferred casing: “bag of cells” with lowercase words; “BoC” is uppercase. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#b-banned-and-preferred-terms (TON‑specific casing). Minimal fix: `BoC (bag of cells) file`.

---

- [ ] **24. Missing safety warning callout for funds/chain operations**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/how-to-deploy.mdx?plain=1#L6

Procedures that deploy contracts and send on‑chain messages can move funds and create irreversible state and require a Warning callout. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-safety-critical-content-blockchain-specific and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#a-admonition-levels-and-usage. Minimal fix: add an `<Aside type="danger" title="Warning — funds at risk">` at the top, modeled on https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-mint.mdx?plain=1#L7–15, noting scope, rollback limits, and advising testnet first.

---

- [ ] **25. External link used where internal page exists (metadata standard)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/how-to-deploy.mdx?plain=1#L130

Prefer internal docs when available. Replace the external TEP link with the internal metadata page. Minimal fix: change link target to `/standard/tokens/metadata` (TEP link may remain as a secondary reference if necessary).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-links-and-cross-references

---

- [ ] **26. Throat‑clearing before the prerequisites list**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/how-to-deploy.mdx?plain=1#L18

“Before starting the deployment process, ensure you have:” is wordy throat‑clearing. Minimal fix: change to “You need:”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **27. Prefer internal link before external TEP**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/how-to-deploy.mdx?plain=1#L67

When an internal docs page exists, link it first. Minimal fix: add an internal link to the Mintless Jetton overview alongside the TEP reference (e.g., “Ensure compatibility with the [Mintless Jetton overview](/standard/tokens/jettons/mintless/overview) and [TEP‑177](https://github.com/ton-blockchain/TEPs/pull/177)”). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not

---

- [ ] **28. Link text is non‑descriptive (“basic concepts”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/how-to-deploy.mdx?plain=1#L13

Link text must be descriptive and meaningful out of context. Minimal fix: change `[basic concepts](/standard/tokens/jettons/mintless)` to `[Mintless Jetton overview](/standard/tokens/jettons/mintless/overview)`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text

---

- [ ] **29. Frontmatter title/sidebar casing and term consistency**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/how-to-deploy.mdx?plain=1#L2

The page title should use sentence case and preserve proper nouns. Use the canonical form “Mintless Jetton” as in the overview. Minimal fix: change `title: "How to deploy mintless Jetton"` to `title: "How to deploy Mintless Jetton"` and `sidebarTitle: "Deploy mintless Jetton"` (line 3) to `sidebarTitle: "Deploy Mintless Jetton"`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-1-how-to-frontmatter-pattern