### PR TITLE
[AI] fix: qa-guide.mdx

### DIFF
--- a/ecosystem/ton-connect/walletkit/qa-guide.mdx
+++ b/ecosystem/ton-connect/walletkit/qa-guide.mdx
@@ -11,30 +11,35 @@ Integrate TON Connect and verify your implementation works correctly.
   >
     Learn what good integration looks like
   </Card>
+
   <Card
     title="Demo environment and testing platform"
     href="#demo-environment-and-testing-platform"
   >
     Use TON Foundation's testing infrastructure.
   </Card>
+
   <Card
     title="Testing your implementation"
     href="#testing-your-implementation"
   >
     Verify that your basic integration works.
   </Card>
+
   <Card
     title="Go-live procedure"
     href="#go-live-procedure"
   >
     See what's needed for production integrations.
   </Card>
+
   <Card
     title="Support"
     href="#support"
   >
     Get help.
   </Card>
+
   <Card
     title="FAQ"
     href="#faq"
@@ -80,17 +85,17 @@ Our testing platform, Allure TestOps, contains manual test scenarios you execute
 - Login: `guest`
 - Password: `<PROVIDED_BY_TESTOPS>`
 
-| \#  | Test suite                         | Coverage                                                  |
-| :-- | :--------------------------------- | :-------------------------------------------------------- |
-| 1   | Common Checks                      | Pull request (PR) formatting, manifest validation, platform installation |
-| 2   | Connection and Transaction Sending | Core functionality across platforms and dApps             |
-| 3   | Disconnection Testing              | Session termination scenarios                             |
-| 4   | Transaction Data Validation        | Wallet-side security checks                               |
-| 5   | Max Messages                       | Batch transaction handling                                |
-| 6   | App Domain Validation              | Security testing for TON Proof wallets                    |
-| 7   | Extra Currency Support             | Advanced currency features                                |
-| 8   | Merkle Proof/Update                | Advanced cryptographic operations                         |
-| 9   | Sign data                          | Custom payload signing                                    |
+| #  | Test suite                         | Coverage                                                                 |
+| :- | :--------------------------------- | :----------------------------------------------------------------------- |
+| 1  | Common Checks                      | Pull request (PR) formatting, manifest validation, platform installation |
+| 2  | Connection and Transaction Sending | Core functionality across platforms and dApps                            |
+| 3  | Disconnection Testing              | Session termination scenarios                                            |
+| 4  | Transaction Data Validation        | Wallet-side security checks                                              |
+| 5  | Max Messages                       | Batch transaction handling                                               |
+| 6  | App Domain Validation              | Security testing for TON Proof wallets                                   |
+| 7  | Extra Currency Support             | Advanced currency features                                               |
+| 8  | Merkle Proof/Update                | Advanced cryptographic operations                                        |
+| 9  | Sign data                          | Custom payload signing                                                   |
 
 Each test case shows:
 
@@ -108,17 +113,23 @@ After building your integration, verify that it works with a basic connection te
 ### Run a basic connection test
 
 1. Open the [React Demo dApp](https://ton-connect.github.io/demo-dapp-with-react-ui/).
+
 1. Click "Connect Wallet" to see the connection modal.
+
 1. Choose connection method:
 
-    - "Scan universal QR code": Use your mobile wallet to scan the QR code (works with any TON Connect wallet)
-    - Find your wallet in the testing wallets list and click it for direct connection
+   - "Scan universal QR code": Use your mobile wallet to scan the QR code (works with any TON Connect wallet)
+   - Find your wallet in the testing wallets list and click it for direct connection
 
 1. Complete the connection based on your wallet type (extension, mobile app, or web wallet).
+
 1. Try sending a simple transaction to confirm full functionality.
 
-<Aside type="caution" title="Funds at risk">
-Use testnet when possible. Sending a transaction can move real funds.
+<Aside
+  type="caution"
+  title="Funds at risk"
+>
+  Use testnet when possible. Sending a transaction can move real funds.
 </Aside>
 
 If this works, your basic integration is successful, and you can start using our testing platform suites. If your wallet doesn't appear in the list or connection fails, revisit the technical implementation guides.


### PR DESCRIPTION
- [ ] **1. Throat-clearing opener; replace with direct purpose**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/qa-guide.mdx?plain=1#L5

The first sentence is meta ("This document provides a complete guide…") and delays the task. Replace with a direct, action-focused purpose. For example: "Integrate TON Connect and verify your implementation works correctly." Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **2. Undefined acronym in title ("QA")**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/qa-guide.mdx?plain=1#L2

Expand the acronym on first use in the title. For example: "Integration quality assurance (QA) guide." Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **3. Undefined acronym ("UX")**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/qa-guide.mdx?plain=1#L54

Spell out on first mention: "demonstrates the user experience (UX) for wallets implemented as Telegram Mini Apps." Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **4. Undefined acronym on first use ("dApp")**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/qa-guide.mdx?plain=1#L58

Define on first occurrence: "Open the React demo decentralized application (dApp)…" Subsequent uses may keep "dApp". Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **5. Non-descriptive link text ("via this link")**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/qa-guide.mdx?plain=1#L78

Replace "via this link" with descriptive link text. For example: "View all test scenarios." Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text

---

- [ ] **6. UI label not quoted ("Description" field)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/qa-guide.mdx?plain=1#L72

Literal UI labels must be in quotation marks. Change to: a "Description" field indicating which dApp to use… Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **7. Ordered list uses explicit numbering instead of `1.` auto-numbering**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/qa-guide.mdx?plain=1#L110

Use `1.` for each step to let the renderer auto-number the ordered list. Change each list item marker in this sequence to `1.`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **8. Step sentences missing terminal periods**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/qa-guide.mdx?plain=1#L110

These ordered list items are full sentences and SHOULD end with periods for consistency. Add periods at the end of items on lines 110, 111, 117, and 118. Keep line 112 as a colon since it introduces sub-steps. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **9. Task heading not imperative ("Basic connection test")**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/qa-guide.mdx?plain=1#L108

Use an imperative verb for procedure headings. For example: "Run a basic connection test". Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form

---

- [ ] **10. Task heading not imperative ("Wallet submission")**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/qa-guide.mdx?plain=1#L124

Use an imperative verb for procedure headings. For example: "Submit your wallet". Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form

---

- [ ] **11. Missing safety callout for funds movement**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/qa-guide.mdx?plain=1#L118

Step 5 instructs sending a transaction (funds movement) without a Caution/Warning. Add an `<Aside type="caution" title="Funds at risk">` advising readers to use testnet and that sending a transaction can move real funds. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-3-safety-and-secrets-in-code

---

- [ ] **12. Secrets exposed in examples (guest credentials)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/qa-guide.mdx?plain=1#L80

Do not include passwords in public examples. Replace the password with a placeholder and instruct readers to obtain credentials from the platform owner. For example: "Password: `<PROVIDED_BY_TESTOPS>`". Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-3-safety-and-secrets-in-code

---

- [ ] **13. Undefined acronym ("PR") in table**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/qa-guide.mdx?plain=1#L85

Expand on first mention: "Pull request (PR) formatting". Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **14. Imprecise wording/grammar ("use … into")**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/qa-guide.mdx?plain=1#L102

Fix the preposition for clarity: "Paste the provided JSON configurations into the demo dApp’s editable transaction interface." This relies on general English grammar. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **15. Word order for clarity ("relevant following information")**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/qa-guide.mdx?plain=1#L142

Prefer natural phrasing: change to "the following relevant information". Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **16. Inconsistent repository name ("wallet-list" vs "wallets-list")**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/qa-guide.mdx?plain=1#L126

Use the same repository name consistently to match the linked target. Change "wallet-list repository" to "wallets-list repository". Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules

---

- [ ] **17. Inconsistent list punctuation in Support bullets**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/qa-guide.mdx?plain=1#L144

Within the Support list, items at lines 145 and 146 end with periods while the first does not. Make punctuation consistent with the non-sentence style: remove the trailing periods from the second and third bullets. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **18. Card copy not imperative and not sentence case**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/qa-guide.mdx?plain=1#L18-L42

Card body text starts lowercase and uses non‑imperative phrasing. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#52-plain-precise-wording. This also relies on general English grammar: sentences start with a capital letter. Minimal fixes (use sentence case + imperative where appropriate):
- 18: “Use TON Foundation’s testing infrastructure.”
- 24: “Verify that your basic integration works.”
- 30: “See what’s needed for production integrations.”
- 36: “Get help.”
- 42: “Frequently asked questions.”

---

- [ ] **19. UI labels styled in bold instead of quoted**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/qa-guide.mdx?plain=1#L70-L72

The test suite labels are styled as **GENERAL**/**CUSTOM**. UI/log strings must appear verbatim in quotation marks and not use bold for emphasis. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#62-quotation-marks-and-emphasis. Minimal fix: replace bold with quotation marks: “GENERAL” and “CUSTOM”.

---

- [ ] **20. Field label should be quoted as literal UI text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/qa-guide.mdx?plain=1#L72-L97

References to the “Description” field appear without quotation marks, and the bullet list bolds the UI label. Literal UI labels must be quoted and not bolded. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#62-quotation-marks-and-emphasis. Minimal fix: change both instances to “Description” (remove bold) and keep exact casing/punctuation.

---

- [ ] **21. Mis‑nested sublist under numbered step**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/qa-guide.mdx?plain=1#L114-L116

Bullets under step 3 are indented with two spaces, which can render as a separate list instead of a nested sublist. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#82-structure-for-scanning. Minimal fix: indent the two bullet items by four spaces so they nest under step 3. This relies on basic Markdown nesting rules: four spaces consistently create a nested list under a numbered item.

---

- [ ] **22. Undefined abbreviation “BizDev”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/qa-guide.mdx?plain=1#L130

Uses “BizDev” without defining it. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#53-acronyms-and-terms. Minimal fix: “business development (BizDev) liaison”.

---

- [ ] **23. Wordy/awkward support request phrasing**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/qa-guide.mdx?plain=1#L142-L145

Phrases “the relevant following information” and “the attached URL to the corresponding Allure scenario” reduce clarity. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#52-plain-precise-wording. Minimal fixes:
- 142: “include the following relevant information”
- 145: “or a link to the corresponding Allure scenario”

---

- [ ] **24. Comma splice and number agreement in Demo dApps**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/qa-guide.mdx?plain=1#L72

Two independent clauses are joined by a comma, and plural “dApps” mismatches singular “it”. Minimal fix: “Additionally, there are several demo dApps used for testing specific scenarios. In our testing platform, they are called “CUSTOM”.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons. General English grammar applies for number agreement.

---

- [ ] **25. Procedure section uses gerund; prefer imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/qa-guide.mdx?plain=1#L104

“Testing your implementation” is a task section and should start with an imperative verb. Minimal fix: “Test your implementation”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-2-gerunds-and-labels

---

- [ ] **26. Remove marketing tone adverb**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/qa-guide.mdx?plain=1#L140

“…help you reach production smoothly.” uses a marketing-style adverb. Minimal fix: “…help you reach production.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles-reader-first-answer-first

---

- [ ] **27. Quote literal UI option names**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/qa-guide.mdx?plain=1#L114-L115

List items refer to literal options (“universal QR code”, testing wallets list entry). Where exact UI strings exist, they should be in quotes to be copy‑matching. Minimal fix: quote literal UI/menu labels that appear on screen (e.g., “Scan universal QR code”, wallet list entry names). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **28. Overlong bold emphasis span**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/qa-guide.mdx?plain=1#L130

Within a paragraph, bold spans should be short (≤ 3 words). “three to five business days” exceeds this and is used for emphasis. Minimal fix: remove bold from this phrase or replace with plain text.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **29. Inconsistent punctuation in Support list**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/qa-guide.mdx?plain=1#L144

List items mix terminal punctuation (some with periods, some without). For full‑sentence items, end with periods consistently. Minimal fix: add a period to the first bullet (“Wallet platform and version: …”).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **30. Jargon/slang “BizDev” — prefer neutral wording**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/qa-guide.mdx?plain=1#L130

Avoid slang/colloquialisms. “BizDev” is internal jargon. Minimal fix: “business development liaison”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#4-voice-and-tone