### PR TITLE
[AI] fix: setup-mylocalton.mdx

### DIFF
--- a/ecosystem/node/setup-mylocalton.mdx
+++ b/ecosystem/node/setup-mylocalton.mdx
@@ -1,7 +1,7 @@
 title: "How to set up a local blockchain using MyLocalTon"
 sidebarTitle: "Set up local blockchain"
 description: "Install MyLocalTon to spin up a self-contained TON network for development and testing."
----
+------------------------------------------------------------------------------------------------------
 
 import { Aside } from "/snippets/aside.jsx";
 
@@ -53,15 +53,15 @@ java -jar MyLocalTon-x86-64.jar
 
 Useful arguments:
 
-| Flag                     | Description                                                   |
-| ------------------------ | ------------------------------------------------------------- |
-| `nogui`                  | Run in headless mode without the Swing interface.             |
-| `with-validators=<VALIDATOR_COUNT>`    | Start `VALIDATOR_COUNT` validator instances (default: 1).                   |
-| `explorer`               | Launch the bundled block explorer.                            |
-| `ton-http-api`           | Start the HTTP API bridge (requires Python + `ton-http-api`). |
-| `custom-binaries=<BINARIES_DIR>` | Load TON binaries from a custom directory.                    |
-| `ip.addr.<IP_ADDR>`            | Bind services to a specific local IP.                         |
-| `debug`                  | Increase log verbosity for troubleshooting.                   |
+| Flag                                | Description                                                   |
+| ----------------------------------- | ------------------------------------------------------------- |
+| `nogui`                             | Run in headless mode without the Swing interface.             |
+| `with-validators=<VALIDATOR_COUNT>` | Start `VALIDATOR_COUNT` validator instances (default: 1).     |
+| `explorer`                          | Launch the bundled block explorer.                            |
+| `ton-http-api`                      | Start the HTTP API bridge (requires Python + `ton-http-api`). |
+| `custom-binaries=<BINARIES_DIR>`    | Load TON binaries from a custom directory.                    |
+| `ip.addr.<IP_ADDR>`                 | Bind services to a specific local IP.                         |
+| `debug`                             | Increase log verbosity for troubleshooting.                   |
 
 Placeholders: `<VALIDATOR_COUNT>` — number of validators to start; `<BINARIES_DIR>` — directory containing TON binaries; `<IP_ADDR>` — local IP address to bind.
 
@@ -115,17 +115,20 @@ The bridge exposes Representational State Transfer (REST) endpoints that mirror 
 - Re-run with `debug` when reproducing issues.
 - Upgrade by downloading the latest JAR, replacing the existing file, and deleting the `myLocalTon` directory so the genesis state regenerates.
 
-<Aside type="caution" title="Local data will be removed">
-Deleting the `myLocalTon` directory resets the local chain state in your local workspace. This action cannot be undone (no rollback) and applies only to local or development environments.
+<Aside
+  type="caution"
+  title="Local data will be removed"
+>
+  Deleting the `myLocalTon` directory resets the local chain state in your local workspace. This action cannot be undone (no rollback) and applies only to local or development environments.
 </Aside>
 
 ## Troubleshoot
 
-| Symptom            | Resolution                                                                                                             |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| Symptom            | Resolution                                                                                                                                                                          |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | JAR fails to start | Verify Java 21+ is installed and the file is not quarantined by the OS (macOS: `xattr -d com.apple.quarantine <JAR>`; replace `<JAR>` with the downloaded `MyLocalTon-*.jar` path). |
-| HTTP API errors    | Ensure Python 3.9-3.12 and `ton-http-api` are installed.                                                               |
-| Need a clean reset | Stop the process, delete the `myLocalTon` directory, and restart the JAR to regenerate the network.                       |
+| HTTP API errors    | Ensure Python 3.9-3.12 and `ton-http-api` are installed.                                                                                                                            |
+| Need a clean reset | Stop the process, delete the `myLocalTon` directory, and restart the JAR to regenerate the network.                                                                                 |
 
 ## Where to go next
 


### PR DESCRIPTION
- [ ] **1. How‑to title pattern and missing `sidebarTitle`**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/setup-mylocalton.mdx?plain=1#L1

The page is a how‑to but the frontmatter `title` does not follow the required “How to X” pattern and exceeds 30 characters without a `sidebarTitle`. Minimal fix: change `title` to "How to set up a local blockchain using MyLocalTon" and add `sidebarTitle: "Set up local blockchain"` (≤ 30 chars).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16.2-navigation-labels

---

- [ ] **2. Terminology inconsistency: “lite-server” vs “liteserver”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/setup-mylocalton.mdx?plain=1#L8-L103

The page mixes “lite-server” and “liteserver”. Elsewhere in the docs, the canonical term is “liteserver” (one word), for example in https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/overview.mdx?plain=1#Interacting-with-TON-nodes and throughout that page. Minimal fix: replace all “lite-server” instances with “liteserver” for consistency.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-terminology-and-naming; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms

---

- [ ] **3. Acronyms not expanded on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/setup-mylocalton.mdx?plain=1#L8-L103

Several acronyms appear without first‑mention expansion: JAR (line 8), CLI (line 68), HTTP API (line 12), REST (line 103), UI (line 86), and ADNL (line 103). Minimal fix: expand each on first mention, then use the acronym thereafter, e.g., “Java archive (JAR)”, “command‑line interface (CLI)”, “Hypertext Transfer Protocol (HTTP) API”, “Representational State Transfer (REST)”, “user interface (UI)”, and “Abstract Datagram Network Layer (ADNL)”. For ADNL, this expansion matches https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/overview.mdx?plain=1#Interacting-with-TON-nodes. For HTTP/REST/UI/JAR/CLI, expansions rely on general technical usage.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms

---

- [ ] **4. Placeholders `<N>`, `<PATH>`, and `<JAR>` are not defined**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/setup-mylocalton.mdx?plain=1#L59-L116

Placeholders must be defined on first use. `<N>` and `<PATH>` in the “Useful arguments” table and `<JAR>` in the Troubleshooting row lack definitions. Minimal fix: add a one‑line note under the table such as “Placeholders: `<N>` — number of validators; `<PATH>` — directory containing TON binaries.” Also clarify `<JAR>` in the Troubleshooting tip (e.g., “replace `<JAR>` with the downloaded `MyLocalTon-*.jar` path”).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10.1-general-rules

---

- [ ] **5. Placeholder style inconsistency in `ip.addr.X.X`**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/setup-mylocalton.mdx?plain=1#L63

The argument uses `X.X` as an implicit placeholder, which violates the required `<ANGLE_CASE>` format. Minimal fix: change to `ip.addr.<IP>` or show a concrete example. If the literal flag syntax truly requires `X.X`, this needs confirmation from the domain owner; otherwise, prefer `<IP>` for consistency.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10.1-general-rules

---

- [ ] **6. Destructive action lacks a safety callout**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/setup-mylocalton.mdx?plain=1#L110

Instruction suggests deleting the `myLocalTon` directory, which is destructive. Safety callouts are required for actions that can cause data loss and must include risk, scope, rollback/mitigation, and environment. Minimal fix: add a `<Aside type="caution" title="Local data will be removed">` callout near this instruction explaining that deleting `myLocalTon` resets the local chain state (scope: local workspace), cannot be undone (rollback: none), and applies only to local/dev environments.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11.1-when-a-safety-callout-is-required; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11.2-how-to-write-the-callout

---

- [ ] **7. Mixed OS commands in one `bash` block**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/setup-mylocalton.mdx?plain=1#L88-L101

The block mixes Linux/macOS and Windows commands but is tagged `bash`. Minimal fix: split into separate fenced blocks by OS with correct language tags (e.g., `bash` for Linux/macOS; `powershell` for Windows), or use tabs/subsections per OS.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10.1-general-rules (language tags); https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10.4-os-and-language-variants

---

- [ ] **8. Hyphenation: “smart-contract” should be “smart contract”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/setup-mylocalton.mdx?plain=1

Intro paragraph: “smart-contract dry runs”. Minimal fix: “smart contract dry runs.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#b-banned-and-preferred-terms

---

- [ ] **9. Miscalibrated callout type and missing required fields (OpenSSL note)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/setup-mylocalton.mdx?plain=1

The Windows prerequisite is rendered as `<Aside type=\"caution\">`, which is reserved for potential data loss. It also lacks required risk/rollback fields for a safety callout. Minimal fix: downgrade to `<Aside type=\"note\" title=\"Important\">Install OpenSSL v1.1.1 on Windows before enabling the HTTP API.</Aside>` (use supported types), or rewrite as a full Caution if there’s actual risk. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#112-how-to-write-the-callout; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#a-admonition-levels-and-usage

---

- [ ] **10. External link may be unofficial; needs owner confirmation**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/setup-mylocalton.mdx?plain=1

The OpenSSL link points to `https://slproweb.com/products/Win32OpenSSL.html`. Global overrides flag non‑official links when an official source exists. This cannot be verified from the corpus. Minimal fix: confirm an official Windows OpenSSL download URL (or host a vetted mirror) and update the link if needed. Domain decision required. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#severity-model-release-blocking

---

- [ ] **11. ```**

(path missing)

---

- [ ] **12. Memory/storage units should use binary (GiB)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/setup-mylocalton.mdx?plain=1

RAM and disk sizes are specified as “GB.” Memory/storage must use binary units (GiB). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#14.2-units-and-conventions. Minimal fix: update “16 GB RAM, and 20 GB of free disk space” to “16 GiB RAM and 20 GiB of free disk space.”

---

- [ ] **13. Placeholders in arguments table are non‑descriptive**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/setup-mylocalton.mdx?plain=1

The “Useful arguments” table uses `<N>`, `<PATH>`, and `ip.addr.X.X`. Placeholders must use `<ANGLE_CASE>` with descriptive names, and each placeholder must be defined on first use. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13.5-placeholder-names; Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10.1-general-rules. Minimal fix:
- Change `<N>` → `<VALIDATOR_COUNT>` and define it.
- Change `<PATH>` → `<BINARIES_DIR>` and define it.
- Change `ip.addr.X.X` → `<IP_ADDR>` and define it.
Add brief definitions immediately after the table (first use), for example: `<VALIDATOR_COUNT>` — number of validators to start; `<BINARIES_DIR>` — path to TON binaries; `<IP_ADDR>` — local IP address to bind.

---

- [ ] **14. Heading label: prefer “Troubleshoot” over “Troubleshooting tips”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/setup-mylocalton.mdx?plain=1

House default is “Troubleshoot”; “Troubleshooting” is acceptable when aligning with ecosystem conventions. “Tips” is an extra label and not a standard section name. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.2-gerunds-and-labels. Minimal fix: rename the H2 to “Troubleshoot”.

---

- [ ] **15. Link text should mirror target heading**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/setup-mylocalton.mdx?plain=1

The link text “Setting up a node using MyTonCtrl” points to `./setup-mytonctrl`, whose page title is “Run a node with MyTonCtrl” (see https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/setup-mytonctrl.mdx?plain=1). Link text should be descriptive and, where possible, mirror the target heading to avoid drift. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12.1-link-text. Minimal fix: change the link text to “Run a node with MyTonCtrl”.

---

- [ ] **16. Mixed use of “folder” vs “directory”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/setup-mylocalton.mdx?plain=1

The page predominantly uses “directory” but one troubleshooting row says “delete the `myLocalTon` folder.” Avoid synonyms for the same concept within a page; prefer consistent terminology. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms. Minimal fix: change “folder” to “directory” for consistency. The guide is otherwise silent on this term; following in‑page consistency keeps usage predictable.

---

- [ ] **17. Define `<BASE64_PUBLIC_KEY>` at first use**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/setup-mylocalton.mdx?plain=1

The placeholder `<BASE64_PUBLIC_KEY>` is explained after the command block. Placeholders must be defined on first use. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10.1-general-rules. Minimal fix: move the sentence “Replace `<BASE64_PUBLIC_KEY>` with the key printed in the MyLocalTon logs.” to appear immediately before the command block, or include a one‑line definition right above it.

---

- [ ] **18. Moving-target download URLs violate stable permalink rule**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/setup-mylocalton.mdx?plain=1#L30

The commands use `releases/latest/download/...`, a moving target. For reproducible installation, prefer versioned permalinks. Minimal fix: change to a versioned URL with a placeholder (e.g., `https://github.com/neodix42/MyLocalTon/releases/download/<VERSION_TAG>/MyLocalTon-x86-64.jar`) or link to the Releases page and instruct manual selection.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references