### PR TITLE
[AI] fix: telegram-apps-mate.mdx

### DIFF
--- a/ecosystem/tma/mate/telegram-apps-mate.mdx
+++ b/ecosystem/tma/mate/telegram-apps-mate.mdx
@@ -2,33 +2,32 @@
 title: "@telegram-apps/mate"
 ---
 
-Mate is a multifunctional tool for developers at the Telegram Mini Apps platform, that solves a wide range of problems.
+Mate is a tool for developers on the Telegram Mini Apps (TMAs) platform.
 
-## Installing
+## Install
 
-To start using Mate, it is required to install the `@telegram-apps/mate` package. The developer can do it both locally and globally:
+Install the `@telegram-apps/mate` package locally or globally.
 
-```sh locally icon="npm"
+```bash locally icon="npm"
 npm i -D @telegram-apps/mate
 ```
 
-```sh globally icon="npm"
+```bash globally icon="npm"
 npm i -g @telegram-apps/mate
 ```
 
-Once installed, the package will be accessible via the `mate` CLI tool:
+After installation, the package is accessible via the `mate` command-line interface (CLI):
 
 ```bash
 mate --help
 ```
 
-It is highly recommended to install the package locally to avoid confusion over package versions and to ensure a consistent usage experience within the development team.
+Install the package locally to avoid version confusion and ensure a consistent experience within your team.
 
-## Install-free Usage
+## Use without installing
 
-Not to install the package, you can also use the package using `pnpm` or `npx`:
+To avoid installing the package, you can use `npx`:
 
-```sh icon="npm"
+```bash icon="npm"
 npx @telegram-apps/mate@latest --help
 ```
-


### PR DESCRIPTION
- [ ] **1. Gerund in task heading; use imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/telegram-apps-mate.mdx?plain=1#L7

“## Installing” uses a gerund in a procedural section. Prefer an imperative verb to make the action clear. Minimal fix: change to “## Install”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.2-gerunds-and-labels

---

- [ ] **2. Title case in heading; should be sentence case**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/telegram-apps-mate.mdx?plain=1#L27

“## Install-free Usage” uses Title Case. All headings must use sentence case. Minimal fix: change to “## Install-free usage”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.1-case-and-form

---

- [ ] **3. Comma misuse and preposition in intro sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/telegram-apps-mate.mdx?plain=1#L5

The clause uses an unnecessary comma before a restrictive “that” and the preposition “at” is awkward for platforms. Minimal fix: “Mate is a multifunctional tool for developers on the Telegram Mini Apps platform that solves a wide range of problems.” (Comma rule is general English; preposition choice follows plain, precise wording.)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.1-commas-colons-semicolons
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording

---

- [ ] **4. Wordy passive phrasing; simplify to direct instruction**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/telegram-apps-mate.mdx?plain=1#L9

“To start using Mate, it is required to install … The developer can do it both locally and globally:” is passive and wordy. Minimal fix: “Install the `@telegram-apps/mate` package locally or globally.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.7-avoid-tautology-pleonasm-throat-clearing-and-circular-references
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording

---

- [ ] **5. Define acronym on first use (CLI)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/telegram-apps-mate.mdx?plain=1#L19

Introduces “CLI” without expansion. On first mention, spell out the term, then the acronym. Minimal fix: “Once installed, the package will be accessible via the `mate` command-line interface (CLI):”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms

---

- [ ] **6. Intensifier in recommendation (“highly”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/telegram-apps-mate.mdx?plain=1#L25

Avoid hedges/intensifiers. Minimal fix: remove “highly” → “It is recommended to install the package locally …”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **7. Awkward phrasing and repetition in install-free section**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/telegram-apps-mate.mdx?plain=1#L29

“Not to install the package, you can also use the package using `pnpm` or `npx`:” is ungrammatical and repeats “package”/“using”. Minimal fix: “To avoid installing the package, you can use `pnpm` or `npx`:”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording

---

- [ ] **8. Mention of two tools but only one example shown**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/telegram-apps-mate.mdx?plain=1#L29-L33

Text mentions both `pnpm` and `npx`, but the example shows only `npx`, which can confuse readers. Minimal fix: either remove `pnpm` from the sentence or add a `pnpm` example block (do not invent command semantics without confirmation; removing `pnpm` is the safe minimal change).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles-reader-first-answer-first
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording

---

- [ ] **9. Vague/marketing phrasing in intro (“wide range of problems”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/telegram-apps-mate.mdx?plain=1#L5

Avoid marketing language and vague claims. Minimal fix: remove the clause or replace with a specific, factual scope if available. Since we must not invent domain facts, prefer removal: “Mate is a multifunctional tool for developers on the Telegram Mini Apps platform.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles-reader-first-answer-first
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording

---

- [ ] **10. Acronym not defined on first mention ("Telegram Mini Apps")**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/telegram-apps-mate.mdx?plain=1#L5

First mention of "Telegram Mini Apps" does not define the acronym. Minimal fix: "Telegram Mini Apps (TMAs)". Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms. If the acronym is not used later on this page, defining it is still preferred for consistency with nearby pages (see https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/overview.mdx?plain=1).

---

- [ ] **11. Title case and label in heading; use sentence case + imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/telegram-apps-mate.mdx?plain=1#L27

Heading "Install-free Usage" uses title case and a noun label. For procedures, use sentence case and an imperative. Minimal fix: "Use without installing". Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.1-case-and-form and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.2-gerunds-and-labels.

---

- [ ] **12. Opening sentence: comma splice, awkward preposition, and marketing tone**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/telegram-apps-mate.mdx?plain=1#L5

The sentence uses a comma splice and awkward preposition ("at the ... platform"), and includes marketing phrasing ("multifunctional", "solves a wide range of problems"). Minimal fix: "Mate is a tool for developers on the Telegram Mini Apps platform." (Removes the comma, fixes the preposition, and trims marketing tone.)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.1-commas-colons-semicolons
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles-reader-first-answer-first

---

- [ ] **13. Shell code fences use `sh`; align to `bash` for consistency**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/telegram-apps-mate.mdx?plain=1#L11-L31

Fences are labeled "sh" while similar pages use "bash" for shell commands. Align to the prevalent tag for consistency. Minimal fix: change "```sh ..." to "```bash ..." for all shell command blocks.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10.1-general-rules
Note: The guide is silent on `sh` vs `bash`; nearby pages use `bash` (see https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/create-mini-app.mdx?plain=1#L16). Aligning improves consistency.

---

- [ ] **14. Future tense in accessibility sentence; use present**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/telegram-apps-mate.mdx?plain=1#L19

"Once installed, the package will be accessible ..." uses future tense. Use present for general behavior. Minimal fix: "After installation, the package is accessible via the `mate` CLI tool:".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.1-voice-tense-and-person

---

- [ ] **15. Wordy, passive recommendation; use direct instruction**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/mate/telegram-apps-mate.mdx?plain=1#L25

"It is highly recommended to install the package locally ... to ensure a consistent usage experience within the development team." is passive and verbose. Minimal fix: "Install the package locally to avoid version confusion and ensure a consistent experience within your team." (Uses active voice and simpler wording.)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.1-voice-tense-and-person
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording