### PR TITLE
[AI] fix: first-smart-contract.mdx

### DIFF
--- a/guidebook/first-smart-contract.mdx
+++ b/guidebook/first-smart-contract.mdx
@@ -22,6 +22,7 @@ By the end of this tutorial, you'll have:
 A **smart contract** is a computer program stored on [TON blockchain](/ton/overview) — a distributed database that many computers maintain together. It runs on the [TON Virtual Machine](/tvm/overview) (TVM) — the computer that runs smart contract code on TON.
 
 The contract is made of two parts:
+
 - **Code** (compiled TVM instructions) — the rules or program logic
 - **Data** (persistent state) — the memory that remembers things between interactions
 
@@ -39,14 +40,14 @@ Both are stored at a specific **address** on TON blockchain, a unique identifier
 
 This tutorial is organized into 6 clear steps that build upon each other:
 
-| Step                                                               | What You'll Do              | Key Skills                                           |
-|--------------------------------------------------------------------|-----------------------------|------------------------------------------------------|
+| Step                                                            | What You'll Do              | Key Skills                                           |
+| --------------------------------------------------------------- | --------------------------- | ---------------------------------------------------- |
 | **[Step 1](#step-1-development-environment-setup)**             | Set up Blueprint toolkit    | Project structure, development environment           |
 | **[Step 2](#step-2-understanding-smart-contract-architecture)** | Learn contract architecture | Storage, messages, getters concept                   |
 | **[Step 3](#step-3-writing-the-smart-contract)**                | Write contract in Tolk      | Programming, message handling, data structures       |
-| **[Step 4](#step-4-compiling-your-contract)**                                                    | Compile to bytecode         | Build process, TVM compilation                       |
-| **[Step 5](#step-5-deploying-to-testnet)**                         | Deploy to blockchain        | Testnet deployment, wallet integration               |
-| **[Step 6](#step-6-contract-interaction)**                         | Interact with contract      | Message sending, get methods, TypeScript integration |
+| **[Step 4](#step-4-compiling-your-contract)**                   | Compile to bytecode         | Build process, TVM compilation                       |
+| **[Step 5](#step-5-deploying-to-testnet)**                      | Deploy to blockchain        | Testnet deployment, wallet integration               |
+| **[Step 6](#step-6-contract-interaction)**                      | Interact with contract      | Message sending, get methods, TypeScript integration |
 
 Let's dive into development!
 
@@ -76,8 +77,8 @@ Example/
 ```
 
 <Aside>
-    TON provides plugins that add syntax support for various IDEs and code editors.
-    Check out the [IDE and plugins](/ecosystem/ide/overview) section for VS Code and JetBrains support.
+  TON provides plugins that add syntax support for various IDEs and code editors.
+  Check out the [IDE and plugins](/ecosystem/ide/overview) section for VS Code and JetBrains support.
 </Aside>
 
 Now, move into the project directory:
@@ -90,13 +91,16 @@ cd Example
 
 Every smart contract in TON is typically divided into three sections: **storage**, **messages**, and **getters**.
 
-- **Storage**: Defines the contract’s persistent data. For example, our *counter* variable must keep its value across calls from different users.
+- **Storage**: Defines the contract’s persistent data. For example, our _counter_ variable must keep its value across calls from different users.
 - **Messages**: Define how the contract reacts to incoming messages. On TON, the primary way to interact with contracts is by sending [messages](/ton/transaction). Each processed message produces a [transaction](/ton/transaction) — a recorded change on the blockchain (like "Alice sent 5 TON to Bob").
 - **Getters**: Provide read-only access to contract data without modifying state. For example, we’ll create a getter to return the current value of the counter.
 
-<Aside type="note" title="Important">
-    Due to the [TON architecture](/guidebook/from-ethereum#on-chain-get-methods), getters cannot be called from other contracts.
-    Inter-contract communication is possible only through **messages**.
+<Aside
+  type="note"
+  title="Important"
+>
+  Due to the [TON architecture](/guidebook/from-ethereum#on-chain-get-methods), getters cannot be called from other contracts.
+  Inter-contract communication is possible only through **messages**.
 </Aside>
 
 ## Step 3: Write the smart contract
@@ -131,6 +135,7 @@ fun Storage.save(self) {
 
 Behind the scenes, structures know how to serialize and deserialize themselves into [cells](/tvm/serialization/cells) — the fundamental way TON stores data. This happens through the `fromCell` and `toCell` functions - Tolk automatically converts between your nice structures and the cell format that TON understands.
 You may think of cells like containers that hold data on TON:
+
 - Each cell can store up to 1023 bits of data.
 - Cells can reference other cells (like links).
 - Everything on TON (contracts, messages, storage) is made of cells.
@@ -193,9 +198,11 @@ fun onInternalMessage(in: InMessage) {
 }
 ```
 
-<Aside title={"Learn more about Tolk"}>
-    - [Tolk Language Guide](/language/tolk) - Complete language documentation
-    - [View the complete contract on GitHub](https://github.com/tact-lang/ton-docs-examples/blob/main/guidebook/first-smart-contract/Example/contracts/first_contract.tolk)
+<Aside
+  title={"Learn more about Tolk"}
+>
+  - [Tolk Language Guide](/language/tolk) - Complete language documentation
+  - [View the complete contract on GitHub](https://github.com/tact-lang/ton-docs-examples/blob/main/guidebook/first-smart-contract/Example/contracts/first_contract.tolk)
 </Aside>
 
 ### 3.3 Adding getter functions
@@ -270,8 +277,10 @@ get fun currentCounter(): int {
 
 Congratulations — you've built your first smart contract in **Tolk**!
 
-<Aside title={"Complete example code"}>
-    You can find the full working code for this tutorial in our [GitHub repository](https://github.com/tact-lang/ton-docs-examples/tree/main/guidebook/first-smart-contract/Example). This includes all contract files, scripts, and wrappers ready to use.
+<Aside
+  title={"Complete example code"}
+>
+  You can find the full working code for this tutorial in our [GitHub repository](https://github.com/tact-lang/ton-docs-examples/tree/main/guidebook/first-smart-contract/Example). This includes all contract files, scripts, and wrappers ready to use.
 </Aside>
 
 ## Step 4: Compile your contract
@@ -376,7 +385,10 @@ export async function run(provider: NetworkProvider) {
 
 The `sendDeploy` method accepts three arguments, but we only pass two because `provider.open` automatically supplies the ContractProvider as the first argument.
 
-<Aside type="caution" title="Funds at risk (testnet recommended)">
+<Aside
+  type="caution"
+  title="Funds at risk (testnet recommended)"
+>
   These commands send value from your wallet. Scope: only the specified contract. If a transaction fails, retry on testnet and verify amounts before using mainnet.
 </Aside>
 
@@ -412,6 +424,7 @@ Congratulations! Your contract is live on testnet. Let's interact with it by sen
 Technically speaking, we've already sent messages to the contract - the deploy message in previous steps. Now let's see how to send messages with body.
 
 First of all, we should update our wrapper class with three methods: `sendIncrease`, `sendReset`, and `getCounter`:
+
 ```typescript title="./wrappers/FirstContract.ts"
 import { Address, beginCell, Cell, Contract, contractAddress, ContractProvider, Sender, SendMode } from '@ton/core';
 
@@ -476,11 +489,13 @@ The only difference from the deploy message is that we pass a **body** to it —
 ### Building message bodies
 
 Construction of cells starts with the `beginCell` method ([learn more about cell serialization](/tvm/serialization/cells)):
+
 - `beginCell()` - creates a new cell builder
 - `storeUint(value, bits)` - adds an unsigned integer of specified bit length
 - `endCell()` - finalizes the cell
 
 **Example**: `beginCell().storeUint(0x7e8764ef, 32).storeUint(42, 32).endCell()`
+
 - First 32 bits: `0x7e8764ef` (opcode for increase)
 - Next 32 bits: `42` (increase by this amount)
 
@@ -517,11 +532,13 @@ Do not forget to replace `<CONTRACT_ADDRESS>` with your actual contract address 
 - **Transaction waiting**: `waitForLastTransaction()` waits for the transaction to be processed on-chain
 
 To run this script:
+
 ```bash
 npx blueprint run sendIncrease --testnet --tonconnect --tonviewer
 ```
 
 Expected result:
+
 ```text
 Using file: sendIncrease
 Connected to wallet at address: ...
@@ -542,7 +559,7 @@ You can view it at https://testnet.tonviewer.com/transaction/fe6380dc2e4fab5c2ca
 1. **Confirmation**: The transaction hash is returned, and you can view it on the explorer.
 
 <Aside type={"tip"}>
-    **Composability**: Messages can be sent to your contract by other contracts too! This means different contracts can increment your counter, allowing the TON ecosystem to create composable apps and protocols that build on top of each other and interact in unforeseen ways.
+  **Composability**: Messages can be sent to your contract by other contracts too! This means different contracts can increment your counter, allowing the TON ecosystem to create composable apps and protocols that build on top of each other and interact in unforeseen ways.
 </Aside>
 
 Let's create a script `./scripts/sendReset.ts` that would reset the counter:
@@ -562,11 +579,13 @@ export async function run(provider: NetworkProvider) {
 ```
 
 To run this script:
+
 ```bash
 npx blueprint run sendReset --testnet --tonconnect --tonviewer
 ```
 
 Expected result:
+
 ```text
 Using file: sendReset
 Connected to wallet at address: ...
@@ -575,7 +594,6 @@ Sent transaction
 Transaction 0fc1421b06b01c65963fa76f5d24473effd6d63fc4ea3b6ea7739cc533ba62ee successfully applied!
 You can view it at https://testnet.tonviewer.com/transaction/fe6380dc2e4fab5c2caf41164d204e2f41bebe7a3ad2cb258803759be41b5734
 ```
-
 
 ### 6.2 Reading contract data with get methods
 
@@ -608,15 +626,17 @@ export async function run(provider: NetworkProvider) {
 1. **Data parsing**: Our wrapper automatically converts the returned stack value to a JavaScript number.
 
 <Aside>
-    Getters are only accessible **off-chain** (from JavaScript clients, web apps, and similar clients) through RPC service providers. **Contracts cannot call getters on other contracts** - inter-contract communication must use messages only.
+  Getters are only accessible **off-chain** (from JavaScript clients, web apps, and similar clients) through RPC service providers. **Contracts cannot call getters on other contracts** - inter-contract communication must use messages only.
 </Aside>
 
 To run this script:
+
 ```bash
 npx blueprint run getCounter --testnet --tonconnect
 ```
 
 Expected output:
+
 ```text
 Using file: getCounter
 Counter:  42
@@ -631,18 +651,21 @@ Congratulations! You've successfully built, deployed, and interacted with your f
 Ready to build more advanced contracts? Here's your roadmap:
 
 #### Next steps
+
 - [Tolk Language Guide](/language/tolk) - Master advanced Tolk features and syntax
 - [Blueprint Documentation](/ecosystem/blueprint/overview) - Learn advanced development patterns
 - [Tutorial Example Repository](https://github.com/tact-lang/ton-docs-examples/tree/main/guidebook/first-smart-contract/Example) - Complete working code from this tutorial
 - [Smart Contract Examples](/techniques/examples) - Study real-world contract implementations
 
 #### Advanced topics
+
 - [Gas Optimization](/techniques/gas) - Reduce transaction costs
 - [Security Best Practices](/techniques/security) - Protect your contracts
 
-
-<Aside title={"Tutorial Credits"}>
-    This tutorial was enhanced with insights from the excellent [TON Hello World series](https://helloworld.tonstudio.io/02-contract/) by Tal Kol and the TON community. For additional examples and alternative approaches, check out the original series.
+<Aside
+  title={"Tutorial Credits"}
+>
+  This tutorial was enhanced with insights from the excellent [TON Hello World series](https://helloworld.tonstudio.io/02-contract/) by Tal Kol and the TON community. For additional examples and alternative approaches, check out the original series.
 </Aside>
 
 Happy coding on TON! You're now equipped with the fundamentals to build amazing smart contracts. The blockchain world awaits your innovations!


### PR DESCRIPTION
- [ ] **1. In-body H1 duplicates frontmatter title**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1#L7

The page includes an in-body H1 (`# Your first smart contract`) while the frontmatter `title` already renders the page title. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.1-case-and-form. Minimal fix: remove the in-body H1 line and start headings at `##` (H2).

---

- [ ] **2. Capitalization of “TON Blockchain” mid-sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1#L24-L30

“TON Blockchain” capitalizes the generic noun “blockchain.” Generic concepts must not be capitalized mid-sentence. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13.2-general-casing-rules. Minimal fix: change to “TON blockchain” in both sentences.

---

- [ ] **3. Quotation marks used for emphasis**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1#L24-L28

Quotation marks are used for emphasis around words like “computer,” “rules,” “program logic,” and “memory.” Quotes must be reserved for literal UI/log/error strings, not emphasis. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.2-quotation-marks-and-emphasis. Minimal fix: remove ornamental quotes and use plain wording (e.g., “the computer that runs…”, “the rules or program logic”, “the memory…”).

---

- [ ] **4. Missing article before “distributed database”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1#L24

Sentence reads “— distributed database that many computers maintain together” and is missing the article “a,” which harms readability. This is basic English grammar (general knowledge). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#8.1-paragraphs-and-sentences. Minimal fix: “— a distributed database that many computers maintain together.”

---

- [ ] **5. Non-descriptive link text (“Download here”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1#L36

Link text must be descriptive; “Download here” is vague. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12.1-link-text. Minimal fix: change link text to “Download Node.js”.

---

- [ ] **6. Unordered list markers use `*` instead of `-`**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1#L95-L345

Unordered lists use `*` markers; the guide requires `-` (hyphen) for all unordered lists. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.4-lists. Minimal fix: replace leading `*` with `-` for the listed items.

---

- [ ] **7. Step overview table links use encoded colon in anchors**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1#L46-L51

Internal anchors include `%3A` (encoded colon), which may not match generated heading slugs and can break navigation. Anchors must resolve correctly. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12.3-link-targets-and-format. Minimal fix: update links to omit the colon in the fragment, e.g., `#step-1-development-environment-setup`, `#step-2-understanding-smart-contract-architecture`, `#step-3-writing-the-smart-contract`, `#step-4-compiling-your-contract`, `#step-5-deploying-to-testnet`, `#step-6-contract-interaction`.

---

- [ ] **8. TODO leaked to readers in prerequisites**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1#L38

User-facing text contains a TODO (“TODO: NOT DONE YET, WAIT FOR FAUCET COMPONENT”), violating content hygiene and timelessness. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17.3-freshness-and-updates. Minimal fix: remove the TODO and rephrase to a stable statement, e.g., “TON wallet — you will set this up in Step 5.” If a status must be signaled, use an `<Aside>` with a clear title per §16.4.

---

- [ ] **9. Task headings use gerunds instead of imperatives**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1#L104-L308

For procedure sections, headings SHOULD be imperative. Current headings use gerunds: “Writing the smart contract,” “Compiling your contract,” “Deploying to testnet.” Rules: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.1-case-and-form and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.2-gerunds-and-labels. Minimal fix: “Write the smart contract,” “Compile your contract,” “Deploy to testnet.”

---

- [ ] **10. Step 1 heading not imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1#L55

“Step 1: Development environment setup” is a task section and should start with an imperative verb. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.1-case-and-form. Minimal fix: “Step 1: Set up the development environment.”

---

- [ ] **11. Missing language tag on fenced output block**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1#L289-L302

The “Expected output” fenced block lacks a language tag; all fenced blocks must specify a language. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10.1-general-rules. Minimal fix: change opening fence to “```text”.

---

- [ ] **12. Placeholder definition and style in code**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1#L584-L600

Placeholders must be defined on first use, and inside language code a neutral style is preferred to avoid syntax collisions. `provider.get(<GET_METHOD_NAME>)` uses an angle-bracket placeholder without definition; `<CONTRACT_ADDRESS>` appears in multiple scripts without a clear first-use definition in prose before the code. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10.1-general-rules. Minimal fix: (a) Add a one-sentence definition at first use, e.g., “Replace `<CONTRACT_ADDRESS>` with the address printed after deployment in Step 5.” placed immediately before the first code snippet that uses it. (b) Prefer a neutral placeholder in code (e.g., `provider.get(METHOD_NAME)`) or use the actual example method name (`currentCounter`) consistently.

---

- [ ] **13. Grammar: missing preposition in replacement instruction**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1#L505

Sentence reads “Do not forget to replace `<CONTRACT_ADDRESS>` your actual contract address…” and is missing “with.” This is basic English grammar (general knowledge). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#8.1-paragraphs-and-sentences. Minimal fix: “Do not forget to replace `<CONTRACT_ADDRESS>` with your actual contract address from Step 5.”

---

- [ ] **14. Full-sentence list items without terminal periods**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1#L532-L604

In “What happens during execution” and “Understanding the get method execution,” list items are full sentences but lack terminal periods. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.4-lists. Minimal fix: add periods at the end of each sentence in these lists.

---

- [ ] **15. Heading case and styling in “Continue/Next/Advanced” section**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1#L625-L635

Headings must use sentence case and must not contain styling like bold. Current headings use Title Case and bold: “Continue Your Learning Journey”, “**Next Steps**”, “**Advanced Topics**”. Rules: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.1-case-and-form and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.4-formatting-restrictions. Minimal fix: “Continue your learning journey”, “Next steps”, “Advanced topics” (remove bold).

---

- [ ] **16. Non-standard `<Warning>` component instead of `<Aside>`**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1#L99-L102

Callouts must use the `<Aside>` component with supported `type` values; other components (e.g., `<Warning>`) are not allowed. Rules: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11.2-admonitions and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#19-appendices-a-admonition-levels-and-usage. Minimal fix: replace with `<Aside type="note" title="Important">…</Aside>` (least-severe label that fits the content) or choose `type="caution"`/`type="danger"` only if warranted by risk.

---

- [ ] **17. Use a stable permalink for GitHub code link**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1#L198-L200

Linking to a moving `main` branch for a specific code file risks drift. Prefer a versioned/tagged or commit permalink when referencing exact code. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12.5-external-references. Minimal fix: change the GitHub URL to a tag or commit permalink for the example repository path.

---

- [ ] **18. Ordered lists should use `1.` for all items**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1#L532-L604

Ordered lists must use `1.` for every item to enable auto-numbering; the current lists hard-code `1., 2., 3., …`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.4-lists. Minimal fix: change all items in these lists to start with `1.`.

---

- [ ] **19. Code fence language incorrect for expected output**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1#L616-L619

The “Expected output” block is labeled `bash` but contains output, not commands. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10.1-general-rules. Minimal fix: change the fence to ` ```text `.

---

- [ ] **20. Missing safety callout before wallet-funded actions**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1#L383-L619

Commands initiate wallet connections and send value (`toNano('0.05')`). Add a Caution/Warning callout before the first deployment/interaction command that states risk, scope, rollback/mitigation, and testnet/mainnet labeling. Minimal addition example:

```mdx
<Aside type="caution" title="Funds at risk (testnet recommended)">
  These commands send value from your wallet. Scope: only the specified contract. If a transaction fails, retry on testnet and verify amounts before using mainnet.
</Aside>
```
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-1-when-a-safety-callout-is-required; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout

---

- [ ] **21. Acronym introduction order reversed**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1#L24

Use “full term (ACRONYM)” on first mention. Change “the [TVM] (TON Virtual Machine)” to “the TON Virtual Machine (TVM)”. Keep the link on the first useful mention.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **22. Quotation marks used for emphasis**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1#L24-L482

Quotation marks should be for literal UI/log strings only. Remove emphasis quotes:
- “the "computer" that runs …” → “the computer that runs …”
- “opcode for "increase"” → “opcode for increase” (or use code font if it’s a literal token)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **23. Example filenames not in kebab-case**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1#L70-L598

Filenames in examples should be kebab-case. Update occurrences consistently:
- `deployFirstContract.ts` → `deploy-first-contract.ts`
- `FirstContract.ts` → `first-contract.ts`
- `FirstContract.compile.ts` → `first-contract.compile.ts`
- `sendIncrease.ts` → `send-increase.ts`
- `sendReset.ts` → `send-reset.ts`
- `getCounter.ts` → `get-counter.ts`
- `FirstContract.spec.ts` → `first-contract.spec.ts`
Also update command invocations, import paths, and code fence titles accordingly.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **24. Marketing tone in opening sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1#L9

Reduce marketing phrasing in technical sections. Replace “Welcome to your journey into TON smart contract development! In this comprehensive tutorial, you'll learn to…” with a direct objective, e.g., “Build, deploy, and interact with a TON smart contract from scratch.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles-reader-first-answer-first

---

- [ ] **25. Link text capitalization consistency**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1#L82

Prefer sentence case in link text unless it’s a proper noun. Change “IDE & plugins” to “IDE and plugins” to improve readability; “IDE” remains uppercase as an acronym.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **26. Silent truncation of transaction ID in expected output**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1#L520-L528

The expected output shows a truncated transaction URL (`.../transaction/fe638`). Do not silently truncate IDs. Use a full transaction ID or indicate truncation explicitly (e.g., `EQC…9gA`) with a note that the value is shortened.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#14-2-units-and-conventions

---

- [ ] **27. Emojis in prose and headings**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1

Emojis appear in prose, lists, aside titles, and headings (e.g., ✅ in “What you'll learn” bullets; 🎉 in “Congratulations — you've built…”, “🎉 Tutorial complete!”, and final line; 🚀 in “Ready to put your contract on-chain? 🚀”; 📚/📁 in Aside titles). Emojis in prose and headings must not appear. Minimal fix: remove emojis from prose, list items, headings, and aside titles; keep plain text labels.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#4-voice-and-tone

---

- [ ] **28. Partial code snippets not labeled “Not runnable”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1

Several focused excerpts are not runnable by themselves (e.g., the Tolk struct/union/message handler snippets in §3.2, the single getter in §3.3, and the one-line cell construction example). Partial snippets must be labeled “Not runnable” above the block, and should link to a full runnable example (which you already provide in §3.4 and the GitHub link). Minimal fix: add a “Not runnable” label line immediately above each partial snippet.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **29. First‑person and inclusive “let’s” phrasing**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1

The page uses first‑person and “let’s” phrasing (e.g., “Let's dive into development!”, “Now let's see…”, “remember the cells I talked about previously?”). The style prefers second person, present tense, active voice, and avoiding ambiguous “we/I”. Minimal fix: revise to direct imperatives and second‑person phrasing, e.g., “Start development.”, “Send messages with a body.”, “Recall cell serialization covered earlier” (or link to the anchor instead of referencing prior text).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#4-voice-and-tone
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **30. Entire sentence bolded in prose**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1#L623-L647

Full sentences are bolded (and include emojis). You must not bold entire sentences/paragraphs. Minimal fix: remove bold formatting (and remove emojis per item 2). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **31. “etc.” used in list context**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/first-smart-contract.mdx?plain=1#L606-L608

The Aside uses “web apps, etc.” The guide discourages “etc.” in lists. Minimal fix: replace with a bounded phrase like “web apps and similar clients”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references