### PR TITLE
[AI] fix: library.mdx

### DIFF
--- a/tvm/serialization/library.mdx
+++ b/tvm/serialization/library.mdx
@@ -2,10 +2,10 @@
 title: "Library cells"
 ---
 
-Library cells allows to extend deduplication mechanism on-chain. This significantly reduces the size of serialized data
-and enables efficient storage of incrementally updated data. For the details see [library cells page](/ton/cells/library-cells).
-Always has level zero, so does not contain any higher hashes.
+Library cells allow extending the on-chain deduplication mechanism. This significantly reduces the size of serialized data
+and enables efficient storage of incrementally updated data. For details, see [Library cells](../../ton/cells/library-cells#low-level-details).
+A library cell always has level 0, so it does not contain higher hashes.
 
 Each library cell is serialized as follows:
-- The 1-byte tag that always equals to `0x02`.
-- The 256-bit [representation hash](/tvm/serialization/cells) of the library cell being referred to.
+- A 1-byte tag that always equals `0x02`.
+- The 256-bit [representation hash](./cells#standard-cell-representation-and-its-hash) of the referenced cell.


### PR DESCRIPTION
- [ ] **1. Fix subject–verb agreement and awkward infinitive in opening sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/library.mdx?plain=1#L5

“Library cells allows to extend deduplication mechanism on-chain.” uses the wrong verb form and awkward “allows to”. Minimal fix: “Library cells allow extending the on-chain deduplication mechanism.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **2. Add comma after introductory phrase and use precise link text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/library.mdx?plain=1#L6

“For the details see …” is missing a comma after the introductory phrase and uses generic link text. Minimal fix: “For details, see [Library cells](/ton/cells/library-cells).” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **3. Convert sentence fragment to a complete sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/library.mdx?plain=1#L7

“Always has level zero, so does not contain any higher hashes.” is a fragment. Minimal fix: “A library cell always has level 0, so it does not contain higher hashes.” This also aligns numeric style with the related concept page (https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/library-cells.mdx?plain=1#low-level-details). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **4. Correct “equals to” grammar in list item**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/library.mdx?plain=1#L10

“The 1-byte tag that always equals to `0x02`.” should not use “equals to”. Minimal fix: “A 1-byte tag that always equals `0x02`.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **5. Deep-link to the specific “representation hash” section**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/library.mdx?plain=1#L11

The link points to the page top. Cross-section links should target specific anchors. Minimal fix: change to “[representation hash](/tvm/serialization/cells#standard-cell-representation-and-its-hash)”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-3-links-and-anchors

---

- [ ] **6. Deep-link to the relevant section instead of page top**

`https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/library.mdx?plain=1#L6`

Link directly to the most relevant section on the target page. Minimal fix: update the link to `../../ton/cells/library-cells#low-level-details`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#links-and-anchors

---

- [ ] **7. Replace "being referred to" with concise "referenced cell"**

`https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/library.mdx?plain=1#L11`

Tighten phrasing. Minimal fix: "... of the referenced cell."
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#plain-precise-wording

---

- [ ] **8. Internal link should be relative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/library.mdx?plain=1#L6

The internal link uses an absolute path: `[library cells page](/ton/cells/library-cells)`. The guide recommends relative, stable links. Minimal fix: `[library cells page](../../ton/cells/library-cells)`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format (internal links should be relative and stable).

---

- [ ] **9. Deep-link to the specific section and use a relative link**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/library.mdx?plain=1#L11

“[representation hash](/tvm/serialization/cells)” links to the page top and uses an absolute path. Per the guide, cross-section links should target specific anchors and be relative. Minimal fix: “./cells#standard-cell-representation-and-its-hash”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format.