### PR TITLE
[AI] fix: filetree.mdx

### DIFF
--- a/contribute/snippets/filetree.mdx
+++ b/contribute/snippets/filetree.mdx
@@ -13,6 +13,7 @@ To display the structure of a directory with file icons and collapsible subfolde
 ## Import
 
 Not runnable
+
 ```tsx
 import { FileTree } from '/snippets/filetree.jsx';
 ```
@@ -22,6 +23,7 @@ import { FileTree } from '/snippets/filetree.jsx';
 To display the file tree with file icons and collapsible subfolders using the `<FileTree>` component, specify the structure of your files and directories inside the [`items` property](#items) as a JavaScript list of objects and strings.
 
 Not runnable
+
 ```mdx
 import { FileTree } from '/snippets/filetree.jsx';
 
@@ -31,6 +33,7 @@ import { FileTree } from '/snippets/filetree.jsx';
 ### Specify files and placeholders
 
 Not runnable
+
 ```mdx
 import { FileTree } from '/snippets/filetree.jsx';
 
@@ -47,16 +50,17 @@ import { FileTree } from '/snippets/filetree.jsx';
 
 <FileTree
   items={[
-    "file-name-1",
-    "file-name-2",
-    "file-name-3",
-    "...",
-  ]}
+  "file-name-1",
+  "file-name-2",
+  "file-name-3",
+  "...",
+]}
 />
 
 ### Add notes
 
 Not runnable
+
 ```mdx
 import { FileTree } from '/snippets/filetree.jsx';
 
@@ -78,21 +82,22 @@ import { FileTree } from '/snippets/filetree.jsx';
 
 <FileTree
   items={[
-    "file-name-1",
-    { kind: "file", name: "file-name-2", note: "very important file" },
-    {
-      kind: "folder",
-      name: "best-folder",
-      note: "not really",
-      open: false,
-      items: ["file-name-3-within-subfolder"],
-    },
-  ]}
+  "file-name-1",
+  { kind: "file", name: "file-name-2", note: "very important file" },
+  {
+    kind: "folder",
+    name: "best-folder",
+    note: "not really",
+    open: false,
+    items: ["file-name-3-within-subfolder"],
+  },
+]}
 />
 
 ### Specify folders and their state
 
 Not runnable
+
 ```mdx
 import { FileTree } from '/snippets/filetree.jsx';
 
@@ -108,9 +113,9 @@ import { FileTree } from '/snippets/filetree.jsx';
 
 <FileTree
   items={[
-    { kind: "folder", name: "folder-1", open: true, items: ["something1"] },
-    { kind: "folder", name: "folder-2", items: ["something2"] },
-  ]}
+  { kind: "folder", name: "folder-1", open: true, items: ["something1"] },
+  { kind: "folder", name: "folder-2", items: ["something2"] },
+]}
   defaultOpen={false}
 />
 
@@ -143,7 +148,7 @@ Folders are open by default: their `open` property is `true` unless specified ot
 
 ### `defaultOpen`
 
-**type:** `boolean` <br/>
+**type:** `boolean` <br />
 **default:** `true`
 
 Whether to open all folders on page load. Can be overridden by the `open` property of the `FileTreeItem` entry.


### PR DESCRIPTION
- [ ] **1. Use “subdirectories/subfolders” (American English) instead of hyphenated forms**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/filetree.mdx?plain=1

The page uses hyphenated variants that are nonstandard in American English: “sub-directories” (lines 9, 21), “sub-directory” (line 9), and “sub-folders” (line 94). Replace with “subdirectories”, “subdirectory”, and “subfolders” respectively for consistency. Minimal fixes:
- Line 9: “sub-directories” → “subdirectories”; “sub-directory” → “subdirectory”.
- Line 21: “sub-directories” → “subdirectories”.
- Line 94 (code comment): “sub-folders” → “subfolders”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-6-spelling-and-contractions

---

- [ ] **2. Replace Latinism and filler with a direct statement**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/filetree.mdx?plain=1#L137

Current: “Notice that folders are open by default, i.e., their `open` property is `true` unless specified otherwise.” Prefer plain, direct wording and punctuation. Minimal fix:
- “Folders are open by default: their `open` property is `true` unless specified otherwise.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **3. Remove filler “Additionally,” from Aside for direct tone**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/filetree.mdx?plain=1#L11

The Aside starts with the filler adverb “Additionally,”. Use a direct statement. Minimal fix:
- “Additionally, you can add notes to files and directories.” → “You can add notes to files and directories.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **4. Use neutral, instructional example text (avoid subjective/humorous tone)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/filetree.mdx?plain=1#L63-L67

Example values use subjective/humorous phrasing: `note: "very important file"` and `note: "not really"`. Replace with neutral, instructional labels. Minimal fixes (examples):
- Line 63: `note: "very important file"` → `note: "example note"`
- Line 67: `note: "not really"` → `note: "example"`
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-5-comments-and-omissions

---

- [ ] **5. Simplify phrasing “upon the page load” to “on page load”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/filetree.mdx?plain=1#L144

Current: “Whether to open all folders upon the page load.” Use the standard concise form. Minimal fix:
- “Whether to open all folders on page load.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **6. Inconsistent “folder” vs “directory” terminology and hyphenation**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/filetree.mdx?plain=1#L9-L131–135

The page mixes “directory/sub-directory/sub-folders” with “folder,” which conflicts with the component API (`kind: "folder"`) and nearby usage. For consistency and clarity, use “folder/subfolder” throughout. Minimal fixes:
- Line 9: “sub-directories” → “subfolders”; “sub-directory” → “subfolder”.
- Line 11: “directories” → “folders”.
- Line 21: “sub-directories” → “subfolders”.
- Line 94: “sub-folders” → “subfolders”.
- Line 131: “— syntax for folders and directories,” → “— syntax for folders,”.
- Line 133: “the directory name” → “the folder name”.
- Line 134: “open the directory” → “open the folder”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **7. Partial snippets missing required “Not runnable” label**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/filetree.mdx?plain=1#L15–17, 23–27, 31–43, 56–73, 91–102

Multiple code fences are excerpts that are not runnable in isolation. Label each affected block with a plain “Not runnable” line immediately above the fence. Minimal fixes: add a single line “Not runnable” before the code blocks starting at lines 15, 23, 31, 56, and 91.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **8. Invalid inline code omission with literal ellipses**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/filetree.mdx?plain=1#L128-L131

Inline examples use “`...fields...`”, which is not valid syntax and violates the rule against literal ellipses for omissions. Use language-appropriate comments instead. Minimal fixes:
- Line 128: “`{ kind: "file", ...fields... }`” → “`{ kind: "file", /* fields shown below */ }`”.
- Line 131: “`{ kind: "folder", ...fields... }`” → “`{ kind: "folder", /* fields shown below */ }`”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-5-comments-and-omissions

---

- [ ] **9. Awkward phrasing in code comment**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/filetree.mdx?plain=1#L94

Prefer concise, idiomatic phrasing. Minimal fix in the comment: “Make all sub-folders be closed by default” → “Make all subfolders closed by default”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **10. Avoid synonym drift for the `note` property (“comment” vs “note”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/filetree.mdx?plain=1

The heading and prop descriptions use “comments” for the `note` field, introducing a synonym for the same concept. Minimal fixes:
- Line 54: “Add notes and comments” → “Add notes”.
- Line 130: “optional comment” → “optional note”.
- Line 133: “optional comment” → “optional note”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms

---

- [ ] **11. Use a stable permalink for the Implementation link**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/filetree.mdx?plain=1#L114

The “Implementation” link points to the `main` branch, which is a moving target. For precision-critical references to exact source, prefer a versioned or permanent URL. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references (Stable permalinks). Minimal fix: update the URL to a commit or tag permalink of `snippets/filetree.jsx`.