### PR TITLE
[AI] fix: api-endpoints.mdx

### DIFF
--- a/ecosystem/tma/analytics/api-endpoints.mdx
+++ b/ecosystem/tma/analytics/api-endpoints.mdx
@@ -1,5 +1,4 @@
-title: "API endpoints"
----
+## title: "API endpoints"
 
 View available endpoints and request formats.
 
@@ -17,35 +16,35 @@ The request body may be an array of events; each event must match the schema bel
 
 #### Required
 
-| Field        | Type   | Description                                                                                                                                               |
-| ------------ | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `user_id`    | number | Unique identifier for the user.                                                                                                                           |
-| `event_name` | string | The name of the event from the [supported events](./supported-events.mdx).                                                                                |
-| `session_id` | string | Session identifier for tracking user sessions; must be a UUID.                                                                                             |
-| `app_name`   | string | The name of the application that you specified when creating the token.                                                                                   |
+| Field        | Type   | Description                                                                |
+| ------------ | ------ | -------------------------------------------------------------------------- |
+| `user_id`    | number | Unique identifier for the user.                                            |
+| `event_name` | string | The name of the event from the [supported events](./supported-events.mdx). |
+| `session_id` | string | Session identifier for tracking user sessions; must be a UUID.             |
+| `app_name`   | string | The name of the application that you specified when creating the token.    |
 
 #### Optional
 
-| Field              | Type                                  | Description                                                                                   |
-| ------------------ | ------------------------------------- | --------------------------------------------------------------------------------------------- |
-| `is_premium`       | boolean                               | If the user has a premium account, default: false.                                            |
-| `is_success`       | boolean                               | Indicates whether a wallet is connected or the transaction was successful, default: false.    |
-| `error_message`    | string                                | Error message if the wallet connection or transaction is unsuccessful.                        |
-| `error_code`       | number                                | Error code if the wallet connection or transaction is unsuccessful.                           |
-| `wallet_address`   | string                                | Wallet address involved in the event.                                                         |
-| `wallet_type`      | string                                | Type of the wallet.                                                                           |
-| `wallet_version`   | string                                | Version of the wallet software.                                                               |
-| `auth_type`        | enum                                  | Type of authorization used. `0`: `ton_addr`; `1`: `ton_proof`.                                |
-| `valid_until`      | string                                | Timestamp until which the transaction offer is valid.                                         |
-| `from`             | string                                | Wallet address initiating the transaction.                                                    |
-| `messages`         | `{ address: string; amount: string }` | List of transactions `{to, amount}` involved in the event.                                    |
-| `custom_data`      | object                                | Object to store custom event details as needed.                                               |
-| `client_timestamp` | string                                | The time when the event occurred on the client.                                               |
-| `platform`         | string                                | The platform from which the Mini App was opened.                                              |
-| `locale`           | string                                | User language code.                                                                           |
-| `start_param`      | string                                | `tgWebAppStartParam`.                                                                         |
-| `url_referer`      | string                                | The URL of the web application from which the request was sent.                               |
-| `scope`            | string                                | Event scope.                                                                                  |
+| Field              | Type                                  | Description                                                                                |
+| ------------------ | ------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `is_premium`       | boolean                               | If the user has a premium account, default: false.                                         |
+| `is_success`       | boolean                               | Indicates whether a wallet is connected or the transaction was successful, default: false. |
+| `error_message`    | string                                | Error message if the wallet connection or transaction is unsuccessful.                     |
+| `error_code`       | number                                | Error code if the wallet connection or transaction is unsuccessful.                        |
+| `wallet_address`   | string                                | Wallet address involved in the event.                                                      |
+| `wallet_type`      | string                                | Type of the wallet.                                                                        |
+| `wallet_version`   | string                                | Version of the wallet software.                                                            |
+| `auth_type`        | enum                                  | Type of authorization used. `0`: `ton_addr`; `1`: `ton_proof`.                             |
+| `valid_until`      | string                                | Timestamp until which the transaction offer is valid.                                      |
+| `from`             | string                                | Wallet address initiating the transaction.                                                 |
+| `messages`         | `{ address: string; amount: string }` | List of transactions `{to, amount}` involved in the event.                                 |
+| `custom_data`      | object                                | Object to store custom event details as needed.                                            |
+| `client_timestamp` | string                                | The time when the event occurred on the client.                                            |
+| `platform`         | string                                | The platform from which the Mini App was opened.                                           |
+| `locale`           | string                                | User language code.                                                                        |
+| `start_param`      | string                                | `tgWebAppStartParam`.                                                                      |
+| `url_referer`      | string                                | The URL of the web application from which the request was sent.                            |
+| `scope`            | string                                | Event scope.                                                                               |
 
 ### Request body examples
 


### PR DESCRIPTION
- [ ] **1. Title uses Title Case; sentence case required**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/api-endpoints.mdx?plain=1#L2

