### PR TITLE
[AI] fix: platform-and-palette.mdx

### DIFF
--- a/ecosystem/tma/telegram-ui/platform-and-palette.mdx
+++ b/ecosystem/tma/telegram-ui/platform-and-palette.mdx
@@ -2,36 +2,36 @@
 title: "AppRoot component"
 ---
 
-The `AppRoot` component is pivotal in implementing a dynamic theming system within your application. It employs a sophisticated approach to CSS variables and React context to seamlessly adapt to various themes and platforms. This section delves into the inner workings of this system, explaining how themes are managed and applied internally.
+The `AppRoot` component implements a dynamic theming system within your application. It uses CSS variables and React context to adapt to various themes and platforms.
 
 ## CSS variables: the backbone of theming
 
-At the heart of the `AppRoot` theming system lie CSS variables, which are utilized to create a flexible and adaptable styling framework. These variables are divided into two main categories: **Basic Variables** and **Custom Variables**. Both play a crucial role in tailoring the application's appearance to match both Telegram's theme and any additional stylistic preferences.
+The `AppRoot` theming system uses CSS variables to create a flexible styling framework. These variables fall into two categories: **basic variables** and **custom variables**. Both play a crucial role in tailoring the application's appearance to match Telegram's theme and any additional stylistic preferences.
 
 ### Basic variables
 
-Basic Variables are designed to inherit styles directly from Telegram or fall back on predefined styles within the library. This ensures that the application remains consistent with the user's current Telegram theme settings.
+Basic variables inherit styles directly from Telegram or fall back on predefined styles within the library. This ensures that the application remains consistent with the user's current Telegram theme settings.
 
-- **Telegram Style Inheritance**: When available, Basic Variables dynamically adopt values from Telegram's theme, aligning the application's appearance with the platform's chosen theme.
-- **Library Defaults**: In scenarios where Telegram theme data isn't available or not support in current version, these variables revert to a set of default styles specified within the library, maintaining a coherent and user-friendly interface.
+- **Telegram style inheritance**: When available, basic variables dynamically adopt values from Telegram's theme, aligning the application's appearance with the platform's chosen theme.
+- **Library defaults**: In scenarios where Telegram theme data isn't available or is not supported in the current version, these variables revert to a set of default styles specified within the library, maintaining a coherent and user-friendly interface.
 
 ### Custom variables
 
-Custom Variables offer an extension to the theming capabilities, allowing for more nuanced and specific styling adjustments that go beyond the scope of Telegram's native themes.
+Custom variables extend the theming capabilities, allowing for more nuanced and specific styling adjustments that go beyond the scope of Telegram's native themes.
 
-- **Enhanced Styling Flexibility**: These variables enable the definition of unique stylistic elements like accent colors, providing opportunities for brand alignment and distinct visual design.
-- **Brand Identity Support**: By leveraging Custom Variables, developers can ensure that the application not only adheres to Telegram's theming but also reflects the brand's identity through consistent use of colors, typography, and other design elements.
+- **Enhanced styling flexibility**: These variables enable the definition of unique stylistic elements like accent colors, providing opportunities for brand alignment and distinct visual design.
+- **Brand identity support**: By using custom variables, developers can ensure that the application not only adheres to Telegram's theming but also reflects the brand's identity through consistent use of colors, typography, and other design elements.
 
 ## Internal mechanism for theme and platform adaptation
 
-`AppRoot` intelligently leverages React context and CSS variables to dynamically adjust the application's styling based on the current theme (light, dark, or Telegram custom themes) and platform (iOS, Android, web). Here's an overview of how this process unfolds internally:
+`AppRoot` uses React context and CSS variables to dynamically adjust the application's styling based on the current theme (light, dark, or Telegram custom themes) and platform (iOS, Android, and web):
 
 - **Theme Detection and Application**: Upon initialization, `AppRoot` detects the current theme settings (from Telegram or manually set preferences) and updates the CSS variables accordingly. This process ensures that the theme is consistently applied across the application.
-- **Platform-Specific Styling**: In addition to theme management, `AppRoot` also detects the user's platform and applies platform-specific styles to optimize the user experience. This might include adjustments to typography, element sizing, and interaction feedback, aligning with platform conventions.
+- **Platform-Specific Styling**: In addition to theme management, `AppRoot` also detects the user's platform and applies platform-specific styles to optimize the user experience. For example, adjustments to typography, element sizing, and interaction feedback align with platform conventions.
 - **Contextual Theme and Platform Information**: Through the use of React context, `AppRoot` provides nested components with access to current theme and platform information. This allows for conditional rendering or styling adjustments deep within the component tree, based on the overall application context.
 
 ## Summary
 
-The `AppRoot` theming system is a sophisticated framework designed to ensure visual consistency and adaptability across different themes and platforms. By combining CSS variables with React context, it offers a robust solution for managing theme and platform-specific styling, all while keeping the application aligned with Telegram's theming capabilities and the brand's visual identity.
+The `AppRoot` theming system ensures visual consistency across themes and platforms. By combining CSS variables with React context, it offers a solution for managing theme and platform-specific styling, all while keeping the application aligned with Telegram's theming capabilities and the brand's visual identity.
 
-Through this internal mechanism, `AppRoot` abstracts away the complexities of dynamic theming, allowing developers to focus on building feature-rich and visually appealing applications that provide a seamless user experience across all platforms and themes.
+`AppRoot` handles dynamic theming so you can focus on features.


### PR DESCRIPTION
- [ ] **1. Marketing language and intensifiers in intro and summary**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/telegram-ui/platform-and-palette.mdx?plain=1#L5-L35

The page uses subjective, marketing-toned adjectives and adverbs (e.g., “pivotal,” “sophisticated,” “seamlessly,” “robust,” “feature-rich,” “visually appealing,” “seamless”) that reduce clarity and add no actionable information. Replace with neutral, factual wording. Minimal fixes:
- L5: “The `AppRoot` component implements a dynamic theming system…” (drop “pivotal,” “sophisticated,” “seamlessly”).
- L35–37: Remove “sophisticated,” “robust,” “feature-rich,” “visually appealing,” and “seamless,” or rephrase to neutral statements about behavior.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **2. Throat-clearing/meta phrasing**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/telegram-ui/platform-and-palette.mdx?plain=1#L5-L27

Meta sentences delay value delivery: “This section delves into the inner workings…” (L5) and “Here’s an overview of how this process unfolds internally:” (L27). Remove these or replace with direct statements. Minimal fixes:
- L5: Delete the second sentence after the first period.
- L27: “`AppRoot` uses React context and CSS variables to adjust styling based on theme and platform:” (remove the lead-in).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **3. Capitalization of generic concepts mid-sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/telegram-ui/platform-and-palette.mdx?plain=1#L9-L23

Generic categories “Basic Variables” and “Custom Variables” are capitalized mid-sentence. Use lowercase for common nouns. Minimal fixes:
- L9, L13, L20, L22–23: change to “basic variables” and “custom variables”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules

---

- [ ] **4. Title Case in bold list labels**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/telegram-ui/platform-and-palette.mdx?plain=1#L15-L23

Bold labels within bullets use Title Case for generic concepts (e.g., “Telegram Style Inheritance”, “Library Defaults”, “Enhanced Styling Flexibility”, “Brand Identity Support”). Use sentence case for common nouns. Minimal fixes:
- L15: “Telegram style inheritance:”
- L16: “Library defaults:”
- L22: “Enhanced styling flexibility:”
- L23: “Brand identity support:”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **5. Grammar error: “not support in current version”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/telegram-ui/platform-and-palette.mdx?plain=1#L16

The phrase is ungrammatical. Minimal fix: “or is not supported in the current version,”. This follows general English grammar conventions (general knowledge) and improves readability.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **6. Verb choice: avoid “leverages” and intensifier “intelligently”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/telegram-ui/platform-and-palette.mdx?plain=1#L27

Avoid “leverage” as a verb and remove the intensifier. Minimal fix: “`AppRoot` uses React context and CSS variables to dynamically adjust the application’s styling…”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-6-banned-and-preferred-terms; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **7. Missing Oxford comma in a three-item list**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/telegram-ui/platform-and-palette.mdx?plain=1#L27

The list “iOS, Android, web” lacks the required serial comma. Minimal fix: “iOS, Android, and web”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **8. Redundant “both … both …” construction**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/telegram-ui/platform-and-palette.mdx?plain=1#L9

The sentence uses “Both … both …” redundantly. Minimal fix: “Both play a crucial role in tailoring the application’s appearance to match Telegram’s theme and any additional stylistic preferences.” (remove the second “both”).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **9. Idiom: “At the heart of …”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/telegram-ui/platform-and-palette.mdx?plain=1#L9

Avoid idioms to improve clarity and translation. Minimal fix: “The theming system uses CSS variables to create a flexible and adaptable styling framework.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-5-global-and-inclusive-language

---

- [ ] **10. Prefer active, concise verbs over passive/wordy forms**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/telegram-ui/platform-and-palette.mdx?plain=1#L9-L35

Several sentences use passive or wordy constructions. Minimal fixes:
- Line 9: “are utilized to create” → “use”.
- Line 9: “are divided into two main categories” → “fall into two categories”.
- Line 13: “are designed to inherit” → “inherit”.
- Line 20: “offer an extension to” → “extend”.
- Line 35: “is designed to ensure” → “ensures”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-1-voice-tense-and-person; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **11. Replace hedge “might include” with clearer phrasing**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/telegram-ui/platform-and-palette.mdx?plain=1#L30

“This might include…” hedges without adding clarity. Prefer a concrete phrasing or an example qualifier. Minimal fix: “For example, adjustments to typography, element sizing, and interaction feedback align with platform conventions.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **12. Reduce rhetorical flourish in concept sections**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/telegram-ui/platform-and-palette.mdx?plain=1#L9-L37

Phrases like “At the heart of…”, “sophisticated framework”, and “abstracts away the complexities” add rhetorical weight without information. Replace with concise, factual wording. Minimal fixes: Line 9 start “`AppRoot` uses CSS variables…”, line 35 “The `AppRoot` theming system ensures visual consistency across themes and platforms.”, line 37 “`AppRoot` handles dynamic theming so you can focus on features.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **13. Verb choice: avoid “leverages” and intensifier “intelligently”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/telegram-ui/platform-and-palette.mdx?plain=1#L23-L27

Avoid “leverage” as a verb and remove the intensifier. Minimal fixes:
- L23: “By using custom variables, developers can …” (replace “leveraging”).
- L27: “`AppRoot` uses React context and CSS variables to dynamically adjust the application’s styling …” (replace “intelligently leverages”).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#b-banned-and-preferred-terms; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **14. Pleonasm and passive phrasing (utilized; flexible and adaptable)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/telegram-ui/platform-and-palette.mdx?plain=1#L9

Wordy passive construction and pleonasm: "are utilized to create a flexible and adaptable styling framework." Minimal fix: "use CSS variables to create a flexible styling framework."
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references