### PR TITLE
[AI] fix: index.mdx

### DIFF
--- a/ecosystem/ton-connect/walletkit/index.mdx
+++ b/ecosystem/ton-connect/walletkit/index.mdx
@@ -29,8 +29,13 @@ First, follow this step-by-step guide:
 Then, follow relevant usage recipes:
 
 <Tabs>
-  <Tab title="Web" icon="globe">
-    <Columns cols={3}>
+  <Tab
+    title="Web"
+    icon="globe"
+  >
+    <Columns
+      cols={3}
+    >
       <Card
         title="Initialize the kit"
         href="/ecosystem/ton-connect/walletkit/web/init"
@@ -55,9 +60,10 @@ Skim the reference pages with more in-depth information:
     title="TON Connect manifests"
     href="/ecosystem/ton-connect/manifest"
   />
+
   <Card
     title="@tonconnect/protocol"
     arrow="true"
-    href="https://ton-connect.github.io/sdk/modules/_tonconnect_protocol.html">
-  </Card>
+    href="https://ton-connect.github.io/sdk/modules/_tonconnect_protocol.html"
+  />
 </Columns>


### PR DESCRIPTION
- [ ] **1. Subject–verb agreement in opening sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/index.mdx?plain=1#L6

The sentence uses a plural verb with a singular subject: “is an open-source SDK that help integrate…”. Minimal fix: change “help” to “helps”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-punctuation-and-mechanics
General English grammar used for this correction.

---

- [ ] **2. Acronym not defined on first use (SDK)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/index.mdx?plain=1#L6

Per first-mention rule, expand the acronym. Minimal fix: replace “open-source SDK” with “open-source software development kit (SDK)”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **3. Wordy phrase (“streamlined fashion”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/index.mdx?plain=1#L6

The phrase “in a secure and streamlined fashion” is wordy. Minimal fix: replace with “securely and efficiently”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **4. Acronym not defined on first use (UX)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/index.mdx?plain=1#L8

“UX” appears without first defining it. Minimal fix: change “UX” to “user experience (UX)”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **5. Nonstandard callout component (<Note> instead of <Aside>)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/index.mdx?plain=1#L12; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/index.mdx?plain=1#L16

Callouts must use the `<Aside>` component with a supported `type`. Minimal fix: replace `<Note>Awaits a partial or full release of the WalletKit</Note>` with `<Aside type="note">Awaits a partial or full release of the WalletKit</Aside>` in both sections.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#a-admonition-levels-and-usage

---

- [ ] **6. Unnecessary article and filler (“the TON Connect itself”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/index.mdx?plain=1#L42

The phrase “Read more about the TON Connect itself:” is awkward and includes an unnecessary article and filler. Minimal fix: change to “Read more about TON Connect:”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **7. Missing import for Aside component**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/index.mdx?plain=1#L1

When replacing <Note> with <Aside>, the page must import the Aside component. Minimal fix: after frontmatter, add “import { Aside } from '/snippets/aside.jsx';”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11.2-how-to-write-the-callout

---

- [ ] **8. Acronym “TON” not expanded on first mention in body text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/index.mdx?plain=1#L6

Expand the project name on first use. Minimal fix: “… with The Open Network (TON) …”. Use “TON” thereafter.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms