### PR TITLE
[AI] fix: coverage.mdx

### DIFF
--- a/ecosystem/blueprint/coverage.mdx
+++ b/ecosystem/blueprint/coverage.mdx
@@ -42,6 +42,7 @@ There might be some reasons why you don't want to use `--coverage`.
 Before running tests, add `blockchain.enableCoverage()` to collect coverage data:
 
 Not runnable
+
 ```typescript
 import {Blockchain} from '@ton/sandbox';
 
@@ -68,6 +69,7 @@ describe('Contract Tests', () => {
 ### 2. Collect coverage after tests
 
 Not runnable
+
 ```typescript
 afterAll(() => {
     const coverage = blockchain.coverage(contract);
@@ -78,6 +80,7 @@ afterAll(() => {
 ### 3. Generate reports
 
 Not runnable
+
 ```typescript
 import {writeFileSync} from 'fs';
 
@@ -102,6 +105,7 @@ afterAll(() => {
 The coverage summary provides key metrics about your test coverage:
 
 Not runnable
+
 ```typescript
 const summary = coverage.summary();
 
@@ -129,6 +133,7 @@ summary.instructionStats.forEach(stat => {
 When running multiple test files, you might want to merge coverage data:
 
 Not runnable
+
 ```typescript
 // In first test file
 const coverage1 = blockchain.coverage(contract);
@@ -155,6 +160,7 @@ console.log(`Combined coverage: ${totalCoverage.summary().coveragePercentage}%`)
 When testing systems with multiple contracts:
 
 Not runnable
+
 ```typescript
 describe('Multi-Contract System', () => {
     let blockchain: Blockchain;


### PR DESCRIPTION
- [ ] **1. Procedural heading not imperative: “Easy way”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/coverage.mdx?plain=1#L14

This H2 introduces a procedure but does not start with an imperative verb. Use an imperative to guide action. Minimal fix: change to “Collect coverage (easy)”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form

---

- [ ] **2. Procedural heading not imperative: “Customizable way”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/coverage.mdx?plain=1#L31

This section provides steps/options but the heading is a noun phrase. Use an imperative heading. Minimal fix: change to “Collect coverage (customizable)”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form

---

- [ ] **3. Procedural subheading not imperative: “Multiple test suites”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/coverage.mdx?plain=1#L123

This H3 presents steps to merge coverage, so it should be imperative. Minimal fix: change to “Merge coverage from multiple test suites”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form

---

- [ ] **4. Procedural heading not imperative: “Coverage for multiple contracts”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/coverage.mdx?plain=1#L148

This section contains actionable steps and code; make the heading imperative. Minimal fix: change to “Collect coverage for multiple contracts”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form

---

- [ ] **5. Banned filler word “simply” in prose**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/coverage.mdx?plain=1#L33

The sentence includes the filler “simply”, which the guide bans. Minimal fix: remove “simply”: “There might be reasons you don’t want to use `--coverage`.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#b-banned-and-preferred-terms

---

- [ ] **6. Grammar and clarity in caution aside text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/coverage.mdx?plain=1#L20

Awkward phrasing and subject–verb agreement: “For this way to work correctly, version of … is needed.” Minimal fix for plain English and clarity: “To use this method, install `@ton/sandbox` >= 0.37.2 and `@ton/blueprint` >= 0.41.0.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#15-1-language-and-reading

---

- [ ] **7. Missing “Not runnable” labels for partial TypeScript snippets**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/coverage.mdx?plain=1#L44-L127

These fenced TypeScript blocks are excerpts that are not runnable as-is (no full context/imports). Partial snippets must be labeled above the block. Minimal fix: add a plain line “Not runnable” immediately above each block; keep the fence as ```typescript.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **8. Incorrect partial-snippet annotation inside code fence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/coverage.mdx?plain=1#L152

Using “```typescript not runnable” misuses the language tag position. Label partials above the block instead. Minimal fix: change the fence to “```typescript” and add a preceding line “Not runnable”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **9. Typo: duplicated word “text text”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/coverage.mdx?plain=1#L89

Duplicate word in comment reduces clarity. Minimal fix: “// Print text report to console”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **10. Inconsistent casing for “Blueprint” (proper noun)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/coverage.mdx?plain=1#L23

“When using blueprint” uses a lowercase common noun; elsewhere in the docs it appears as the proper name “Blueprint” (e.g., https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/tact.mdx?plain=1#L148-L156). Align casing. Minimal fix: “When using Blueprint, …”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-terminology-and-naming

---

- [ ] **11. Missing alt text for image**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/coverage.mdx?plain=1#L188-L190

The image has no alt text. Provide a brief text alternative. Minimal fix: `<Image src="/resources/images/coverage-report.png" alt="Coverage report example" />`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#15-2-structure-and-tables

---

- [ ] **12. Awkward phrasing in “Limitations” paragraph**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/coverage.mdx?plain=1#L200-L202

The phrase “when code of other contracts is stored directly in the code of contract” is unidiomatic. Minimal fix: “when the code of other contracts is stored directly in a contract’s code …”. This keeps meaning while using plain English.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#15-1-language-and-reading

---

- [ ] **13. Pleonasm in opening Aside (“covers coverage”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/coverage.mdx?plain=1

The sentence “This page covers coverage calculated on TVM assembly instructions.” repeats the word “cover” and reads awkwardly. Minimal fix: “This page explains coverage calculated on TVM assembly instructions.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **14. Wordy boilerplate before the command**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/coverage.mdx?plain=1

“the only thing you need to collect coverage is to run” is verbose. Minimal fix: “run:” or “To collect coverage, run:”. Resulting sentence: “When using Blueprint, run:”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **15. Command invocation consistency and copy-pasteability**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/coverage.mdx?plain=1

The command shows `blueprint test --coverage`. Across nearby pages, commands are invoked via `npx` (e.g., “npx blueprint test”). To keep examples copy‑pasteable and consistent, use `npx`. Minimal fix (in the bash block):

```bash
npx blueprint test --coverage
```

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules (examples must be copy‑pasteable). Consistency reference: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/testing/overview.mdx?plain=1#running-tests.

---

- [ ] **16. Internal links should be relative (not root-absolute)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/coverage.mdx?plain=1

Internal links use root‑absolute paths: `[TVM](/ton/tvm)` and `[Tact](/language/tact)`. Prefer relative links for stability. Minimal fix: change to `../../ton/tvm` and `../../language/tact` respectively. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-3-links-and-anchors

---

- [ ] **17. Tautology and agreement in opening Aside**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/coverage.mdx?plain=1#L8

The sentence “This page covers coverage calculated on TVM assembly instructions. Path- and source-line coverage is not implemented.” contains a tautology (“covers coverage”) and subject–verb mismatch; the “Path-” hyphen fragment is also awkward. Minimal fix: “This page explains how coverage is calculated for TVM assembly instructions. Path and source-line coverage are not implemented.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **18. First use of acronym TVM not expanded**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/coverage.mdx?plain=1#L8

On first mention, spell out the term and follow with the acronym. Minimal fix: “This page explains how coverage is calculated for the Telegram Open Network Virtual Machine (TVM) instructions.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **19. Missing Aside type for informational callouts**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/coverage.mdx?plain=1#L8-L194

Bare `<Aside>` lacks a severity/type; use `type="note"` for auxiliary information. Minimal fix: change `<Aside>` to `<Aside type="note">` in both locations.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#a-admonition-levels-and-usage

---

- [ ] **20. Admonition severity and grammar in “Library compatibility”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/coverage.mdx?plain=1#L16–21

Version prerequisites are “Important,” not a caution. Use the supported type/title mapping and fix number agreement. Minimal fix:
`<Aside type="note" title="Important"> For this to work correctly, versions of \`@ton/sandbox\` (\>= 0.37.2) and \`@ton/blueprint\` (\>= 0.41.0) are required. </Aside>`
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#a-admonition-levels-and-usage

---

- [ ] **21. Mixed list style and terminal punctuation in reasons list**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/coverage.mdx?plain=1#L35–38

Items are sentence fragments but end with periods; use consistent list punctuation. Minimal fix: remove the trailing periods from all four bullets.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **22. Product name capitalization and missing article**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/coverage.mdx?plain=1#L23-L29

Use consistent product casing and natural articles. Minimal fixes: “When using Blueprint, …” and “Results will appear in the `coverage/` directory …”. This aligns with prevailing usage in Blueprint docs (see https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/reference.mdx?plain=1).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms