### PR TITLE
[AI] fix: config.mdx

### DIFF
--- a/ecosystem/blueprint/config.mdx
+++ b/ecosystem/blueprint/config.mdx
@@ -18,14 +18,14 @@ export const config: Config = {
 
 The configuration supports the following options:
 
-| Field                                                                 |                     Type/Values                     | Description                                                                              |
-| --------------------------------------------------------------------- | :-------------------------------------------------: | ---------------------------------------------------------------------------------------- |
-| [`plugins`](#plugins)                      |                      `Plugin[]`                     | Extend or customize the behavior.                                                        |
-| [`network`](#custom-network)               | `'mainnet'<br />'testnet'<br />`CustomNetwork` | Specifies the target network for deployment or interaction.                              |
-| `separateCompilables`                                                 |                      `boolean`                      | If `true`, `*.compile.ts` files go to `compilables/`. <br /> If `false`, to `wrappers/`. |
-| [`requestTimeout`](#request-timeouts)      |                       `number`                      | HTTP request timeout in milliseconds.                                                    |
-| [`recursiveWrappers`](#recursive-wrappers) |                      `boolean`                      | If `true`, searches `wrappers/` or `compilables/` recursively for contracts.             |
-| [`manifestUrl`](#ton-connect-manifest)     |                       `string`                      | Overrides the default TON Connect manifest URL.                                          |
+| Field                                      |                   Type/Values                   | Description                                                                              |
+| ------------------------------------------ | :---------------------------------------------: | ---------------------------------------------------------------------------------------- |
+| [`plugins`](#plugins)                      |                    `Plugin[]`                   | Extend or customize the behavior.                                                        |
+| [`network`](#custom-network)               | `'mainnet'<br />'testnet'<br />`CustomNetwork\` | Specifies the target network for deployment or interaction.                              |
+| `separateCompilables`                      |                    `boolean`                    | If `true`, `*.compile.ts` files go to `compilables/`. <br /> If `false`, to `wrappers/`. |
+| [`requestTimeout`](#request-timeouts)      |                     `number`                    | HTTP request timeout in milliseconds.                                                    |
+| [`recursiveWrappers`](#recursive-wrappers) |                    `boolean`                    | If `true`, searches `wrappers/` or `compilables/` recursively for contracts.             |
+| [`manifestUrl`](#ton-connect-manifest)     |                     `string`                    | Overrides the default TON Connect manifest URL.                                          |
 
 ## Plugins
 


### PR DESCRIPTION
- [ ] **1. Capitalize “Blueprint” as a proper noun**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/config.mdx?plain=1#L6-L32

“blueprint” is used as a common noun in prose, but elsewhere in the docs it’s a proper product name and should be capitalized. Change “blueprint features” → “Blueprint features” (line 6) and “blueprint’s core code” → “Blueprint’s core code” (line 32).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#general-casing-rules

---

- [ ] **2. Use a stable permalink for external code reference**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/config.mdx?plain=1#L5

The link points to a moving branch URL (“develop”), which can drift. For precision-critical code/file references, use a versioned or permanent URL (tag/commit) or link an internal reference if available. Replace the URL with a commit/tag permalink to `src/config/Config.ts`. If a canonical internal page exists, link that instead. Domain decision required to select the exact target.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#external-references

---

- [ ] **3. Make internal anchors relative (avoid absolute self-links)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/config.mdx?plain=1#L23-L28

Self-links in the table use absolute paths (`/ecosystem/blueprint/config#…`). Internal links SHOULD be relative and stable. Change to local anchors: `#plugins`, `#custom-network`, `#request-timeouts`, `#recursive-wrappers`, `#ton-connect-manifest`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#link-targets-and-format

---

- [ ] **4. Fix code span spacing in table Type/Values**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/config.mdx?plain=1#L24

There is a leading space inside the code span before ``CustomNetwork`` and stray spaces around `'mainnet'`/`'testnet'`. Code spans MUST contain only the literal. Remove the leading space and extra internal spaces so the cell reads: `'mainnet'<br />'testnet'<br />CustomNetwork`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#code-styling

---

- [ ] **5. Standardize “dApp” casing and define on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/config.mdx?plain=1#L48

Use the project-preferred casing “dApp” and expand the acronym on first mention. Change “creates a simple DApp” → “creates a simple decentralized application (dApp)”. This matches usage across the docs (e.g., https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/manifest.mdx?plain=1) and clarifies the term.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#acronyms-and-terms

---

- [ ] **6. Prefer a period instead of a semicolon in instruction**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/config.mdx?plain=1#L8-L9

Semicolons SHOULD be rare; prefer shorter sentences. Replace the semicolon with a period and capitalize the next sentence: “…named `config`. Do not use a `default` export:”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#commas-colons-semicolons

---

- [ ] **7. Define the `<YOUR_API_KEY>` placeholder on first use**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/config.mdx?plain=1#L63-L76

Placeholders MUST be defined on first use. Add a one-line definition immediately after the first snippet (before the CLI example), for example: “`<YOUR_API_KEY>` — your API key.” This is a basic placeholder definition (general knowledge).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#general-rules

---

- [ ] **8. Expand “CLI” on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/config.mdx?plain=1#L97

Spell out the term on first use and follow with the acronym. Change “using CLI” → “using the command-line interface (CLI)”. Later occurrences can use “CLI”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#acronyms-and-terms

---

- [ ] **9. Use “TON Mainnet” for the proper network name in comment**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/config.mdx?plain=1#L90

In the TypeScript comment, “Mainnet” should be the proper name. Change “for Mainnet” → “for TON Mainnet” to follow casing guidance for named networks.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#general-casing-rules

---

- [ ] **10. Add a language to the final code fence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/config.mdx?plain=1#L147-L149

Fenced code blocks MUST specify a language. Add `text` to the final code fence that contains only the manifest URL.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#general-rules

---

- [ ] **11. Link to the canonical reference anchor for `run`**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/config.mdx?plain=1#L79

When mentioning flags/options, link to the canonical reference anchor. Replace “See the `blueprint help run` for details.” with a link to the internal reference, e.g., “See [Blueprint reference → `run`](/ecosystem/blueprint/reference#run) for details.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#what-to-link-and-what-not

---

- [ ] **12. Sentence fragment in table cell**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/config.mdx?plain=1#L25

"If `false`, to `wrappers/`." is a fragment. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording. Minimal fix: "If `false`, they go to `wrappers/`."

---

- [ ] **13. Unclear capitalization/term for “Liteclient”; needs canonical term**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/config.mdx?plain=1#L81

The heading and prose use “Liteclient”, but the glossary is silent and no other pages establish this form. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms. Minimal fix (requires domain decision): pick a canonical form (e.g., a proper name or “lite client”) and apply consistently in the heading and body.

---

- [ ] **14. Weasel/filler word “certain”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/config.mdx?plain=1#L6

"…customize certain blueprint features" uses “certain,” which adds no information. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references. Minimal fix: remove the filler: "…customize Blueprint features."

---

- [ ] **15. TypeScript placeholder value is unquoted, making the snippet invalid**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/config.mdx?plain=1#L63

`key: <YOUR_API_KEY>,` is not valid TypeScript and may be parsed as a type assertion/generic. Examples must be copy‑pasteable unless marked as partial. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets. Minimal fix: quote the placeholder to preserve syntax and keep the `<ANGLE_CASE>` style: `key: '<YOUR_API_KEY>',`.

---

- [ ] **16. Relative “above” reference**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/config.mdx?plain=1#L68

“The above configuration is equivalent to running:” relies on a relative reference. Minimal fix: rephrase to “This configuration is equivalent to running:”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **17. Mainnet capitalization in comment (common noun)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/config.mdx?plain=1#L90

Comment reads “Use https://ton.org/global.config.json for Mainnet or any custom configuration”. Use lowercase “mainnet” when not referring to the proper name “TON Mainnet”. Minimal fix: “Use https://ton.org/global.config.json for mainnet or any custom configuration”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-3-hyphenation-and-abbreviations

---

- [ ] **18. Default manifest URL uses moving branch (“main”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/config.mdx?plain=1#L147

The default manifest URL is a raw GitHub link to the `main` branch, which can change over time. For normative defaults, prefer a versioned permalink (tag/commit) if available. Minimal fix: pin to a tag/commit URL for the manifest file. Requires domain owner confirmation of the correct stable target.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references

---

- [ ] **19. Inline code formatting missing for identifier “config”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/config.mdx?plain=1#L33

The sentence “add a `plugins` array to your config” mentions the exported identifier but does not format the final “config” as code. Code identifiers must use code font with exact case. Minimal fix: wrap the second occurrence in backticks: “add a `plugins` array to your `config`:”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-3-code-styling