### PR TITLE
[AI] fix: how-to-get-supply-data.mdx

### DIFF
--- a/standard/tokens/jettons/how-to-get-supply-data.mdx
+++ b/standard/tokens/jettons/how-to-get-supply-data.mdx
@@ -7,7 +7,7 @@ import { Image } from '/snippets/image.jsx';
 
 To retrieve specific jetton data, use jetton master contract's `get_jetton_data()` method.
 
-Outputs: see [API → get_jetton_data](standard/tokens/jettons/API.mdx#get_jetton_data).
+Outputs: see [API → get\_jetton\_data](standard/tokens/jettons/API.mdx#get_jetton_data).
 
 Call the `get_jetton_data()` method:
 


### PR DESCRIPTION
- [ ] **1. Duplicated reference table for `get_jetton_data()` outputs**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-get-supply-data.mdx?plain=1#L12

This how-to repeats a full outputs table for `get_jetton_data()`, which belongs in the reference. Minimal fix: replace the table with one sentence summarizing the return and link directly to the canonical reference entry (for example, “See API → get_jetton_data”). Use the internal anchor: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/API.mdx?plain=1#get_jetton_data. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#single-source-of-truth

---

- [ ] **2. Mixed capitalization and wording in table descriptions**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-get-supply-data.mdx?plain=1#L14-L18

Cells mix capitalization and phrasing (“the total…”, “Indicates…”, “admin's address”, “a code of the corresponding Jetton wallet”). Minimal fixes: use consistent sentence style and terms.
- Line 15: change “Indicates whether…” → “indicates whether…”.
- Line 16: change “admin's address” → “admin address” (or “the admin address”).
- Line 18: change “a code of the corresponding Jetton wallet” → “code of the corresponding jetton wallet”. Also keep “jetton” casing consistent within the page. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#proofread

---

- [ ] **3. External TEP link where internal page exists; moving branch URL**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-get-supply-data.mdx?plain=1#L17

Linking TEP‑64 via GitHub “master” is a moving target and violates internal‑first. Minimal fix: link to the internal page instead: “data formatted according to the metadata standard” → link to /standard/tokens/metadata. If the TEP link is still needed, add a stable permalink (specific commit) in addition to the internal link. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#what-to-link-and-what-not; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#stable-permalinks-situation-aware

---

- [ ] **4. Non-descriptive link text and .mdx extension in internal link**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-get-supply-data.mdx?plain=1#L59

Link text “API” is vague, and the URL includes “.mdx”. Minimal fix: make the link descriptive and remove the extension: “RPC overview” → /ecosystem/rpc/overview. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#link-text; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#links-and-anchors

---

- [ ] **5. Missing alt text for Image component**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-get-supply-data.mdx?plain=1#L54-L57

The Image component lacks `alt`/`darkAlt`, which are required for accessibility. Minimal fix: add meaningful `alt` and `darkAlt` descriptions (for example, alt="Tonviewer get_jetton_data screenshot"). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/image.mdx?plain=1#alt

---

- [ ] **6. Code sample should use placeholders and define them**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-get-supply-data.mdx?plain=1#L27-L31

Hard-coded endpoint and address reduce reuse and can mislead readers. Minimal fix: replace with placeholders and define them below the snippet, for example:
- In code: `endpoint: '<RPC_URL>'` and `.parse('<JETTON_MASTER_ADDRESS>')`.
- Define placeholders (first use) after the block:
  `<RPC_URL>` — HTTPS endpoint of your TON RPC provider.
  `<JETTON_MASTER_ADDRESS>` — address of the jetton master contract to query.
Additionally, prefer a testnet endpoint by default when feasible. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#full-runnable-examples; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#safer-defaults

---

- [ ] **7. Inconsistent type term with reference (`Address` vs `MsgAddress`)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-get-supply-data.mdx?plain=1#L16

The table uses `Address` for the admin field, while the canonical API page uses `MsgAddress` for jetton addresses. Minimal fix: align the type label with the reference (`MsgAddress`) or link to the reference anchor to avoid drift. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#single-source-of-truth; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#proofread

---

- [ ] **8. Internal link should be relative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-get-supply-data.mdx?plain=1#L59

Internal links should be relative to avoid domain coupling. Minimal fix: change `[https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860//ecosystem/rpc/overview.mdx?plain=1]` to `[https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/rpc/overview.mdx?plain=1]`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#163-links-and-anchors

---

- [ ] **9. Non-imperative phrasing (“You can call…”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-get-supply-data.mdx?plain=1#L20

Task text should use present‑tense imperative. “You can call…” is indirect and chatty. Minimal fix: “Call the `get_jetton_data()` method:” (remove “from your favorite IDE”).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#51-voice-and-tense

---

- [ ] **10. Acronym “API” not defined on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-get-supply-data.mdx?plain=1#L59

On first use, expand the term and include the acronym. Minimal fix: “Finally, you can get this information using the Application Programming Interface (API) — see the [RPC API overview](https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/rpc/overview.mdx?plain=1).”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#53-acronyms-and-terms

---

- [ ] **11. Literal values in prose should use code formatting**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-get-supply-data.mdx?plain=1#L15

Numeric literal values in technical prose should be formatted as code for clarity and copy‑paste fidelity. Minimal fix: wrap `-1` and `0` in backticks: “indicates whether new jettons can be minted (`-1` for true, `0` for false)”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#63-code-styling

---

- [ ] **12. Capitalize common noun “jetton” correctly (lowercase mid‑sentence)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-get-supply-data.mdx?plain=1#L8

“Jetton” is capitalized as a common noun in the sentence. Use lowercase mid‑sentence for generic concepts: “jetton data” and “jetton master contract’s …”. Minimal fix: “To retrieve specific jetton data, use jetton master contract’s `get_jetton_data()` method.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules

---

- [ ] **13. Code block language tag and style consistency**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-get-supply-data.mdx?plain=1#L22-L50

Minor inconsistencies with code style:
- Missing semicolons on imports and some statements (L23, L33-34, L46) — keep JS examples consistent and syntactically valid.
- Quote style mixes single and double quotes within the same snippet (L23 vs L27/L31/L34). Prefer a consistent style.

Minimal fixes:
- Add semicolons to JS statements and use a consistent quote style (e.g., double quotes throughout) to match nearby pages like https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-get-wallet-data.mdx?plain=1.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **14. Link to internal RPC page should target a meaningful anchor**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-get-supply-data.mdx?plain=1#L59

The closing sentence links to "https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860//ecosystem/rpc/overview.mdx?plain=1" which is a stub and not an anchored reference. Cross‑section links should jump to precise anchors when available; otherwise avoid placeholder pages.

Minimal fix:
- Update to a precise internal anchor when the RPC reference exists, or remove the sentence until a stable target is available. Marked for domain owner confirmation if no anchor exists yet.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-4-avoid-circularity-and-drift

Evidence: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/rpc/overview.mdx?plain=1

---

- [ ] **15. Web service link text should be descriptive**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-get-supply-data.mdx?plain=1#L52

Link text "Tonviewer" is acceptable, but the phrase "Or call it through a web service, such as" is throat‑clearing and informal. Use direct, descriptive link text.

Minimal fix:
- "Alternatively, use Tonviewer to call the method." with the existing link.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text

---

- [ ] **16. Consistent naming for variables in JS example**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-get-supply-data.mdx?plain=1#L30-L37

Variable names are in PascalCase (e.g., `JettonMasterAddress`, `Stack`) which is uncommon for local variables in JS examples in this repo. Prefer lowerCamelCase for variables to match common JS style and nearby pages.

Minimal fix:
- Rename to `jettonMasterAddress` and `stack` consistently within the snippet.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

Evidence: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-get-wallet-data.mdx?plain=1 uses `JettonwalletAddress` (mixed case); standardizing improves consistency — domain owner confirmation may be needed across pages.

---

- [ ] **17. Add period at end of table sentences**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-get-supply-data.mdx?plain=1#L14-L18

Table descriptions are full sentences but lack terminal periods. Maintain consistent sentence punctuation in tables where other rows use sentences.

Minimal fix:
- Add a period at the end of each description cell.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicola