### PR TITLE
[AI] fix: native-web.mdx

### DIFF
--- a/ecosystem/ton-connect/walletkit/native-web.mdx
+++ b/ecosystem/ton-connect/walletkit/native-web.mdx
@@ -106,6 +106,7 @@ The TON Connect Bridge protocol uses these main endpoints:
 - Server-Sent Events (SSE) channel — for receiving messages:
 
   Not runnable
+
   ```http
   GET /events?client_id=<to_hex_str(A1)>,<to_hex_str(A2)>,<to_hex_str(A3)>&last_event_id=<lastEventId>
   Accept: text/event-stream
@@ -114,6 +115,7 @@ The TON Connect Bridge protocol uses these main endpoints:
 - **Message Sending** — For sending messages:
 
   Not runnable
+
   ```http
   POST /message?client_id=<sender_id>&to=<recipient_id>&ttl=300
   body: <base64_encoded_message>
@@ -122,6 +124,7 @@ The TON Connect Bridge protocol uses these main endpoints:
 Here, `client_id` and `sender_id` are the public keys of the wallet's session in hex.
 
 Define placeholders:
+
 - `<to_hex_str(Ax)>` — hex-encoded session public keys.
 - `<lastEventId>` — last received event ID from the bridge (string).
 - `<sender_id>` — wallet session public key (hex).
