### PR TITLE
[AI] fix: preparation.mdx

### DIFF
--- a/ecosystem/tma/analytics/preparation.mdx
+++ b/ecosystem/tma/analytics/preparation.mdx
@@ -1,20 +1,20 @@
-# Preparations
+## Preparations
 
 ### Connect the TON Connect SDK
 
-Web3 events for the Telegram Mini Apps Analytics SDK are supported by the [`@tonconnect/ui`](https://www.npmjs.com/package/@tonconnect/ui) and [`@tonconnect/ui-react`](https://www.npmjs.com/package/@tonconnect/ui-react) libraries since version 2.0.3, [`@tonconnect/sdk`](https://www.npmjs.com/package/@tonconnect/sdk) since version 3.0.3.
+web3 events for the Telegram Mini Apps Analytics SDK are supported by the [`@tonconnect/ui`](https://www.npmjs.com/package/@tonconnect/ui) and [`@tonconnect/ui-react`](https://www.npmjs.com/package/@tonconnect/ui-react) libraries since version 2.0.3, [`@tonconnect/sdk`](https://www.npmjs.com/package/@tonconnect/sdk) since version 3.0.3.
 
-[Read more about TON Connect integration](https://github.com/ton-connect)
+[TON Connect overview](/ecosystem/ton-connect/index)
 
-Don't worry if your app doesn't use TON Connect, the analytics SDK will still work and collect non-Web3 events.
+If your app doesn't use TON Connect, the analytics SDK still collects non-web3 events.
 
 ### Get the token with TON Builders
 
-Register your project on [TON Builders](https://builders.ton.org) and go to the Analytics tab.
+Register your project on [TON Builders](https://builders.ton.org) and go to the "Analytics" tab.
 
-![](/resources/images/tma-analytics/analytics-preparations-1.png)
+![Analytics tab in TON Builders](/resources/images/tma-analytics/analytics-preparations-1.png)
 
-Enter your Telegram Bot URL and mini app domain to receive an **API key** for SDK initialization. You can also manage your existing keys from the same section. Enter your Telegram Bot URL and mini app domain to receive a token for SDK initialization.
+Enter your Telegram bot URL and Mini App domain to receive an access token for SDK initialization. You can also manage your existing keys from the same section.
 
 ### Initialize SDK
 


### PR DESCRIPTION
- [ ] **1. H1 used in MDX content; start at H2**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/preparation.mdx?plain=1

The page begins with `# Preparations`, but MDX content must not include an H1; pages must start headings at H2. Minimal fix: change `# Preparations` to `## Preparations` (or move the title to frontmatter and remove the in-body H1). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles

---

- [ ] **2. External link used where internal canonical exists**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/preparation.mdx?plain=1

“Read more about TON Connect integration” links to `https://github.com/ton-connect` (repo root). Per “Internal first,” prefer the internal overview page. Minimal fix: change the link to `[TON Connect overview](/ecosystem/ton-connect/index)`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not

---

- [ ] **3. Comma splice and informal tone in reassurance sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/preparation.mdx?plain=1

“Don't worry if your app doesn't use TON Connect, the analytics SDK will still work and collect non-Web3 events.” uses a comma splice and informal reassurance. Minimal fix: “If your app doesn't use TON Connect, the analytics SDK still collects non‑Web3 events.” (split the clause and use neutral tone). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **4. Duplicate sentence and inconsistent term (“API key” vs “token”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/preparation.mdx?plain=1

The paragraph repeats “Enter your Telegram Bot URL and mini app domain to receive …” and mixes “API key” and “token”. Elsewhere in this section, and in `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/analytics.mdx?plain=1`, the term “access token”/“token” is used. Minimal fix: remove the duplicate sentence and use one consistent term: “Enter your Telegram Bot URL and Mini App domain to receive an access token for SDK initialization.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-terminology-and-naming. Cross‑doc: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/analytics.mdx?plain=1#installation

---

- [ ] **5. Missing alt text for image**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/preparation.mdx?plain=1

The image is embedded with an empty alt attribute `![](...)`. Provide descriptive alt text to aid accessibility. Minimal fix: `![Analytics tab in TON Builders](/resources/images/tma-analytics/analytics-preparations-1.png)`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#15-2-structure-and-tables

---

- [ ] **6. Mid‑sentence capitalization of common noun (“Telegram Bot URL”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/preparation.mdx?plain=1#L17

“Bot” is capitalized mid‑sentence in “Telegram Bot URL.” As a common noun, it should be lowercase. Minimal fix: “Telegram bot URL”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules

---

- [ ] **7. Inconsistent casing for “web3”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/preparation.mdx?plain=1#L5-L9

“Web3 events” and “non-Web3 events” use capitalized “Web3”, while other pages use lowercase “web3” (e.g., https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/index.mdx?plain=1#are-you-building-a-web3-app). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#terminology-and-naming (Follow canonical casing; keep terminology consistent across the docs). Minimal fix: change to “web3 events” and “non-web3 events”.

---

- [ ] **8. UI label not quoted**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/preparation.mdx?plain=1#L13

The tab name Analytics is a literal UI label and should be quoted. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#quotation-marks-and-emphasis (UI/log strings must appear verbatim in quotation marks; punctuation remains outside). Minimal fix: “Register your project on TON Builders and go to the “Analytics” tab.”