The frontmatter `title` is "API Endpoints" (Title Case). Headings and titles must use sentence case. Minimal fix: change to `title: "API endpoints"` (keep "API" uppercase as an acronym). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form

---

- [ ] **2. Throat-clearing introduction; replace with a direct purpose**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/api-endpoints.mdx?plain=1#L5-L6

"Here you can view information about existing endpoints and how to make requests for them." is meta/throat‑clearing. Replace with a direct purpose sentence, e.g., "View available endpoints and request formats." or remove the sentence. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **3. Bare URL as link text; use descriptive text and code font for endpoint**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/api-endpoints.mdx?plain=1#L10

The link text is a bare URL. Link text must be descriptive; API endpoints should use code formatting. Minimal fix: replace with `Requests URL: \`https://tganalytics.xyz/events\`` or use a descriptive link like `[Events endpoint](https://tganalytics.xyz/events)`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-3-code-styling

---

- [ ] **4. Informal phrasing and typo "scheme" → "schema"**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/api-endpoints.mdx?plain=1#L18

"The main thing is that... satisfy the scheme" is informal and uses the wrong term. Minimal fix: "The request body may be an array of events; each event must match the schema below." Add a terminal period. (General knowledge: "schema" is the correct term in API docs.) Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **5. Inconsistent terminal punctuation in Required table**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/api-endpoints.mdx?plain=1#L22-L27

Descriptions mix sentences with/without periods (e.g., `app_name` row lacks a period). Make terminal punctuation consistent: either end all sentence-style descriptions with periods or none; prefer periods for full sentences. Minimal fix: add a period to the `app_name` row. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **6. Overuse of bold for emphasis in table**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/api-endpoints.mdx?plain=1#L26

"**Must be**" uses bold for emphasis inside prose. Avoid bold for emphasis; use plain wording. Minimal fix: change to "must be a UUID" (no bold) and keep casing per sentence case. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **7. Default value phrasing uses hyphen; prefer colon and period**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/api-endpoints.mdx?plain=1#L33-L34

"by default - false" uses a hyphen incorrectly. Minimal fix: "default: false." (lowercase "default", colon, and terminal period). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **8. Redundant "Description:" prefix in table cell**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/api-endpoints.mdx?plain=1#L36

"Description: error code..." contains boilerplate. Remove the redundant label. Minimal fix: "Error code if the wallet connection or transaction is unsuccessful." Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **9. Field description and type mismatch for `messages`**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/api-endpoints.mdx?plain=1#L43

Type shows `{ address: string; amount: string }` but the description references `{to, amount}`. This internal inconsistency reduces clarity. Minimal fix (requires domain owner confirmation): update the description to `{ address, amount }` or adjust the type to `{ to, amount }` to match. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules (code identifiers exact) and style_of_issues truthfulness/internal consistency

---

- [ ] **10. Terminology: "MiniApp" should be "Mini App"**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/api-endpoints.mdx?plain=1#L46

Terminology should follow the canonical term. Elsewhere we use "Telegram Mini Apps"/"Mini App" (with a space), not "MiniApp". Minimal fix: "The platform from which the Mini App was opened." Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-1-term-bank-canonical-source; Evidence: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/overview.mdx?plain=1#telegram-mini-apps-tma

---

- [ ] **11. Missing terminal periods across Optional table descriptions**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/api-endpoints.mdx?plain=1#L35-L50

Many description cells lack terminal periods while others include them. Make punctuation consistent across the table; end sentence-style descriptions with periods. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **12. Unresolved placeholder note "(TO DO link)"**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/api-endpoints.mdx?plain=1#L112

A placeholder note remains and the link is missing. Links must resolve and avoid placeholders. Minimal fix: replace with an internal link to the token instructions, e.g., "Specify the token obtained during setup (see [Installation](/ecosystem/tma/analytics/analytics#installation))." Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format; Global overrides: broken/missing anchors (HIGH)

---

- [ ] **13. Placeholder formatting: use `<PLACEHOLDER>` style**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/api-endpoints.mdx?plain=1#L116

The example uses `"YOUR_TOKEN"`. Placeholders must be formatted as `<LIKE_THIS>`. Minimal fix: `"TGA-Auth-Token": "<YOUR_TOKEN>"`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#0-purpose-scope-and-normative-terms (Definitions → Placeholder)

---

- [ ] **14. Example type mismatch: `error_code` is `number` in table but `null` in example**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/api-endpoints.mdx?plain=1#L36-L94

The Optional table defines `error_code` as `number`, but the example sets it to `null`. Minimal fix (requires domain owner confirmation): either change the type to `number | null` in the table, set a numeric example value, or omit the field when not applicable. Rule: style_of_issues → Truthfulness and internal consistency

---

- [ ] **15. Extra space after colon in several response descriptions**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/api-endpoints.mdx?plain=1#L147-L180