@@ -155,6 +158,7 @@ Refer to the [`@tonconnect/protocol` documentation](https://github.com/ton-conne
 The foundation of TON Connect is secure communication using the SessionCrypto class:
 
 Not runnable
+
 ```ts expandable
 import { SessionCrypto, KeyPair, AppRequest, Base64 } from '@tonconnect/protocol';
 
@@ -217,6 +221,7 @@ Refer to the [SessionCrypto implementation](https://github.com/ton-connect/sdk/b
 TON Connect uses a bridge service as a relay for messages between dApps and wallets:
 
 Not runnable
+
 ```ts expandable
 // Bridge URL for your wallet
 const bridgeUrl = 'https://bridge.[custodian].com/bridge';
@@ -260,6 +265,7 @@ Refer to the [bridge API documentation](https://github.com/ton-blockchain/ton-co
 When a user opens a connection link in your browser wallet, this flow begins:
 
 Not runnable
+
 ```ts expandable
 // This code runs when a URL like this is opened:
 // https://wallet.[custodian].com/ton-connect?v=2&id=<client_id>&r=<connect_request>&ret=<return_strategy>
@@ -399,6 +405,7 @@ window.addEventListener('load', async () => {
 ```
 
 Define placeholders:
+
 - `<client_id>` — dApp session public key (hex).
 - `<connect_request>` — URL-encoded connect request JSON.
 - `<return_strategy>` — dApp return strategy token.
@@ -410,6 +417,7 @@ Refer to [Universal link](https://github.com/ton-blockchain/ton-connect/blob/mai
 After establishing connections, you need to listen for messages from connected dApps:
 
 Not runnable
+
 ```ts expandable
 // This function sets up listeners for all active sessions
 // Note: this is a simplified example, in a real wallet there can be multiple sessions per one connection
@@ -683,6 +691,7 @@ Refer to the [SendTransactionRequest](https://github.com/ton-blockchain/ton-conn
 Allow users to disconnect from dApps when needed. This action is initiated by the user on the custodian’s side:
 
 Not runnable
+
 ```ts expandable
 // Function to disconnect from a dApp
 // Parameters:


### PR DESCRIPTION
- [ ] **1. Unsupported frontmatter key `documentation`**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L4

Frontmatter uses a non-standard key (`documentation`). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-2-navigation-labels (Frontmatter keys). Minimal fix: replace `documentation:` with `description:` keeping the same text.

---

- [ ] **2. Throat-clearing opening sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L8

Starts with “This document provides instructions…”, which describes the doc instead of delivering value. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references. Minimal fix: rewrite to action-first, e.g., “Integrate TON Connect into wallets and other custodian services for iOS, Android, macOS, Windows, Linux, and web.”

---

- [ ] **3. Gerund headings in procedural sections**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L134-L663

Procedural H2/H3 headings use gerunds; prefer imperative form. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-2-gerunds-and-labels. Minimal fixes:
- “Setting up the protocol” → “Set up the protocol”
- “Handling TON Connect links for new connections” → “Handle TON Connect links for new connections”
- “Listening for messages from connected dApps” → “Listen for messages from connected dApps”
- “Disconnecting from dApps” → “Disconnect from dApps”

---

- [ ] **4. “On-premise” wording**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L78-L93

Use the standard adjective “on‑premises,” not “on‑premise.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording. Minimal fix: replace “On‑premise” → “On‑premises”. (General grammar convention.)

---

- [ ] **5. Acronym not expanded on first use (SSE)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L106

“SSE Events Channel” uses the acronym without expansion. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms. Minimal fix: “Server‑Sent Events (SSE) channel — for receiving messages:”.

---

- [ ] **6. Missing language tags on HTTP request examples**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L108–111,115–118

Fenced code blocks lack a language tag. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules. Minimal fix: change the fences to specify a language, e.g., ```http for the request blocks.

---

- [ ] **7. Placeholders not defined on first use**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L108–118,253–258

Placeholders like `<to_hex_str(A1)>`, `<lastEventId>`, `<sender_id>`, `<recipient_id>`, `<client_id>`, `<connect_request>`, `<return_strategy>`, and `<base64_encoded_message>` aren’t defined near first use. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules. Minimal fix: add a short “Define placeholders” list immediately after the blocks, for example:
- `<to_hex_str(Ax)>` — hex‑encoded session public keys.
- `<lastEventId>` — last received event ID from the bridge (string).
- `<sender_id>` — wallet session public key (hex).
- `<recipient_id>` — dApp session public key (hex).
- `<client_id>` — dApp session public key (hex).
- `<connect_request>` — URL‑encoded connect request JSON.
- `<return_strategy>` — dApp return strategy token.
- `<base64_encoded_message>` — Base64‑encoded encrypted payload.

---

- [ ] **8. Partial snippets not labeled “Not runnable”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L148–200,209–243,251–387,395–659,667–714,108–118,115–118

Multiple excerpts are partial and not copy‑pasteable end‑to‑end but lack the required “Not runnable” label above each block. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets. Minimal fix: add a single line “Not runnable” immediately above each partial `ts expandable` and HTTP example block.

---

- [ ] **9. Comma splice in procedural sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L665

“Allow users to disconnect from dApps when needed, this action is initiated by the user on the custodian's side:” joins two independent clauses with a comma. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons. Minimal fix: split into two sentences: “Allow users to disconnect from dApps when needed. This action is initiated by the user on the custodian’s side:”.

---

- [ ] **10. “etc.” in a procedural list**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L88

Open‑ended “etc.” leaves requirements unclear. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references. Minimal fix: replace with a closed example, e.g., “Configure your infrastructure (for example, load balancers and SSL certificates).”

---

- [ ] **11. Filler phrase “please refer to”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L122

Uses polite filler (“please refer to”) instead of direct instruction. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording. Minimal fix: “See the TON Connect Bridge documentation”.

---

- [ ] **12. Minor grammar: missing article**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L761

“provide access to technical team” lacks the article. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording. Minimal fix: “provide access to the technical team”. (General grammar.)

---

- [ ] **13. Redundant concluding paragraph**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L775

Final paragraph repeats the commitment/support message from the preceding section, adding verbosity without new information. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references. Minimal fix: remove the duplicate paragraph starting “The TON Foundation is committed to supporting custodians…”.

---

- [ ] **14. Improper capitalization of common noun “web”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L5-L8

“Web” is capitalized mid‑sentence; generic concepts must not be. Minimal fix: use lowercase “web” in both the frontmatter description and the first paragraph.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules

---

- [ ] **15. Non‑conforming placeholders in HTTP examples**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L109–117

Placeholders must use `<ANGLE_CASE>` with descriptive names. Current forms like `<to_hex_str(A1)>` and `<lastEventId>` violate this. Minimal fix:
- `GET /events?client_id=<CLIENT_ID_HEX_LIST>&last_event_id=<LAST_EVENT_ID>`
- `POST /message?client_id=<SENDER_ID>&to=<RECIPIENT_ID>&ttl=300` and `body: <BASE64_MESSAGE>`
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-5-placeholder-names

---

- [ ] **16. Square‑bracket placeholders; use project placeholder style**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L211-L253

Strings use `[custodian]` inside URLs, which conflicts with the placeholder rules. Minimal fix: in programming‑language code strings, use UPPER_SNAKE without brackets: `CUSTODIAN_DOMAIN`. Examples: `https://bridge.CUSTODIAN_DOMAIN/bridge` and `https://wallet.CUSTODIAN_DOMAIN/ton-connect?...`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-5-placeholder-names

---

- [ ] **17. Safety callout missing where secrets are stored**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L182–201,357–374

Examples generate and persist session keys (including a `secretKey`). Pages that expose/store keys MUST include an explicit safety callout. Minimal fix: insert an `<Aside type="danger" title="Keys at risk">` near the storage example, warning against storing secrets in localStorage and instructing to use secure storage, with testnet‑first guidance.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-1-when-a-safety-callout-is-required; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout

---

- [ ] **18. Links to moving “main” for normative specs; use permalinks**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L122-L736

Normative references point to `.../blob/main/...`, which is a moving target. Minimal fix: switch to versioned permalinks (tag/commit) for these GitHub docs, or link to internal, versioned docs when available.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references

---

- [ ] **19. Abbreviation casing: use “BoC”, not “boc”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L532–553

Error messages and comments use “boc”. Project style requires the abbreviation “BoC”. Minimal fix: change occurrences of “boc” in user‑visible strings/comments to “BoC”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-4-ton-specific-examples

---

- [ ] **20. Banned filler phrase “please note”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L724

Sentence begins with “Please note…”, which the guide bans as filler. Minimal fix: remove “Please note” and start directly with the fact, for example: “This serves as a reference implementation to understand how to achieve transaction signing:”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **21. How‑to title not following required pattern**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L2

The page reads like a how‑to but the frontmatter `title` is not in the required “How to …” format. Minimal fix: change to `title: How to integrate TON Connect for native and web wallets`. Keep `sidebarTitle` concise: `sidebarTitle: Native and web wallets`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#how-to-frontmatter-pattern

---

- [ ] **22. Syntactic error in example: reassigning `const` variable**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L481–506

`valid_until` is destructured as a constant, then reassigned (`valid_until = Math.min(...)`), which is invalid. Minimal fix: compute into a new variable (e.g., `const boundedValidUntil = Math.min(...);`) and use that in subsequent checks.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **23. Undefined identifier in message listener example**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L428–439

The handler uses `appRequest` without declaring it. Minimal fix: reference `event.data` consistently or assign `const appRequest = event.data;` before use so the excerpt is syntactically valid.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **24. Minor agreement: pluralize “custodian” in aside comment**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L258

Comment reads “may be ignored for custodian”; plural form improves clarity. Minimal fix: “may be ignored for custodians”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles-reader-first-answer-first

---

- [ ] **25. Code fence language should be bash (not shell)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L138

The install command uses a `shell` fence. Prefer `bash` for correct highlighting. Minimal fix: change ```shell to ```bash.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **26. Overuse of bold inside sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L720

Two bold link texts in one sentence reduce scannability. Minimal fix: remove bold from “Transaction signing” and “TON Proof implementation”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **27. Duplicated support commitment paragraph**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L176

The second paragraph repeats the prior commitment, adding redundancy. Minimal fix: delete the second paragraph to keep the section concise.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **28. Indefinite “There,” pronoun; prefer direct wording**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L120

“There, `client_id` and `sender_id` …” is indirect. Minimal fix: “Here, `client_id` and `sender_id` are the public keys of the wallet’s session in hex.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **29. Missing article in support bullet**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L162

“provide access to technical team” misses the article. Minimal fix: “provide access to the technical team for consultations”. This is a basic grammar correction.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **30. Undefined variable in example (`dAppName`)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L558

The example uses `dAppName` in a template string without defining it, making the snippet non–copy-pasteable. Minimal fix: use `sessionData.dAppName` or define `const dAppName = sessionData.dAppName;` above.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **31. Incorrect EventSource closing pattern**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L705

`EventSource` is not a DOM node; selecting `#event-source-…` and calling `.close()` on the result will fail. Minimal fix: store the `EventSource` returned by `listenFromBridge` (e.g., in a map keyed by `sessionId`) and call `.close()` on that reference.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **32. Avoid “etc.” in inline comment**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L445

Open-ended “etc.” in code comments adds ambiguity. Minimal fix: name the expected request types explicitly or end without “etc.” (e.g., “transaction or disconnect requests”).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **33. Inconsistent link text vs section title (“TON Proof signing”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L720

The link text says “TON Proof signing” but the section heading is “TON Proof implementation”. Minimal fix: change the link text to “TON Proof implementation” to match the section.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms