### PR TITLE
[AI] fix: hosting.mdx

### DIFF
--- a/ecosystem/tma/mate/hosting.mdx
+++ b/ecosystem/tma/mate/hosting.mdx
@@ -1,29 +1,28 @@
 ---
-title: "Hosting"
+title: "Mate hosting"
 ---
 
 With Mate's fast and reliable hosting, developers can effectively manage static
-assets for their mini applications. Delivering static files efficiently and
+assets for their mini apps. Delivering static files efficiently and
 securely is vital for optimal performance.
 
-By utilizing a Content Delivery Network (CDN), Mate's hosting boosts reliability
-and accelerates file loading for users across various regions, surpassing the
-performance of single-server solutions.
+By using a content delivery network (CDN), Mate's hosting boosts reliability
+and accelerates file loading for users across various regions.
 
 The hosting service is free, though there are some limitations on data transfer.
 
-<Warning>
-  If you’re currently using a single server for both static file hosting and server-side operations, transitioning to Mate's hosting may require code adjustments. If your app already distinguishes between static and dynamic requests, integration will be much simpler.
-</Warning>
+<Aside type="note" title="Important">
+  If you’re using a single server for both static file hosting and server-side operations, transitioning to Mate's hosting may require code adjustments. If your app already distinguishes between static and dynamic requests, integration will be much simpler.
+</Aside>
 
-### Important recommendation
+## Important recommendation
 
-When deploying an SPA on a static hosting platform (like Mate's hosting), it’s crucial to choose
+When deploying a single-page application (SPA) on a static hosting platform (like Mate's hosting), use
 routing methods that do not depend on server-side configurations.
 
-Hash-based routing (using the `#` symbol in URLs) is a simple and effective way to manage routes without needing server support. Many frameworks offer built-in solutions or plugins to implement this type of routing.
+Hash-based routing (using the `#` symbol in URLs) manages routes without server support. Many frameworks offer built-in solutions or plugins to implement this type of routing.
 
-For instance, if you are using _React_, use `HashRouter` instead of `BrowserRouter`:
+For instance, if you are using React, use `HashRouter` instead of `BrowserRouter`:
 
 ```jsx
 import { HashRouter as Router, Route, Switch } from 'react-router-dom';
@@ -44,15 +43,14 @@ export default App;
 
 ## Features
 
-### Lightning Speed
+### Content delivery network
 
-The crucial feature of Mate's hosting is its well-configured Content Delivery
-Network spread across the world, in countries where mini applications are
+The crucial feature of Mate's hosting is its well-configured content delivery
+network spread across the world, in countries where mini apps are
 commonly used. This feature allows developers to focus on building their
-applications rather than worrying about how to deliver static assets as quickly
-as possible.
+applications rather than worrying about how to deliver static assets quickly.
 
-### Version Management System
+### Version management system
 
 Another notable hosting feature is the version management system.
 
@@ -60,7 +58,7 @@ Mate allows the creation of up to five deployment tags, enabling developers to
 deploy the project with a specific tag without affecting previously deployed
 assets.
 
-#### Usage Example
+#### Usage example
 
 A common use case here is when the project has two versions: `latest` and
 `staging`. The developer can use the `latest` version for production and
@@ -70,12 +68,12 @@ After deploying the `staging` assets, the QA team checks if this staging state
 is acceptable. Then, the same assets can be deployed with the `latest` tag for
 production.
 
-#### About Base URL
+#### About base URL
 
 When deploying static assets, Mate uses the following base URL pattern:
 
-```
-https://{storage_key}.tapps.global/{tag}
+```text
+https://<STORAGE_KEY>.tapps.global/<TAG>
 ```
 
 Here’s some information on these parameters for clarification:
@@ -83,7 +81,7 @@ Here’s some information on these parameters for clarification:
 - `storage_key`: a unique key for the deployed project. This value is
   non-configurable and is assigned to the project upon creation.
 - `tag`: a deployment tag. This value is set during the deployment process by
-  the developer. Examples include `staging`, `latest`, `dev`, etc.
+  the developer. Examples include `staging`, `latest`, and `dev`.
 
 ## Getting started
 
@@ -91,18 +89,18 @@ Here’s some information on these parameters for clarification:
 
 To start using the hosting functionality, you must register the project and
 obtain its deployment token. To get the token, go
-to [`@tma_mate_bot`](https://t.me/tma_mate_bot) and press the `Start` button to
+to [`@tma_mate_bot`](https://t.me/tma_mate_bot) and press the "Start" button to
 begin the conversation with the bot.
 
 <p align="center">
-  <img src="/resources/images/tma-mate/start.png" width="320" />
+  <img src="/resources/images/tma-mate/start.png" width="320" alt="Start screen of the bot" />
 </p>
 
-Next, press the `Create a Project` button and enter the title of the project to
+Next, press the "Create a Project" button and enter the title of the project to
 be created, following the specified rules.
 
 <p align="center">
-  <img src="/resources/images/tma-mate/create.png" width="320" />
+  <img src="/resources/images/tma-mate/create.png" width="320" alt="Create project screen" />
 </p>
 
 After this step, the bot will return the created project information, including
@@ -112,25 +110,25 @@ the **deployment token**.
 
 Before deploying the project, ensure that all static assets have a valid base
 URL. You can learn more about how Mate generates the static assets base
-URL [here](#about-base-url).
+URL. See [About base URL](#about-base-url).
 
 To retrieve the project deployment information using a specific tag, use the
 following command:
 
 ```bash
 mate deploy info \
-  --token {DEPLOYMENT_TOKEN} \
-  --project {PROJECT_ID} \
-  --tag {TAG}
+  --token <DEPLOYMENT_TOKEN> \
+  --project <PROJECT_ID> \
+  --tag <TAG>
 ```
 
-Here, the `DEPLOYMENT_TOKEN` and `PROJECT_ID` values refer to the deployment
-token and project identifier received from the previous step. `TAG` is a
+Here, the <DEPLOYMENT_TOKEN> and <PROJECT_ID> values refer to the deployment
+token and project identifier received from the previous step. <TAG> is a
 deployment version tag name.
 
 Output example:
 
-```
+```text
 ✔ Fetched deploy information for paper-planes (id 48) project
 Project Title: paper-planes
 Short title of the project
@@ -172,7 +170,7 @@ present in the directory.
 Let’s assume the following conditions:
 
 - A project with ID `48` and token `aabbccdd` was created.
-- A folder named `dist` contains all the mini application built static assets.
+- A folder named `dist` contains all the mini app built static assets.
 - It is required to deploy the static assets with the tag `latest`.
 
 To deploy the project under these conditions, run the following command:
@@ -180,14 +178,14 @@ To deploy the project under these conditions, run the following command:
 ```bash
 mate deploy upload \
   --dir dist \
-  --token TOKEN \
+  --token <TOKEN> \
   --project 48 \
   --tag latest
 ```
 
 Here’s the possible output:
 
-```
+```text
 ✔ Fetched deploy information for paper-planes (id 48) project
 i Assets base path (using tag "latest"):
 https://35f105bd6b.tapps.global/latest
@@ -200,34 +198,35 @@ i Maximum files count: 100
 ╰ 📄 index.js (https://35f105bd6b.tapps.global/latest/index.js)
 ```
 
-> \[!WARNING]
-> The deployed directory must include only standard files and directories,
-> excluding private ones (starting with the `.` symbol). All other types of
-> files (such as symlinks) are forbidden. If found during the deployment process,
-> the CLI tool will throw a corresponding error.
+<Aside type="danger" title="Warning">
+  The deployed directory must include only standard files and directories,
+  excluding private ones (starting with the `.` symbol). All other types of
+  files (such as symlinks) are forbidden. If found during the deployment process,
+  the CLI tool will throw a corresponding error.
+</Aside>
 
-### Verify deployment and configure TMA
+### Verify deployment and configure Telegram Mini Apps (TMA)
 
 After deploying, it’s recommended to verify that your application is working correctly
 by accessing it via the direct link:
 
-```
-https://{storage_key}.tapps.global/{tag}/index.html
+```text
+https://<STORAGE_KEY>.tapps.global/<TAG>/index.html
 ```
 
-If everything functions properly, use this link as the web app URL when creating your Telegram mini-app.
+If everything functions properly, use this link as the web app URL when creating your Telegram mini app.
 
 **Example:**
 
 If your `storage_key` is `35f105bd6b` and your tag is `latest`, the link will look like this:
 
-```
+```text
 https://35f105bd6b.tapps.global/latest/index.html
 ```
 
-Ensure that when you navigate to this link, your application loads and operates without errors. This guarantees that your Telegram mini-app will work correctly with your hosting setup.
+Ensure that when you navigate to this link, your application loads and operates without errors. This guarantees that your Telegram mini app will work correctly with your hosting setup.
 
-## Using config
+## Use config
 
 To avoid repeatedly specifying parameters, Mate allows creating a special
 configuration with all the parameters included.
@@ -257,22 +256,3 @@ deploy:
 
 Then, the `info` and `upload` commands will retrieve the values from the
 configuration.
-
-```sh
-# Both of these commands will use
-# the options from the Mate config prior:
-# --project = 48
-# --dir "dist"
-# --token "TOKEN"
-# --tag "latest"
-mate deploy info
-mate deploy upload
-```
-
-If any parameter override is required, it should be specified in the command.
-For example, to override the `tag` option with the `staging` value, use the
-following command:
-
-```sh
-mate deploy info --tag staging
-```


### PR DESCRIPTION
- [ ] **1. Admonition component must use `<Aside>` (custom `<Warning>` used)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/hosting.mdx?plain=1#L15

The page uses a custom `<Warning>` component. Per the guide, callouts must use the `<Aside>` component with supported `type` values. Minimal fix: replace the block with `<Aside type="note" title="Important">…</Aside>` (or another supported `type` that matches severity).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#rendering-component-high; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#a-admonition-levels-and-usage

---

- [ ] **2. Blockquote callout `[!WARNING]` used instead of `<Aside>`**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/hosting.mdx?plain=1#L203-L207

Markdown blockquotes must not simulate callouts. Minimal fix: replace the entire block with `<Aside type="danger" title="Warning">…</Aside>` (mapping: Warning → `type="danger"`).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#rendering-component-high; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#a-admonition-levels-and-usage

---

- [ ] **3. First heading starts at H3; must start at H2**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/hosting.mdx?plain=1#L19

Headings in MDX must begin at H2. Minimal fix: change `### Important recommendation` to `## Important recommendation`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form

---

- [ ] **4. Headings use Title Case; sentence case required**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/hosting.mdx?plain=1#L47-L73

Headings must be sentence case. Minimal fixes:
- `### Lightning Speed` → `### Lightning speed`
- `### Version Management System` → `### Version management system`
- `#### Usage Example` → `#### Usage example`
- `#### About Base URL` → `#### About base URL`
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form

---

- [ ] **5. Non-descriptive link text “here”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/hosting.mdx?plain=1#L115

Link text must be descriptive. Minimal fix: replace `URL [here](#about-base-url)` with a descriptive link, e.g., `See [About base URL](#about-base-url)`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text

---

- [ ] **6. Placeholders in commands use `{...}`; must use `<ANGLE_CASE>`**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/hosting.mdx?plain=1#L121-L186

Command placeholders must use `<ANGLE_CASE>` and be copy‑pasteable. Minimal fixes:
- `--token {DEPLOYMENT_TOKEN}` → `--token <DEPLOYMENT_TOKEN>`
- `--project {PROJECT_ID}` → `--project <PROJECT_ID>`
- `--tag {TAG}` → `--tag <TAG>`
- `--token TOKEN` → `--token <TOKEN>`
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **7. Placeholders in URLs use `{...}`; must use `<ANGLE_CASE>`**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/hosting.mdx?plain=1#L77-L216

Placeholders in prose/URLs must use `<ANGLE_CASE>`. Minimal fixes:
- `https://{storage_key}.tapps.global/{tag}` → `https://<STORAGE_KEY>.tapps.global/<TAG>`
- In the verify section, update the URL similarly.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **8. Unlabeled fenced blocks; code fences must specify a language**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/hosting.mdx?plain=1#L77-L226

All fenced blocks must declare a language. Minimal fixes:
- URL and plain‑text examples: use ` ```text ` for the base‑URL pattern and the verify‑link example.
- Expected output blocks: use ` ```text ` for both output examples.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **9. “Utilizing” used instead of “use” (prefer plain wording)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/hosting.mdx?plain=1#L9

Prefer common words. Minimal fix: `By utilizing a …` → `By using a …`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **10. Time-relative “currently” used**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/hosting.mdx?plain=1#L16

Avoid time‑relative words. Minimal fix: remove “currently”: `If you’re using a single server …`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17-2-timelessness

---

- [ ] **11. Undefined acronym “SPA” on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/hosting.mdx?plain=1#L21-L24

Spell out on first use. Minimal fix: `When deploying a single‑page application (SPA) …`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **12. Undefined acronym “TMA” in heading**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/hosting.mdx?plain=1#L209

Acronyms must be defined on first use. Minimal fix: change heading to `### Verify deployment and configure Telegram Mini Apps (TMA)` (sentence case preserved), or define TMA in the first sentence of this section.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form

---

- [ ] **13. Inconsistent term for Mini Apps (mini applications / mini‑app)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/hosting.mdx?plain=1#L6-L228

Terminology must follow the project term bank and be consistent across pages. Nearby pages (for example, `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/overview.mdx?plain=1`) use “Telegram Mini Apps (TMAs)” and “mini app”. Minimal fix: standardize to “mini app(s)” (lowercase) in prose and “Mini Apps” when referring to the named platform; avoid hyphenated “mini‑app” and “mini applications”. The guide is silent on this specific term; preferring consistency with nearby pages.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-1-term-bank-canonical-source

---

- [ ] **14. UI labels styled as code; must use quotation marks**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/hosting.mdx?plain=1#L94-L101

UI text must be quoted, not code‑formatted. Minimal fixes:
- `` `Start` `` → “Start”
- `` `Create a Project` `` → “Create a Project”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **15. Images missing alt text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/hosting.mdx?plain=1#L97-L106

Provide text alternatives for images. Minimal fix: add `alt` attributes to both `<img>` tags (e.g., `alt="Start screen of the bot"`, `alt="Create project screen"`).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#15-2-structure-and-tables

---

- [ ] **16. Gerund in task heading; prefer imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/hosting.mdx?plain=1#L230

Task/procedure headings should use imperative verbs. Minimal fix: `## Using config` → `## Use config` (or `## Use a config file`).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-2-gerunds-and-labels

---

- [ ] **17. Mid‑sentence capitalization of generic concept (“Content Delivery Network”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/hosting.mdx?plain=1#L9-L11

Generic concepts must not be capitalized mid‑sentence. Minimal fix: `content delivery network (CDN)` (lowercase words; acronym defined).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules

---

- [ ] **18. “etc.” used in example list**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/hosting.mdx?plain=1#L86

Avoid “etc.” in lists; make the list finite or use “for example.” Minimal fix: remove “etc.” or rephrase: `Examples include `staging`, `latest`, and `dev`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-and-etc

---

- [ ] **19. Unnecessary italics for product name (“React”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/hosting.mdx?plain=1#L26

Use italics sparingly; do not emphasize product names in procedures. Minimal fix: remove italics: `If you are using React, …`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **20. Hedging/intensifiers reduce clarity**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/hosting.mdx?plain=1#L21-L52

Avoid hedges and intensifiers. Minimal fixes: “it’s crucial to choose routing methods …” → “Use routing methods that do not depend on server‑side configurations.”; “simple and effective way” → “manages routes without server support.”; “as quickly as possible” → “quickly.” (General language guidance applied.)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **21. Frontmatter title is too generic**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/hosting.mdx?plain=1#L2

The `title: "Hosting"` is a one‑word generic label and is not self‑describing outside of context. Minimal fix: change to a descriptive, context‑free title such as `"Mate hosting"` (and set `sidebarTitle: "Hosting"` if needed for brevity).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-2-navigation-labels

---

- [ ] **22. Marketing tone in technical section**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/hosting.mdx?plain=1#L47

Heading “Lightning Speed” and the comparative claim “surpassing the performance of single‑server solutions” introduce marketing tone. Minimal fixes: rename the heading to a neutral label (e.g., `Content delivery network`) and remove the comparative clause.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles-reader-first-answer-first

---

- [ ] **23. Inline placeholder mentions not using `<ANGLE_CASE>`**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/hosting.mdx?plain=1#L127-L129

Placeholders in prose should use `<ANGLE_CASE>`. Minimal fix: use `<DEPLOYMENT_TOKEN>`, `<PROJECT_ID>`, and `<TAG>` in the explanatory sentence to match the command placeholder style.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-5-placeholder-names