### PR TITLE
[AI] fix: index.mdx

### DIFF
--- a/contribute/snippets/index.mdx
+++ b/contribute/snippets/index.mdx
@@ -55,7 +55,6 @@ Read more:
 - [Styling with Tailwind CSS in the Mintlify documentation](https://www.mintlify.com/docs/settings/custom-scripts#styling-with-tailwind-css)
 - [Tailwind CSS v3 Documentation][tailwind]
 
-
 ## See also
 
 - [Learn how to format text, create headers, and style content with Mintlify](https://www.mintlify.com/docs/text)


### PR DESCRIPTION
- [ ] **1. Gerund heading should be imperative (Use a snippet)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/index.mdx?plain=1#L10

The H2 "Using a snippet" uses a gerund. For task/procedure headings, use an imperative verb. Minimal fix: change to "Use a snippet".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-2-gerunds-and-labels

---

- [ ] **2. Gerund heading should be imperative (Use a component)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/index.mdx?plain=1#L16

The H2 "Using a component" uses a gerund. For task/procedure headings, use an imperative verb. Minimal fix: change to "Use a component".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-2-gerunds-and-labels

---

- [ ] **3. Avoid “etc.” in list of built-in components**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/index.mdx?plain=1#L43

The list ends with "etc.", which the guide discourages in procedures/lists. Minimal fix: remove "etc." and end the list after the last example ("Code groups").
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **4. Avoid “etc.” in list of custom components**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/index.mdx?plain=1#L47

The list ends with "etc.", which the guide discourages in procedures/lists. Minimal fix: remove "etc." and end the list after the last example ("Image").
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **5. Code comment: typo and awkward phrasing (“formatter” → “frontmatter”; phrasing)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/index.mdx?plain=1#L25

In the example, the comment says "Right after the formatter go the imports of snippets..." — "formatter" is a typo for "frontmatter" and the phrase is ungrammatical. Minimal fix: "{/* Right after the frontmatter, import snippets... */}".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **6. Awkward phrasing and hedge in opening sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/index.mdx?plain=1#L6

"Snippets allow to conveniently keep the same content in sync, while components let you easily reuse a piece of UI or styling consistently. Examples might include …" uses awkward verb construction ("allow to …") and hedging ("might"). Minimal fix: "Snippets let you keep the same content in sync, and components let you reuse UI or styling consistently. Examples include a link card …" (remove the hedge and fix the verb construction; grammar fix relies on basic English usage).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **7. Expand acronyms on first mention: UI**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/index.mdx?plain=1#L6

"UI" appears without expansion. Expand on first mention, then use the acronym. Minimal fix: "user interface (UI)".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **8. Expand acronyms on first mention: MDX and JSX**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/index.mdx?plain=1#L8

"MDX" and "JSX" appear without expansion. Expand on first mention, then use the acronyms thereafter. Minimal fix: "MDX (Markdown + JSX) snippets and JSX (JavaScript XML) components". This relies on general knowledge of common acronym expansions.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **9. Informal wording: “info” → “information”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/index.mdx?plain=1#L14

Prefer precise, formal wording. Minimal fix: "For more information on their creation and usage, refer to …".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **10. Vague relative reference (“near that page”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/index.mdx?plain=1#L43

"See items on the left navigation panel near that page" is vague and relies on relative context. Minimal fix: remove "near that page" and write a self-contained line, e.g., "Examples include: Accordion, Cards, Columns, Code groups." (keep the existing links as-is).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **11. Inconsistent end punctuation in “Read more” list**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/index.mdx?plain=1#L55

The first bullet ends with a period while the following bullets do not. Keep list punctuation consistent. Minimal fix: remove the trailing period from the first bullet to match the others.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **12. Grammar: “Tailwind CSS v3 style HTML elements” → “to style HTML elements”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/index.mdx?plain=1#L51

The phrase is ungrammatical. Minimal fix: "Mintlify supports [Tailwind CSS v3][tailwind] to style HTML elements and any components or snippets from the `snippets/` folder." (preposition "to" clarifies purpose; relies on basic grammar).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **13. Unofficial external link where official exists (release-blocking)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/index.mdx?plain=1#L57

Linking to "Unofficial Tailwind CSS v3 Cheatsheet" when the official Tailwind documentation is already linked violates the rule against unofficial links when an official source exists. Minimal fix: remove the unofficial cheatsheet link.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#severity-model-release-blocking

---

- [ ] **14. Ambiguous link text “that page”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/index.mdx?plain=1#L43

Link text must be descriptive; “that page” is non-descriptive. Minimal fix: replace the link text with the target’s heading, for example “JSX snippets”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#link-text

---

- [ ] **15. Internal links should be relative, not root-absolute**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/index.mdx?plain=1#L47

Prefer relative internal links. Minimal fix: change “/contribute/snippets/aside” → “aside” and “/contribute/snippets/image” → “image”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#links-and-anchors

---

- [ ] **16. Wordy boilerplate (“for you to use”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/index.mdx?plain=1#L8

Collapse boilerplate for precision. Minimal fix: “…and provides some built-in components.” (remove “for you to use”).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **17. Colon after “such as” — remove colon**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/snippets/index.mdx?plain=1#L43

Colons SHOULD introduce lists after a complete clause; adding a colon after “such as” is unnecessary. Minimal fix: remove the colon after “such as”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#61-commas-colons-semicolons