"Description:  the ..." contains a double space after the colon. Use a single space. Minimal fix: "Description: the ..." Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **16. External code link uses moving branch; avoid volatile targets**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/api-endpoints.mdx?plain=1#L26

The UUID link points to `.../blob/master/...`, which is a moving target. For code references, use a stable permalink or remove the link if not essential. Minimal fix: remove the link and keep plain "UUID". Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references (Stable permalinks)

---

- [ ] **17. Enumeration punctuation in `auth_type` description**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/api-endpoints.mdx?plain=1#L40

Enumeration uses hyphens with spaces ("`0` - `ton_addr`, `1` - `ton_proof`"). Prefer colon/em‑dash and consistent punctuation. Minimal fix: "`0`: `ton_addr`; `1`: `ton_proof`." Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **18. Imperative phrasing in Headers instruction**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/api-endpoints.mdx?plain=1#L112

"you need to specify" is wordy; prefer a direct imperative. Minimal fix: "Set `TGA-Auth-Token` to `<YOUR_TOKEN>` obtained during setup." Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **19. Missing internal link to Supported events**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/api-endpoints.mdx?plain=1#L25

First useful mention of a referenced item should link to its canonical page. Minimal fix: link "supported events" to `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/supported-events.mdx?plain=1`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12.2-what-to-link-and-what-not

---

- [ ] **20. Incorrect code fence language for HTTP headers**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/api-endpoints.mdx?plain=1#L114

HTTP headers are shown as JSON; use an appropriate fence like `http` or `text` for header examples. Minimal fix: change the code fence from ```json to ```http (or ```text).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10.1-language-tags-and-formatting

---

- [ ] **21. Sentence lists without terminal periods**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/api-endpoints.mdx?plain=1#L125-L203

List items that are full sentences should end with periods. Minimal fix: add a period at the end of each "Description:" bullet under Responses.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.4-lists

---

- [ ] **22. Inconsistent response object shape**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/api-endpoints.mdx?plain=1#L128-L210

Some responses include only `message`; one includes both `status` and `message`. Reference pages must be precise and consistent across entries. Minimal fix: standardize the response schema across examples (either include `status` everywhere or remove it). Domain decision required.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#3-doc-types-and-layouts

---

- [ ] **23. Duplicate subheadings “HTTP400” at same level**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/api-endpoints.mdx?plain=1#L134-L178

Headings must be unique at the same nesting level to avoid anchor collisions and improve TOC clarity. Minimal fix: make each subheading unique by appending a short descriptor, for example, "HTTP 400 — server error", "HTTP 400 — token missing/format", "HTTP 400 — invalid token", "HTTP 400 — app name mismatch", "HTTP 400 — validation error" (use existing descriptions; no new facts).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.3-uniqueness-and-linkability

---

- [ ] **24. Wordy/passive summary under "POST events"**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/api-endpoints.mdx?plain=1#L14

"This request is needed to record an event in the database" is passive and verbose. Minimal fix: "Use this request to record an event." (active, direct).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-1-voice-tense-and-person; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **25. Grammar in `valid_until` description**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/api-endpoints.mdx?plain=1#L41

"Timestamp until when a transaction offer is valid" is awkward. Minimal fix: "Timestamp until which the transaction offer is valid.".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-grammar-and-usage

---

- [ ] **26. Sentence capitalization and spacing in response descriptions**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/api-endpoints.mdx?plain=1#L125

Several list item descriptions start with lowercase ("the", "an") and some have double spaces after a colon ("Description:  the"). Minimal fixes: capitalize the first word of each sentence and use single spaces after colons; end descriptions with periods for consistency.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#8-1-paragraphs-and-sentences

---

- [ ] **27. Unexplained term "Data Chief bot" without internal reference**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/api-endpoints.mdx?plain=1#L158

The page mentions "Data Chief bot" but the corpus pages in this section refer to Managing integration via TON Builders and do not define this term (see https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/managing-integration.mdx?plain=1). Minimal fix: replace the parenthetical with an internal reference or remove it. Example: "the entered token is invalid" or "the entered token is invalid (see [Managing integration](/ecosystem/tma/analytics/managing-integration))." (Needs domain confirmation on exact source of tokens.)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17-4-proofread

---

- [ ] **28. Heading "Request body example" is singular while multiple examples follow**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/api-endpoints.mdx?plain=1#L52

There are multiple request body examples, but the heading is singular. Minimal fix: change to "Request body examples".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-5-practical-length-norms

---

- [ ] **29. HTTP 400 description claims server issues (status plausibility)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/api-endpoints.mdx?plain=1#L136-L143

"The event was not recorded due to server issues" under HTTP 400 conflicts with general HTTP semantics (4xx indicates client errors; 5xx indicates server errors). Minimal fix: needs domain decision — either change the status to 5xx, or adjust the description to a client-side cause. (This relies on general HTTP knowledge.)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#9-4-reference-complete-factual