### PR TITLE
[AI] fix: metadata.mdx

### DIFF
--- a/standard/tokens/metadata.mdx
+++ b/standard/tokens/metadata.mdx
@@ -29,10 +29,11 @@ When the payload exceeds the maximum size of a single cell, Snake stores the rem
 Below is an example of Snake encoding and decoding in TypeScript:
 
 <Aside type="note">
-`bufferToChunks`, `BitBuilder`, and `BitReader` are provided by the surrounding tooling and helper utilities.
+  `bufferToChunks`, `BitBuilder`, and `BitReader` are provided by the surrounding tooling and helper utilities.
 </Aside>
 
 Not runnable
+
 ```ts title="TypeScript"
 export function makeSnakeCell(data: Buffer): Cell {
   const chunks = bufferToChunks(data, 127)
@@ -97,6 +98,7 @@ chunked_data#_ data:(HashMapE 32 ^(SnakeData ~0)) = ChunkedData;
 Below is an example of chunked data decoding in TypeScript:
 
 Not runnable
+
 ```typescript title="TypeScript"
 interface ChunkDictValue {
   content: Buffer;
@@ -125,27 +127,27 @@ export function ParseChunkDict(cell: Slice): Buffer {
 
 ## NFT metadata attributes
 
-| Attribute     | Type         | Requirement | Description                                                                                             |
-| ------------- | ------------ | ----------- | ------------------------------------------------------------------------------------------------------- |
-| `uri`         | ASCII string | optional    | A Uniform Resource Identifier (URI) pointing to a JSON document with metadata used by the semi-chain content layout.                  |
-| `name`        | UTF-8 string | optional    | Identifies the asset.                                                                                   |
-| `description` | UTF-8 string | optional    | Describes the asset.                                                                                    |
-| `image`       | ASCII string | optional    | A URI pointing to a resource with an image Multipurpose Internet Mail Extensions (MIME) type.                                                   |
-| `image_data`  | binary       | optional    | Either a binary representation of the image for the on-chain layout or base64 for the off-chain layout. |
+| Attribute     | Type         | Requirement | Description                                                                                                          |
+| ------------- | ------------ | ----------- | -------------------------------------------------------------------------------------------------------------------- |
+| `uri`         | ASCII string | optional    | A Uniform Resource Identifier (URI) pointing to a JSON document with metadata used by the semi-chain content layout. |
+| `name`        | UTF-8 string | optional    | Identifies the asset.                                                                                                |
+| `description` | UTF-8 string | optional    | Describes the asset.                                                                                                 |
+| `image`       | ASCII string | optional    | A URI pointing to a resource with an image Multipurpose Internet Mail Extensions (MIME) type.                        |
+| `image_data`  | binary       | optional    | Either a binary representation of the image for the on-chain layout or base64 for the off-chain layout.              |
 
 ## Jetton metadata attributes
 
-| Attribute      | Type         | Requirement | Description                                                                                                                                                                                                                                                                    |
-| -------------- | ------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `uri`          | ASCII string | optional    | A URI pointing to a JSON document with metadata used by the semi-chain content layout.                                                                                                                                                                                          |
-| `name`         | UTF-8 string | optional    | Identifies the asset.                                                                                                                                                                                                                                                           |
-| `description`  | UTF-8 string | optional    | Describes the asset.                                                                                                                                                                                                                                                            |
-| `image`        | ASCII string | optional    | A URI pointing to a resource with an image MIME type.                                                                                                                                                                                                                           |
-| `image_data`   | binary       | optional    | Either a binary representation of the image for the on-chain layout or base64 for the off-chain layout.                                                                                                                                                                         |
-| `symbol`       | UTF-8 string | optional    | Token symbol — for example, "XMPL" — used in the form "You have received 99 XMPL".                                                                                                                                                                                             |
-| `decimals`     | UTF-8 string | optional    | The number of decimal places used by the token. If not specified, the default is 9. A UTF-8–encoded string containing a number from 0 to 255; for example, 8 means the on-chain amount must be divided by 100000000 to get the user-facing representation.                        |
-| `amount_style` | string       | optional    | Defines how token amounts should be displayed for external applications. One of `n`, `n-of-total`, or `%`.                                                                                                                                                                       |
-| `render_type`  | string       | optional    | Indicates how external applications should categorize and render the token. `currency` — display as a currency (default). `game` — game-style display: renders like an NFT, also shows the number of tokens, and respects `amount_style`.                                        |
+| Attribute      | Type         | Requirement | Description                                                                                                                                                                                                                                                |
+| -------------- | ------------ | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `uri`          | ASCII string | optional    | A URI pointing to a JSON document with metadata used by the semi-chain content layout.                                                                                                                                                                     |
+| `name`         | UTF-8 string | optional    | Identifies the asset.                                                                                                                                                                                                                                      |
+| `description`  | UTF-8 string | optional    | Describes the asset.                                                                                                                                                                                                                                       |
+| `image`        | ASCII string | optional    | A URI pointing to a resource with an image MIME type.                                                                                                                                                                                                      |
+| `image_data`   | binary       | optional    | Either a binary representation of the image for the on-chain layout or base64 for the off-chain layout.                                                                                                                                                    |
+| `symbol`       | UTF-8 string | optional    | Token symbol — for example, "XMPL" — used in the form "You have received 99 XMPL".                                                                                                                                                                         |
+| `decimals`     | UTF-8 string | optional    | The number of decimal places used by the token. If not specified, the default is 9. A UTF-8–encoded string containing a number from 0 to 255; for example, 8 means the on-chain amount must be divided by 100000000 to get the user-facing representation. |
+| `amount_style` | string       | optional    | Defines how token amounts should be displayed for external applications. One of `n`, `n-of-total`, or `%`.                                                                                                                                                 |
+| `render_type`  | string       | optional    | Indicates how external applications should categorize and render the token. `currency` — display as a currency (default). `game` — game-style display: renders like an NFT, also shows the number of tokens, and respects `amount_style`.                  |
 
 ### Amount style
 


### PR DESCRIPTION
- [ ] **1. Page title is too generic for context**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/metadata.mdx?plain=1#L1

The frontmatter `title: "Metadata"` is not context‑free or self‑describing; one‑word generic titles are reserved for top‑level pages or proper names. Minimal fix: set `title: "Token metadata"` (sentence case) and keep `sidebarTitle: "Metadata"` for brevity.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#title-vs-sidebar-semantics

---

- [ ] **2. Acronyms not expanded on first mention (TON, NFT, URI, MIME)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/metadata.mdx?plain=1#L8-L14/tokens/metadata.mdx:128, standard/tokens/metadata.mdx:131

Per first‑use rule, expand acronyms on first mention. Minimal fixes: (a) change “On TON, entities…” to “On The Open Network (TON), entities…”, (b) expand “NFT” at first use to “non‑fungible token (NFT)”, (c) expand “URI” to “Uniform Resource Identifier (URI)”, and (d) expand “MIME” to “Multipurpose Internet Mail Extensions (MIME)”. These are general‑knowledge acronyms.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **3. Positional reference “see the note below”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/metadata.mdx?plain=1#L18

Avoid “above/below” references; link to the exact anchor or remove the positional word. Minimal fix: change “(see the note below for exceptions)” to “(see the note for exceptions)”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **4. Partial code snippets not labeled “Not runnable”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/metadata.mdx?plain=1#L35/tokens/metadata.mdx:98

Both TypeScript examples depend on surrounding tooling/types and are not self‑contained. Partial snippets must be labeled. Minimal fix: insert a line `Not runnable` immediately above each fenced block.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **5. Normative TEP link points to moving branch**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/metadata.mdx?plain=1#L8/tokens/metadata.mdx:211

For precision‑critical references, do not link to moving targets like `master`. Minimal fix: replace both TEP‑64 links with a GitHub commit permalink to `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/text/0064-token-data-standard.md?plain=1`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references

---

- [ ] **6. Vague link text “Read more about similar examples”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/metadata.mdx?plain=1#L25

Link text must be descriptive. Minimal fix: change to “TL‑B complex and non‑trivial examples” (the target page title) or similarly descriptive text.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text

---

- [ ] **7. Non‑descriptive link text uses raw addresses**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/metadata.mdx?plain=1#L192-L196

Clickable text is a raw address, which isn’t descriptive for readers or screen readers. Minimal fix: use descriptive link text and keep the address in surrounding prose if needed, e.g., `[On‑chain NFT example](…)`, `[Semi‑chain NFT example](…)`, and `[On‑chain jetton master example](…)`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text

---

- [ ] **8. Task heading should be imperative, not “How to …”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/metadata.mdx?plain=1#L198

Internal section headings must use imperative verbs; “How to …” is reserved for page titles of How‑to docs. Minimal fix: change `## How to parse` to `## Parse metadata`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles

---

- [ ] **9. Hedging language reduces clarity**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/metadata.mdx?plain=1#L200

Avoid hedges like “in rare cases.” Minimal fix: remove the hedge: “It handles most cases within gas limits; parsing may fail.” (General writing guidance; no domain change.)

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **10. Use relative internal links (absolute paths present)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/metadata.mdx?plain=1#L25

The internal link uses an absolute site path: `/language/TL-B/complex-and-non-trivial-examples`. Internal links SHOULD be relative and stable. Minimal fix: change to a relative path `../../language/TL-B/complex-and-non-trivial-examples` from this file’s location.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12.3-link-targets-and-format

---

- [ ] **11. Ordered lists must use `1.` for every item**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/metadata.mdx?plain=1#L204–207

The ordered list numbers are written as `1., 2., 3., 4.`. Ordered lists MUST use `1.` for every item and let the renderer auto‑number. Minimal fix: change each line to start with `1.`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.4-lists

---

- [ ] **12. Prefer period over semicolon between clauses**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/metadata.mdx?plain=1#L200

The sentence uses a semicolon to join independent clauses: “It handles most cases within gas limits; in rare cases, parsing may fail.” Semicolons SHOULD be rare; prefer shorter sentences. Minimal fix: “It handles most cases within gas limits. In rare cases, parsing may fail.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.1-commas-colons-semicolons

---

- [ ] **13. Use descriptive link text for API reference**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/metadata.mdx?plain=1#L200

Link text “API Metadata” is vague. Minimal fix: change the link text to the exact API name, for example “get-account-metadata” (or “Accounts → get-account-metadata”), keeping the same target URL.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text

---

- [ ] **14. Link TL-B on first mention to its overview**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/metadata.mdx?plain=1#L18–23

“TL-B” appears without a first-mention context link. Minimal fix: link the first “TL-B” mention to the TL‑B overview page to aid discovery: “TL‑B schema:” → “TL‑B schema” with “TL‑B” linking to `/language/TL-B/overview`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not

---

- [ ] **15. Heading contains code font (`amount_style`)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/metadata.mdx?plain=1#L148

Headings must not contain code formatting (exception: dedicated Reference pages). Minimal fix: change heading to “Amount style” and mention the literal `amount_style` in the first sentence of the section body instead of in the heading.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-4-formatting-restrictions

---

- [ ] **16. Vague link text and unstable query in internal link (“API Metadata”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/metadata.mdx?plain=1#L200

Link text should be descriptive and internal links should be stable. “API Metadata” is vague, and the `?playground=open` query adds UI state that may be unstable. Minimal fix: change to “[Get account metadata](/ecosystem/rpc/ton-center-v3/accounts/get-account-metadata)” (drop the query) to match the endpoint and keep the link stable.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format

---

- [ ] **17. Non-sentence bullets end with periods**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/metadata.mdx?plain=1#L12

The three unordered list items under the metadata types are fragments, not full sentences, yet each ends with a period. Per the list punctuation rule, omit terminal punctuation for non‑sentence items. Minimal fix: remove the trailing periods from the three bullets at lines 12–14.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#64-lists

---

- [ ] **18. Bare URL shown without descriptive text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/metadata.mdx?plain=1#L168

Bare URLs reduce accessibility and scannability; use descriptive link text instead. Minimal fix: replace the standalone URL line with a descriptive link, e.g., `Example URL: [GetGems sample metadata](https://s.getgems.io/nft/b/c/62fba50217c3fe3cbaad9e7f/95/meta.json)`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#121-link-text

---

- [ ] **19. Missing conjunction in three‑item inline list (use Oxford comma form)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/metadata.mdx?plain=1#L145

In “One of `n`, `n-of-total`, `%`.” the coordinating conjunction is missing. Use “or” with a serial comma for three or more items. Minimal fix: “One of `n`, `n-of-total`, or `%`.”

This relies on a basic English grammar rule (using a coordinating conjunction in a three-item “one of …” list) in addition to the Oxford comma rule.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#61-commas-colons-semicolons