### PR TITLE
[AI] fix: dapp.mdx

### DIFF
--- a/guidebook/dapp.mdx
+++ b/guidebook/dapp.mdx
@@ -5,9 +5,9 @@ sidebarTitle: "Integrate a dApp"
 
 import { Aside } from '/snippets/aside.jsx';
 
-This guide helps you integrate your dApp with TON or build a fresh one from scratch with the help of [TON Connect](/ecosystem/ton-connect) and auxiliary libraries.
+Integrate your dApp with TON or build one from scratch using [TON Connect](/ecosystem/ton-connect) and auxiliary libraries.
 
-TON Connect is a standard wallet connection protocol used on TON. It consists of many supplementary SDKs and supervises two major use-cases: integrations of dApps with TON and custom wallet integrations. The former are the focus of this guide.
+TON Connect is a standard wallet connection protocol used on TON. It consists of many supplementary SDKs and covers two common use cases: dApp integrations and custom wallet integrations. The former are the focus of this guide.
 
 To proceed with a dApp integration, select your framework or environment:
 
@@ -20,16 +20,16 @@ To proceed with a dApp integration, select your framework or environment:
   <Card
     icon="square-n"
     title="Next.js"
-    href="#next-js"
+    href="#integrate-with-nextjs"
   />
   <Card
     icon="js"
     title="Vanilla JS"
-    href="#vanilla-js"
+    href="#use-vanilla-js"
   />
 </Columns>
 
-## Integration
+## Integrate with your framework
 
 ### React
 
@@ -49,12 +49,14 @@ To proceed with a dApp integration, select your framework or environment:
 </Step>
 <Step title="Create a TON Connect manifest">
   [TON Connect manifest](/ecosystem/ton-connect/manifest) is a small JSON file that lets wallets discover information about your dApp. It should be named `tonconnect-manifest.json`, placed at `https://[yourapp.com]/tonconnect-manifest.json` and be accessible with a simple GET request.
+  
+  <YOUR_APP_URL> — base HTTPS origin of your app (no trailing slash).
 
   <Aside>
-    Notice, that CORS should be disabled and there should be no authorization or intermediate proxies like CloudFlare or similar services.
+    CORS should be disabled, and there should be no authorization or intermediate proxies such as Cloudflare.
   </Aside>
 
-  Here's an example of such file:
+  Here's an example of such a file:
 
   ```json title="tonconnect-manifest.json"
   {
@@ -86,9 +88,9 @@ To proceed with a dApp integration, select your framework or environment:
 
 </Step>
 <Step title="Add a button in the UI">
-  Users need a clear way of connecting their wallets to your app, so you must give a clear UI element to do so. Usually, that is a **Connect wallet** button.
+  Users need a clear way of connecting their wallets to your app, so you must give a clear UI element to do so. Usually, that is a "Connect Wallet" button.
 
-  That said, opening your web dApp from the in-wallet browser of some wallets might automatically show up a wallet connection modal window. But even in those cases, it is good to provide a button alternative in case user dismissed the modal window and wants to connect a wallet after doing their research (DYOR).
+  Some in‑wallet browsers open a connection modal automatically. Still, provide a button in case the user dismisses the modal and wants to connect later.
 
   Adding `TonConnectButton` is straightforward:
 
@@ -105,7 +107,7 @@ To proceed with a dApp integration, select your framework or environment:
   };
   ```
 
-  The `TonConnectButton` is a universal UI component for initializing a connection. After the wallet is connected, it transforms into a wallet menu. Prefer to place the **Connect wallet** button in the top right corner of your app.
+  The `TonConnectButton` is a universal UI component for initializing a connection. After the wallet is connected, it transforms into a wallet menu. Prefer to place the "Connect Wallet" button in the top right corner of your app.
 
   You can add the `className` and style props to the button:
 
