### PR TITLE
[AI] fix: how-works.mdx

### DIFF
--- a/standard/tokens/nft/how-works.mdx
+++ b/standard/tokens/nft/how-works.mdx
@@ -10,14 +10,18 @@ In The Open Network (TON), there is a collection smart contract and a separate s
 Each NFT knows its collection, its index, and its item-specific part of the [metadata](/standard/tokens/metadata). The initial owner is assigned by the collection.
 
 ## NFT deployment
+
 The collection deploys NFT items with the initial owner and the item-specific metadata.
 
 ![NFT deployment](/standard/tokens/nft/pictures/nftDeploy.jpg)
 
 ## Verify that an NFT belongs to a collection
+
 ### High-level check
+
 You can do it with a single request:
 Not runnable
+
 ```ts
 const itemAddress = "EQD3LzasMd4GAmhIEkCQ4k6LnziTqNZ6VPtRfeZKHu0Fmkho";
 const collectionAddress = "EQCOtGTvX-RNSaiUavmqNcDeblB3-TloZpvYuyGOdFnfy-1N";
@@ -40,9 +44,11 @@ console.error(error);
 ```
 
 ### Low-level check
+
 First read the NFT item index. If the collection, for that index, returns the same NFT item address, the item belongs to the collection.
 
 Not runnable
+
 ```ts
 const itemAddress = "EQD3LzasMd4GAmhIEkCQ4k6LnziTqNZ6VPtRfeZKHu0Fmkho";
   const collectionAddress = "EQCOtGTvX-RNSaiUavmqNcDeblB3-TloZpvYuyGOdFnfy-1N";
@@ -125,12 +131,14 @@ const itemAddress = "EQD3LzasMd4GAmhIEkCQ4k6LnziTqNZ6VPtRfeZKHu0Fmkho";
   }
 ```
 
-
 ## Get full metadata for an NFT
+
 ### High-level check
+
 [Open metadata endpoint in playground](/ecosystem/rpc/ton-center-v3/accounts/get-account-metadata?playground=open)
 
 ### Low-level check
+
 Metadata is split into two parts: one part is stored on the item, another on the collection. Merge them.
 
 To get metadata for an NFT of a particular index, first fetch the NFT item address from the collection, then read the item metadata, then combine it with the collection metadata to get the final result.
@@ -140,24 +148,26 @@ To get metadata for an NFT of a particular index, first fetch the NFT item addre
 ## NFT transfer
 
 Not runnable
+
 ```text title="Signature"
 transfer(query_id, new_owner, response_destination, custom_payload, forward_amount, forward_payload)
 ```
 
 ### Transfer parameters
 
-| Parameter | Purpose | Value |
-| --- | --- | --- |
-| `query_id` | Request identifier | Any number (e.g., timestamp or counter), usually 0 |
-| `new_owner` | Address that should receive ownership | New owner address |
-| `response_destination` | Where to send confirmation and excess | Address to receive confirmation and excess |
-| `custom_payload` | Custom information passed to the NFT | Not used in standard NFTs; can be used by protocols |
-| `forward_amount` | Amount to forward to the new owner with a notification | 0 if no notification; >0 to send notification |
-| `forward_payload` | Message for the new owner | Any payload; leave empty if not required |
+| Parameter              | Purpose                                                | Value                                               |
+| ---------------------- | ------------------------------------------------------ | --------------------------------------------------- |
+| `query_id`             | Request identifier                                     | Any number (e.g., timestamp or counter), usually 0  |
+| `new_owner`            | Address that should receive ownership                  | New owner address                                   |
+| `response_destination` | Where to send confirmation and excess                  | Address to receive confirmation and excess          |
+| `custom_payload`       | Custom information passed to the NFT                   | Not used in standard NFTs; can be used by protocols |
+| `forward_amount`       | Amount to forward to the new owner with a notification | 0 if no notification; >0 to send notification       |
+| `forward_payload`      | Message for the new owner                              | Any payload; leave empty if not required            |
 
 The NFT updates its owner field and now belongs to the new owner.
 
 ### Optional notifications
+
 To send a notification to the new owner from the NFT, set a positive `forward_amount`.
 If you want to receive the excess (all remaining TON), set `response_destination` accordingly.
 
@@ -179,6 +189,7 @@ sequenceDiagram
 ```
 
 ## NFT sale
+
 Often a sale contract is created. First, the sale contract becomes the owner; upon successful purchase, it transfers the NFT to the buyer.
 
 ```mermaid
@@ -198,8 +209,10 @@ sequenceDiagram
 ```
 
 See also:
+
 - NFT Standard [TEP-62](https://github.com/ton-blockchain/TEPs/blob/1fbc23cac69723c53251f686ec90d81bf0e83443/text/0062-nft-standard.md)
- - [NFT overview](/standard/tokens/nft/overview)
+- [NFT overview](/standard/tokens/nft/overview)
 
 ## Best practices
+
 - Metadata referenced by each link should be permanent. If you need to change it, send a transaction that updates the reference.


### PR DESCRIPTION
- [ ] **1. Throat-clearing opener; use imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/comparison.mdx?plain=1#L8

The sentence starts with “This page compares…”, which is a throat‑clearing meta‑opener. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references. Minimal fix: rewrite to imperative and drop “This page”: “Compare the available standards for each layer of the NFT protocol on TON. The protocol has two layers — collection and item — and you can mix standards between layers since they are independent.”

---

- [ ] **2. Misused code font and capitalization for generic concepts**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/comparison.mdx?plain=1#L8

“” and “” are formatted as code and capitalized mid‑sentence, but these are generic concepts rather than code identifiers on this page. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-3-code-styling and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules. Minimal fix: remove backticks and use lowercase: “…two layers — collection and item — …”.

---

- [ ] **3. List items end with periods though not full sentences**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/comparison.mdx?plain=1#L21-L66

Bulleted fragments end with periods; rule prefers no terminal punctuation unless items are full sentences. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists. Minimal fix: remove trailing periods from these bullets to keep punctuation consistent.

---

- [ ] **4. Broken/unclear sentence in cNFT paragraph**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/comparison.mdx?plain=1#L35

“NFT Items uses instead of [airdrop markers] …” is ungrammatical and incomplete (subject‑verb agreement and missing object), making the meaning unclear. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-grammar-and-usage (Objective: make sentences easy to parse). Minimal fix: remove the fragment after the first sentence, or clarify the intended statement (e.g., whether cNFT items use airdrop markers) — requires domain owner confirmation to avoid inventing facts.

---

- [ ] **5. Incorrect encoded anchor to Airdrop section**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/comparison.mdx?plain=1#L35

The link uses “/standard/tokens/airdrop#the-scalable-design%3A-shard-and-prove”. MDX slugging drops punctuation; the correct anchor is “#the-scalable-design-shard-and-prove”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format. Minimal fix: change to “/standard/tokens/airdrop#the-scalable-design-shard-and-prove”.

---

- [ ] **6. Grammar: “to proof” → “to prove”; add article**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/comparison.mdx?plain=1#L57

“It also has on-chain API to proof ownership of SBT item.” uses “proof” as a verb and omits an article. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-grammar-and-usage (Objective). Minimal fix: “It also has an on‑chain API to prove ownership of the SBT item.” (General English grammar applied.)

---

- [ ] **7. Add serial (Oxford) comma in three‑item series**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/comparison.mdx?plain=1#L65

“there is no collection index, external indexers or explicit links…” lacks the serial comma before the final conjunction in a three‑item list. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons. Minimal fix: “there is no collection index, external indexers, or explicit links …”.

---

- [ ] **8. Comma splice joins two independent clauses**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/comparison.mdx?plain=1#L65

“there is no collection index, external indexers or explicit links are used…” joins two independent clauses with a comma. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons. Minimal fix: split into two sentences: “Discoverability: there is no collection index. External indexers or explicit links are used to surface the item.” (Alternatively, use a semicolon or add “and”.)

---

- [ ] **9. Heading label is meta; make concise noun phrase**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/comparison.mdx?plain=1#L37

Heading “Additional: Royalty” is a meta label and uses title case for the second word. Headings must be sentence case and concise; concept headings should be noun phrases. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles. Minimal fix: rename heading to “Royalty”.

---

- [ ] **10. Passive voice in table; prefer active**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/comparison.mdx?plain=1#L26

“Items are minted by the creator” uses passive voice. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-1-voice-tense-and-person. Minimal fix: “The creator mints items.” (Tables can use concise active statements.)

---

- [ ] **11. Missing verb in table cell**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/comparison.mdx?plain=1#L28

“root readable via ” lacks a verb. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-grammar-and-usage (Objective). Minimal fix: “root is readable via ”.

---

- [ ] **12. Term casing: “NFT Items” → “NFT items”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/comparison.mdx?plain=1#L35

Use lowercase “items” for the common noun; reserve capitalization for acronyms and proper nouns. Cross-doc usage prefers “NFT item”/“items” (see https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/how-works.mdx?plain=1#L1-L7). Minimal fix: “NFT items …”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms.

---

- [ ] **13. Terminology consistency: “Merkle‑proof” → “Merkle proof”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/comparison.mdx?plain=1#L35

Other TON docs use “Merkle proof” without a hyphen (for example, https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/airdrop.mdx?plain=1#the-scalable-design-shard-and-prove). Align to the prevailing term. Minimal fix: replace “Merkle‑proof” with “Merkle proof”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms.

---

- [ ] **14. Casing in SBT expansion: “Soulbound Token” → “Soulbound token”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/comparison.mdx?plain=1#L48-L50

Follow glossary casing for the term: “Soulbound token (SBT)”. Minimal fix: use lower‑case “token” in the expansion. Cite: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#soulbound-token-sbt. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms.

---

- [ ] **15. First mention acronym expansion for TON**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/comparison.mdx?plain=1#L8

On first mention, spell out the term and follow with the acronym. Minimal fix: “the NFT protocol on The Open Network (TON)”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms.

---

- [ ] **16. First mention acronym expansion for NFT in body text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/comparison.mdx?plain=1#L8

Define the acronym on first useful mention in the body to aid newcomers. Minimal fix: “non‑fungible token (NFT) protocol”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms.

---

- [ ] **17. Terminology: use "Soul-bound" (hyphenated) consistently**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/comparison.mdx?plain=1#L48

The page uses "Soulbound" without a hyphen, while the SBT overview uses "Soul-bound" (hyphenated). Align with existing terminology used elsewhere (see https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/sbt/overview.mdx?plain=1). Minimal fix: change "SBT (Soulbound Token)" to "SBT (Soul-bound Token)".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **18. Hyphen consistency: use "on-chain" (ASCII hyphen) uniformly**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/comparison.mdx?plain=1#L28

Within this page, both "On‑chain" (non‑breaking hyphen) and "on-chain" (ASCII hyphen) appear. Prefer a single form for consistency with nearby docs (e.g., https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/metadata.mdx?plain=1) and within the page. Minimal fix: replace "On‑chain Merkle allowlist" with "On-chain Merkle allowlist".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **19. Acronym not defined on first use: UX**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/comparison.mdx?plain=1#L31

"proof UX" uses the acronym without first defining it. Minimal fix: "proof user experience (UX) and distribution setup required" (define on first use, then use the acronym thereafter).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **20. Throat-clearing labels: "Short overview:" (Collection and Item)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/comparison.mdx?plain=1#L19-L45

"Short overview:" is meta text that doesn't add value and slows scanning. Minimal fix: remove the line in both sections and keep the bullets; the section headings already provide context.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **21. Oxford comma required in three‑item lists (table cells)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/comparison.mdx?plain=1#L30-L53

Per the serial comma rule, add the conjunction with the Oxford comma:
- Line 30 (cNFT Typical use cases): change to "Mass airdrops, growth campaigns, and very large audiences."
- Line 53 (Default Item Typical use cases): change to "Art, collectibles, tickets, and gaming assets."
- Line 53 (SBT Typical use cases): change to "Identity, credentials, achievements, and non‑transferable badges."
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **22. Consistent terminology: "valid proof" → "valid Merkle proof"**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/comparison.mdx?plain=1#L26

The table uses "valid proof" in the cNFT column but "valid Merkle proof" in another row and the page links to Merkle proofs. For consistency within the page and with airdrop docs, use "Merkle proof" consistently. Minimal fix: change to "Any user with a valid Merkle proof can deploy their item". Cross-doc: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/airdrop.mdx?plain=1#the-scalable-design-shard-and-prove.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **23. Symbol in table header: replace '&' with 'and'**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/comparison.mdx?plain=1#L26

Prefer plain words over symbols for clarity and localization. Minimal fix: change the header "Deployment & minting flow" to "Deployment and minting flow".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording