### PR TITLE
[AI] fix: backups.mdx

### DIFF
--- a/ecosystem/node/mytonctrl/backups.mdx
+++ b/ecosystem/node/mytonctrl/backups.mdx
@@ -1,41 +1,44 @@
 ---
-title: "Backup"
+title: "Backup commands"
 description: "MyTonCtrl bundles helper scripts for creating and restoring node backups."
 ---
 
 import { Aside } from "/snippets/aside.jsx";
 
-<Aside type="caution">Exporting and restoring backups exposes private keys and validator configuration.
-Risk: key leakage allows account takeover; config mistakes can halt validation.
+<Aside type="danger">Exporting and restoring backups exposes private keys and validator configuration.
+Risk: key leakage allows account takeover. Config mistakes can halt validation.
 Scope: this node’s keys and validator state.
 Rollback: create a fresh backup first; you can restore it if needed.
 Environment: test on TON Testnet before using on TON Mainnet.</Aside>
 
 ## Operational notes
 
-- Backups capture MyTonCtrl data, validator config, and keyring files. Always store backup archives securely (they contain private keys).
+- Backups capture MyTonCtrl data, validator configuration, and keyring files. Always store backup archives securely (they contain private keys).
 - Restoration overwrites existing configuration. Ensure the donor node is offline before restoring its backup to avoid data divergence.
 - Both scripts expect `sudo` or equivalent privileges when manipulating system files. Use the `-u` flag to match the original install user if necessary.
 
-## create\_backup
+## `create_backup`
 
 **Purpose:** Generate a compressed archive containing MyTonCtrl configuration, keyring, and validator data.
 
 **Syntax**
 
+Not runnable
 ```mytonctrl
 create_backup [filename] [-u <user>]
 ```
+
+<FILENAME> — backup archive name or path; <USER> — system user to run scripts; <WORK_DIR> — MyTonCtrl work directory; <NODE_IP> — this node’s IP address (integer form as required by the script)
 
 **Behavior**
 
 - Exports the validator keyring via `exportallprivatekeys`, captures the current `config.json`, and stages them in a temporary directory.
 - Invokes `scripts/create_backup.sh` with:
-  - `-m` pointing to the MyTonCtrl working directory (usually `/var/ton-work`).
-  - `-t` referencing the temporary snapshot directory.
-  - Optional `-d <filename>` when you supply `filename`; otherwise the script chooses its own name.
-  - Optional `-u <user>` to run the backup script as a specific system user (defaults to the effective user).
-- Removes the temporary directory afterwards and prints `create_backup - OK` or `... - Error` based on the script’s exit code.
+  - `-m` pointing to the MyTonCtrl working directory (usually `/var/ton-work`)
+  - `-t` referencing the temporary snapshot directory
+  - Optional `-d <FILENAME>` when you supply `filename`; otherwise the script chooses its own name
+  - Optional `-u <USER>` to run the backup script as a specific system user (defaults to the effective user)
+- Removes the temporary directory afterward and prints `create_backup - OK` or `... - Error` based on the script’s exit code.
 
 **Examples**
 
@@ -44,12 +47,13 @@ create_backup
 create_backup mynode-backup-2024-05-01.tar -u validator
 ```
 
-## restore\_backup
+## `restore_backup`
 
 **Purpose:** Restore a previously created backup archive into the current node environment.
 
 **Syntax**
 
+Not runnable
 ```mytonctrl
 restore_backup <filename> [-y] [--skip-create-backup] [-u <user>]
 ```
@@ -61,7 +65,7 @@ restore_backup <filename> [-y] [--skip-create-backup] [-u <user>]
   - `--skip-create-backup` prevents MyTonCtrl from making a safety backup of the current state before restoring.
   - `-u <user>` runs the restore script as the specified system user (defaults to the current user).
 - Without `--skip-create-backup`, first calls `create_backup` with default arguments so you can roll back if needed.
-- Resolves the node’s IP address, then runs `scripts/restore_backup.sh` with `-m <work_dir>`, `-n <filename>`, `-i <node_ip>` (converted to integer form).
+- Resolves the node’s IP address, then runs `scripts/restore_backup.sh` with `-m <WORK_DIR>`, `-n <FILENAME>`, `-i <NODE_IP>` (converted to integer form).
 - If restoration succeeds and validator mode is active, reinitializes BTC Teleport to ensure the service still matches the restored state.
 - Exits MyTonCtrl after a successful restore so you can restart with the new configuration.
 


### PR DESCRIPTION
- [ ] **1. One-word generic title violates title rule**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/backups.mdx?plain=1#L2

The frontmatter `title` is a single generic word ("Backup"), which the guide disallows except on top-level pages or for proper names. Minimal fix: change to a descriptive, sentence‑case title such as "Backup commands" to make it self‑describing and compliant. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#title-vs-sidebar-semantics

---

- [ ] **2. Safety callout type should be danger (keys/validator risk)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/backups.mdx?plain=1#L8

The page handles private keys and validator configuration; per severity mapping, this is a Warning‑level risk and must render with `type="danger"`, not `type="caution"`. Minimal fix: change `<Aside type="caution">` to `<Aside type="danger">`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-1-when-a-safety-callout-is-required; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#admonition-levels-and-usage

---

- [ ] **3. Placeholder style in create_backup syntax**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/backups.mdx?plain=1#L26

Placeholders must use `<ANGLE_CASE>` and be uppercase. Current syntax uses `[filename]` and `<user>`. Minimal fix: `create_backup [<FILENAME>] [-u <USER>]`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **4. Placeholder style in restore_backup syntax**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/backups.mdx?plain=1#L53

Placeholders must use `<ANGLE_CASE>` and be uppercase. Current syntax uses `<filename>` and `<user>`. Minimal fix: `restore_backup <FILENAME> [-y] [--skip-create-backup] [-u <USER>]`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **5. Placeholder style in Behavior section (restore_backup)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/backups.mdx?plain=1#L64

Inline placeholders must use `<ANGLE_CASE>` and be uppercase. Current text uses `<work_dir>`, `<filename>`, and `<node_ip>`. Minimal fix: change to `<WORK_DIR>`, `<FILENAME>`, and `<NODE_IP>`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **6. Define placeholders on first use**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/backups.mdx?plain=1#L26

Placeholders are introduced but not defined. Minimal fix: after the first Syntax block, add a short definitions list, for example: `<FILENAME> — backup archive name or path; <USER> — system user to run scripts; <WORK_DIR> — MyTonCtrl work directory; <NODE_IP> — this node’s IP address (integer form as required by the script)`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **7. UI/log message styling is ambiguous and misformatted**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/backups.mdx?plain=1#L38

The output strings are shown in code font with an ellipsis (``create_backup - OK`` or ``... - Error``). If these are literal messages, they must appear in quotation marks (not code font) and without placeholder ellipses; if they are paraphrases, avoid quotes/code styling and state that they are summaries. Minimal fix: either (a) confirm the exact strings and render as “create_backup - OK” / “create_backup - Error” (punctuation outside per house style), or (b) rephrase to “prints a success or error summary” without code styling. Domain confirmation required to choose (a) vs (b). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#quotation-marks-and-emphasis; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#error-and-log-style

---

- [ ] **8. Command headings as identifiers should use code styling**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/backups.mdx?plain=1#L20; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/backups.mdx?plain=1#L47

Headings must use sentence case; for identifiers on reference pages, code font in headings is allowed. Current H2 headings use raw identifiers (`create_backup`, `restore_backup`) without sentence case or code font. Minimal fix: wrap command names in code font to leverage the reference exception, e.g., `## `create_backup`` and `## `restore_backup``. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles

---

- [ ] **9. Bracket notation (`[]`) in Syntax blocks violates placeholder rules**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/backups.mdx?plain=1#L26-L53

The Syntax lines use square brackets to denote optional items (`[filename]`, `[-y]`, `[--skip-create-backup]`, `[-u <user>]`). The style guide forbids `{}`/`[]` placeholder notation in commands. Show canonical invocations without brackets and indicate optionality via multiple lines or prose (e.g., list variants or describe optional flags under Behavior).
Minimal fix examples:
```mytonctrl
create_backup
create_backup <FILENAME> -u <USER>
```
```mytonctrl
restore_backup <FILENAME>
restore_backup <FILENAME> -y --skip-create-backup -u <USER>
```
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#severity-model-release‑blocking; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **10. Terminology consistency: “validator config” vs “validator configuration”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/backups.mdx?plain=1#L16

Use one term consistently on the page. Align “validator config” with “validator configuration” used elsewhere in this page and across MyTonCtrl docs. Minimal fix: change “validator config” to “validator configuration”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-terminology-and-naming

---

- [ ] **11. Non-sentence list items should omit trailing periods**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/backups.mdx?plain=1#L34

In the sub-list under “Invokes `scripts/create_backup.sh` with:”, each item is a fragment (“`-m` pointing to…”) but ends with a period. The guide asks to end with periods only when items are full sentences; otherwise omit terminal punctuation consistently. Minimal fix: remove the trailing periods from the four sub-bullets.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.4-lists

---

- [ ] **12. Prefer periods over semicolons for readability in callouts**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/backups.mdx?plain=1#L8

Within the opening `<Aside>`, “Risk: key leakage allows account takeover; config mistakes can halt validation.” uses a semicolon. Semicolons should be rare; shorter sentences improve scan speed. Minimal fix: replace the semicolon with a period: “Risk: key leakage allows account takeover. Config mistakes can halt validation.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.1-commas-colons-semicolons

---

- [ ] **13. Placeholder casing in Behavior details**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/backups.mdx?plain=1#L36

`-d <filename>` uses lower-case placeholder. Minimal fix: `-d <FILENAME>`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10.1-general-rules

---

- [ ] **14. Placeholder casing in Behavior details (user flag)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/backups.mdx?plain=1#L37

`-u <user>` uses lower-case placeholder. Minimal fix: `-u <USER>`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10.1-general-rules

---

- [ ] **15. Syntax blocks are partial; label as “Not runnable”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/backups.mdx?plain=1#L26

The “Syntax” code blocks use optional notation (e.g., `[filename]`) and are prototypes, not runnable commands. Partial snippets must be labeled “Not runnable” above the block. Minimal fix: insert a line `Not runnable` immediately above each Syntax code fence at lines 26 and 53.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **16. American English spelling (“afterward”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/backups.mdx?plain=1#L38

Use American spelling. “afterwards” (British) should be “afterward” (American). Minimal fix: replace “afterwards” with “afterward”. This relies on general knowledge about American vs. British variants.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-6-spelling-and-contractions