@@ -114,10 +116,10 @@ To proceed with a dApp integration, select your framework or environment:
   ```
 
   <Aside type="caution">
-    You cannot pass a child elements to the `TonConnectButton`.
+    You cannot pass child elements to the `TonConnectButton`.
   </Aside>
 </Step>
-<Step title="Utilize TON Connect in your dApp">
+<Step title="Use TON Connect in your dApp">
   <Card
     title="Common usage recipes"
     href="#usage"
@@ -125,7 +127,7 @@ To proceed with a dApp integration, select your framework or environment:
 </Step>
 </Steps>
 
-#### Manual connection initiation
+#### Initiate a connection manually
 
 You can always initiate the connection manually using the `useTonConnectUI` hook and [openModal](https://github.com/ton-connect/sdk/tree/main/packages/ui#open-connect-modal) method.
 
@@ -147,7 +149,7 @@ export const Header = () => {
 
 To open a modal window for a specific wallet, use the `openSingleWalletModal()` method. It takes the wallet's `app_name` as a parameter and opens the corresponding wallet modal, returning a promise that resolves once the modal window opens successfully.
 
-To find a correct `app_name` of the target wallet, refer to the [wallets-list.json](https://github.com/ton-blockchain/wallets-list/blob/main/wallets-v2.json) file.
+To find the correct `app_name` of the target wallet, refer to the [wallets-list.json](https://github.com/ton-blockchain/wallets-list/blob/main/wallets-v2.json) file.
 
 ```tsx
 <button onClick={() => tonConnectUI.openSingleWalletModal('tonwallet')}>
@@ -155,9 +157,9 @@ To find a correct `app_name` of the target wallet, refer to the [wallets-list.js
 </button>
 ```
 
-#### UI customization
+#### Customize the UI
 
-To customize UI of the modal, use the `tonConnectUI` object provided by the `useTonConnectUI()` hook, and then assign designated values as an object to the `uiOptions` property.
+To customize the modal UI, use the `tonConnectUI` object provided by the `useTonConnectUI()` hook, and then assign designated values as an object to the `uiOptions` property.
 
 ```tsx
 // Somewhere early in the component:
@@ -174,10 +176,12 @@ tonConnectUI.uiOptions = {
 };
 ```
 
-UI element will be re-rendered after such assignment. In the object assigned, you should only pass options that you want to change — they will be merged with current UI options.
+The UI element will be re-rendered after such an assignment. In the object assigned, you should only pass options that you want to change — they will be merged with current UI options.
 
 <Aside type="caution">
-  Note, that you have to pass an object and never set individual sub-properties under `uiOptions`. That is, **DO NOT** do this:
+  Pass an object and never set individual sub-properties under `uiOptions`. That is, **DO NOT** do this:
+
+  Not runnable.
 
   ```tsx
   /* WRONG, WILL NOT WORK */ tonConnectUI.uiOptions.language = 'ru';
@@ -187,9 +191,9 @@ UI element will be re-rendered after such assignment. In the object assigned, yo
 
 See all available `uiOptions` in the separate reference: [`TonConnectUiOptions` Interface](https://ton-connect.github.io/sdk/interfaces/_tonconnect_ui.TonConnectUiOptions.html).
 
-#### Minimal React setup
+#### Set up a minimal React app
 
-Putting all the above together, here's a most minimal React dApp integration example.
+Putting all the above together, here's the most minimal React dApp integration example.
 
 First, start with creating a new project with React and Vite:
 
@@ -262,13 +266,13 @@ function App() {
 
 Now, execute `npm run dev` to launch and preview your app in the browser at `http://localhost:5173`. All changes in code will be reflected live.
 
-Connect a wallet and try using the **Send 0.1 TON** button. Notice, that the exact sum of Toncoin shown in your wallet **will be different**, because there are certain fees required for such transfer by the blockchain itself. When building apps, make sure to **always take fees into consideration** and show them to the end-user.
+Connect a wallet and try using the "Send 0.1 Toncoin" button. The amount shown in your wallet may differ due to fees. Always account for fees and show them to the end user.
 
 <Aside type="caution">
-  This example sends **real TON** from the connected wallet. Try it with a testnet wallet first or send less Toncoin (say, 0.001 instead of 1) to avoid surprises.
+  This example sends real Toncoin from the connected wallet. Try it with a testnet wallet first or send less Toncoin (say, 0.001 instead of 1) to avoid surprises.
 </Aside>
 
-### Next.js
+### Integrate with Next.js
 
 `TonConnectUIProvider` relies on browser APIs and should be rendered only on the client side, i.e., on the frontend. As such, in a Next.js application you should mark the component that wraps the provider with [`"use client"` directive](https://nextjs.org/docs/app/api-reference/directives/use-client). Alternatively, dynamically import the provider to disable server-side rendering. Both approaches ensure that the provider is invoked only in the browser and works correctly there.
 
@@ -311,12 +315,12 @@ function MyApp({ Component, pageProps }) {
 }
 ```
 
-### Vanilla JS
+### Use vanilla JS
 
 For quick testing, use the following single-file HTML example.
 
 <Aside type="caution">
-  This example sends **real TON** from the connected wallet. Try it with a testnet wallet first or send less Toncoin (say, 0.001 instead of 0.1) to avoid surprises.
+  This example sends real Toncoin from the connected wallet. Try it with a testnet wallet first or send less Toncoin (say, 0.001 instead of 0.1) to avoid surprises.
 </Aside>
 
 ```html title="index.html" expandable
@@ -353,58 +357,58 @@ For quick testing, use the following single-file HTML example.
 
 ## Usage
 
-Once the app is [integrated](#integration), follow one of these common usage recipes:
+Once the app is [integrated](#integrate-with-your-framework), follow one of these common usage recipes:
 
 <Columns cols={3}>
   <Card
     title="Send Toncoin"
-    href="https://github.com/tact-lang/mintlify-ton-docs/issues/247"
+    href="/ecosystem/ton-connect/dapps/send-toncoin"
   />
   <Card
     title="Send USDT"
-    href="https://github.com/tact-lang/mintlify-ton-docs/issues/249"
+    href="/ecosystem/ton-connect/dapps/send-usdt"
   />
   <Card
     title="Send a Jetton"
-    href="https://github.com/tact-lang/mintlify-ton-docs/issues/248"
+    href="/ecosystem/ton-connect/dapps/send-jetton"
   />
   <Card
     title="Send an NFT"
-    href="https://github.com/tact-lang/mintlify-ton-docs/issues/250"
+    href="/ecosystem/ton-connect/dapps/send-nft"
   />
   <Card
     title="Check Toncoin balance"
-    href="https://github.com/tact-lang/mintlify-ton-docs/issues/251"
+    href="/ecosystem/ton-connect/dapps/check-toncoin-balance"
   />
   <Card
     title="Check USDT balance"
-    href="https://github.com/tact-lang/mintlify-ton-docs/issues/279"
+    href="/ecosystem/ton-connect/dapps/check-usdt-balance"
   />
   <Card
     title="Check Jetton balance"
-    href="https://github.com/tact-lang/mintlify-ton-docs/issues/252"
+    href="/ecosystem/ton-connect/dapps/check-jetton-balance"
   />
   <Card
     title="Check NFT items present"
-    href="https://github.com/tact-lang/mintlify-ton-docs/issues/253"
+    href="/ecosystem/ton-connect/dapps/check-nfts"
   />
   <Card
     title="Track a transaction and confirm its status"
-    href="https://github.com/tact-lang/mintlify-ton-docs/issues/254"
+    href="/ecosystem/ton-connect/dapps/track-transaction"
   />
   <Card
     title="Make a sign data request and verify signed data"
-    href="https://github.com/tact-lang/mintlify-ton-docs/issues/255"
+    href="/ecosystem/ton-connect/dapps/sign-data"
   />
   <Card
     title="Make a proof request and verify it"
-    href="https://github.com/tact-lang/mintlify-ton-docs/issues/256"
+    href="/ecosystem/ton-connect/dapps/request-proof"
   />
 </Columns>
 
 ## See also
 
-Read more about the TON Connect:
+Read more about TON Connect:
 
 <Columns cols={2}>
   <Card
@@ -434,7 +438,7 @@ Discover wallet integration guides or explore complete examples:
     href="/ecosystem/ton-connect/walletkit"
   />
   <Card
-    title="CEX: Centralized EXchange"
+    title="CEX: Centralized exchange"
     href="/guidebook/cex"
   />
 </Columns>


### PR DESCRIPTION
- [ ] **1. Placeholder style uses square brackets; must use angle-case and define on first use**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1

The manifest path uses `https://[yourapp.com]/tonconnect-manifest.json`. Per the placeholder rule, placeholders must use `<ANGLE_CASE>`, and each placeholder must be defined at first use. Minimal fix: replace with `https://<YOUR_APP_URL>/tonconnect-manifest.json` and add a one‑line definition after the paragraph or code block, for example: `<YOUR_APP_URL> — base HTTPS origin of your app (no trailing slash).` Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **2. Imperative wording: use “Use”, not “Utilize”, in step title**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1

Step title “Utilize TON Connect in your dApp” uses “utilize,” which the guide discourages. Minimal fix: change to “Use TON Connect in your dApp”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **3. Comma splice and brand capitalization in Aside about CORS**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1

Text: “Notice, that CORS should be disabled and there should be no authorization or intermediate proxies like CloudFlare or similar services.” Issues: unnecessary comma after “Notice”, and “CloudFlare” capitalization. Minimal fix: “CORS should be disabled, and there should be no authorization or intermediate proxies such as Cloudflare.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-6-spelling-and-contractions. General knowledge: proper brand capitalization.

---

- [ ] **4. Article usage: “such file” → “such a file”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1

Text: “Here’s an example of such file:”. Minimal fix: “Here’s an example of such a file:”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#8-1-paragraphs-and-sentences. General knowledge: basic English article usage.

---

- [ ] **5. Grammar: “a child elements” → “child elements”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1

Aside says: “You cannot pass a child elements to the `TonConnectButton`.” Minimal fix: “You cannot pass child elements to the `TonConnectButton`.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#8-1-paragraphs-and-sentences. General knowledge: singular/plural agreement.

---

- [ ] **6. Unexplained slang/acronym “DYOR”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1

Text: “…after doing their research (DYOR).” The acronym isn’t defined and is crypto slang. Minimal fix: remove the parenthetical “(DYOR)” or expand on first use as “do your own research (DYOR)”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-5-global-and-inclusive-language

---

- [ ] **7. Contraction and unit wording in code comment**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1

Comment: “Notice that its important to specify Toncoin in nanoToncoin format, where 1 Toncoin is equal to 10⁹ nanoToncoin:”. Issues: missing apostrophe in “it’s” and nonstandard unit term “nanoToncoin”. Minimal fix: “It’s important to specify the amount in nanotons (1 Toncoin = 10^9 nanotons):”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-6-spelling-and-contractions; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms. Evidence: ecosystem/rpc/ton-center-http-api-v-2.json uses “nanotons” in field descriptions.

---

- [ ] **8. Currency term consistency: use “Toncoin” instead of “TON” for amounts**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1

The page mixes “TON” and “Toncoin” for the currency (e.g., button label “Send 0.1 TON” vs. prose “send less Toncoin”). For consistency with the docs, prefer “Toncoin” for the asset name and “nanotons” for the unit. Minimal fix: change UI labels and surrounding prose to “Send 0.1 Toncoin”; keep technical unit mentions as “nanotons”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms. Evidence: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/dapps/send-toncoin.mdx?plain=1 (uses “Toncoin”); ecosystem/rpc/ton-center-http-api-v-2.json (uses “nanotons”).

---

- [ ] **9. Article in Next.js section: “the TON Connect” → “TON Connect”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1

Text: “Read more about the TON Connect:”. Minimal fix: “Read more about TON Connect:”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **10. Card title capitalization: “CEX: Centralized EXchange”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1

Title capitalizes the internal “X” (“EXchange”), which reads as a typo. Minimal fix: “CEX: Centralized exchange”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-6-spelling-and-contractions

---

- [ ] **11. Wording: “To customize UI of the modal” → “To customize the modal UI”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1

Sentence reads awkwardly. Minimal fix: “To customize the modal UI, use the `tonConnectUI` object…”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **12. Style UI labels with quotes, not bold**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1#L89-L109

Replace bolded UI label “**Connect wallet**” with quoted, exact casing to match the example button text, e.g., “Connect Wallet”. Do not use bold for UI strings. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **13. Fix article usage: app_name**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1#L148-L151

“To find a correct `app_name` of the target wallet,” → “To find the correct `app_name` of the target wallet,”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording (General knowledge: article usage.)

---

- [ ] **14. Fix articles and subject in UI customization paragraph**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1#L160-L177

“To customize UI of the modal,” → “To customize the UI of the modal,” and “UI element will be re-rendered…” → “The UI element will be re-rendered…”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording (General knowledge: article and subject usage.)

---

- [ ] **15. Remove throat-clearing in caution note**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1#L179-L186

“Note, that you have to pass an object and never set individual sub-properties under `uiOptions`.” → “Pass an object and never set individual sub-properties under `uiOptions`.” Also remove the comma after “Note”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **16. Fix grammar: “a most minimal” → “the most minimal”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1#L192-L193

“here's a most minimal React dApp integration example.” → “here's the most minimal React dApp integration example.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording (General knowledge: article usage.)

---

- [ ] **17. Fix wording in code comment: “setup” → “set up”; “https” → “HTTPS”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1#L205-L208

In the TSX comment, “setup a tunnel and an https domain” → “set up a tunnel and an HTTPS domain”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording (General knowledge: phrasal verb and acronym casing.)

---

- [ ] **18. Verify and correct in-page anchor for Next.js card**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1#L20-L24

Card uses `href="#next-js"`, but the “Next.js” heading may generate an anchor without punctuation (commonly `#nextjs`). Update the fragment to the actual generated anchor so the link resolves (e.g., `#nextjs`). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format (General knowledge: many generators strip punctuation from heading IDs.)

---

- [ ] **19. Replace external GitHub issue links with internal canonical pages**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1#L337-L378

Usage cards currently link to GitHub issues. Per “Internal first,” link to the corresponding internal pages. Minimal fixes (relative links):
- “Send Toncoin” → `/ecosystem/ton-connect/dapps/send-toncoin`
- “Send USDT” → `/ecosystem/ton-connect/dapps/send-usdt`
- “Send a Jetton” → `/ecosystem/ton-connect/dapps/send-jetton`
- “Send an NFT” → `/ecosystem/ton-connect/dapps/send-nft`
- “Check Toncoin balance” → `/ecosystem/ton-connect/dapps/check-toncoin-balance`
- “Check USDT balance” → `/ecosystem/ton-connect/dapps/check-usdt-balance`
- “Check Jetton balance” → `/ecosystem/ton-connect/dapps/check-jetton-balance`
- “Check NFT items present” → `/ecosystem/ton-connect/dapps/check-nfts`
- “Track a transaction and confirm its status” → `/ecosystem/ton-connect/dapps/track-transaction`
- “Make a sign data request and verify signed data” → `/ecosystem/ton-connect/dapps/sign-data`
- “Make a proof request and verify it” → `/ecosystem/ton-connect/dapps/request-proof`
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format

---

- [ ] **20. Throat-clearing opener**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1#L8

The opening sentence is meta (“This guide helps you…”) instead of delivering the action. Replace with an imperative, answer-first sentence. Minimal fix: “Integrate your dApp with TON or build one from scratch using TON Connect and auxiliary libraries.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **21. Word choice and hyphenation (“use-cases”; “supervises”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1#L10

Prefer common wording and correct hyphenation: “use cases” (no hyphen) and “covers”/“supports” instead of “supervises”. Minimal fix: “…covers two common use cases: dApp integrations and custom wallet integrations.” (General English grammar used for hyphenation.)

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **22. H2 uses a noun; make imperative (“Integration”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1#L32

For procedural sections, headings should be imperative. Minimal fix: change “Integration” to “Integrate with your framework”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-2-gerunds-and-labels

---

- [ ] **23. Terminology consistency: “Dapp” vs “dApp”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1#L62

Use the same casing across the docs. Minimal fix (example JSON value): “Demo dApp with React UI”. Cross-doc usage matches: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/index.mdx?plain=1“Demo TON dApp with React”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **24. Ambiguous phrasing and undefined acronym in button guidance**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1#L91

Avoid filler and define acronyms on first use. Minimal fix: “Some in‑wallet browsers open a connection modal automatically. Still, provide a button in case the user dismisses the modal and wants to connect later.” Remove “(DYOR)” or define it as “do your own research (DYOR)”. Also simplify “show up a wallet connection modal window” → “show a wallet connection modal”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **25. Multiple headings are noun phrases; make imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1 (subsections)

Convert procedural headings to imperatives:
- “Manual connection initiation” → “Initiate a connection manually”.
- “UI customization” → “Customize the UI”.
- “Minimal React setup” → “Set up a minimal React app”.
- “Next.js” → “Integrate with Next.js”.
- “Vanilla JS” → “Use vanilla JS”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-2-gerunds-and-labels

---

- [ ] **26. Comma/filler and hyphenation (“Notice, that… end-user”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1#L146–147

Remove “Notice,” and fix hyphenation. Minimal fix: “The amount shown in your wallet may differ due to fees. Always account for fees and show them to the end user.” (General English grammar used for hyphenation.)

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **27. Safety callouts lack required elements**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1#L148–150,199–201

Caution callouts that involve sending funds must include risk, scope, rollback/mitigation, and environment label (testnet vs mainnet). Minimal fix: expand each Caution to specify: (1) risk of losing funds, (2) scope (connected wallet), (3) mitigation (use testnet first, send a small amount), (4) environment label with safer defaults (testnet recommended).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-3-safer-defaults

---

- [ ] **28. Partial snippet lacks “Not runnable” label**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1#L181–184 (Aside with WRONG assignment)

Focused excerpt is not runnable and should be labeled. Minimal fix: add a line “Not runnable” above the code block inside the Aside.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **29. JavaScript example: `try` without `catch`/`finally` (invalid syntax)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1#L342

Ensure examples are syntactically valid. Minimal fix: add a catch handler (`} catch (e) { console.error(e); }`) or remove the `try` wrapper to make the snippet valid JavaScript. (General JS syntax requirement.)

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules