### PR TITLE
[AI] fix: merkle-update.mdx

### DIFF
--- a/tvm/serialization/merkle-update.mdx
+++ b/tvm/serialization/merkle-update.mdx
@@ -6,6 +6,7 @@ Merkle update cells always have two references, `c1` and `c2`, and behave like a
 for details. The level of a Merkle update cell, $0 \le l < 3$, is determined by `max{Lvl(c1) - 1, Lvl(c2) - 1, 0}`.
 
 Each Merkle update cell serializes as follows:
+
 - 1 tag byte with value `0x04`
 - the first 256-bit [higher hash](../hashes) of the referenced cell `c1` or the [representation hash](./cells#standard-cell-representation-and-its-hash) of `c1` if its level equals 0
 - the same for the second reference `c2`


### PR DESCRIPTION
- [ ] **1. Misspelled and non-descriptive link text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/merkle-update.mdx?plain=1#L5

The link text reads “merkel update cells page” — “Merkle” is misspelled (proper noun) and “page” is redundant. Use a concise, descriptive noun phrase with correct casing. Minimal fix: “See [Merkle update cells](/ton/cells/merkle-update-cells) for details.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-6-spelling-and-contractions

---

- [ ] **2. Inconsistent capitalization of proper noun “Merkle”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/merkle-update.mdx?plain=1#L6

The phrase “the level of a merkle update cell” lowercases “merkle”. “Merkle” is a proper noun and should be capitalized consistently. Minimal fix: “The level of a Merkle update cell …”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-terminology-and-naming

---

- [ ] **3. Comma/conjunction around inline identifiers `c1` and `c2`**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/merkle-update.mdx?plain=1#L5

The segment “two references `c1`, `c2` and behave …” is hard to scan. Use commas to set off the appositive and include the conjunction. Minimal fix: “two references, `c1` and `c2`, and behave like a Merkle proof for both.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **4. List punctuation inconsistent for fragment items**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/merkle-update.mdx?plain=1#L9-L13

Bulleted items are fragments but end with semicolons, and the last ends with a period. For unordered lists of fragments, omit terminal punctuation and keep it consistent. Minimal fix: remove the trailing semicolons and the final period on lines 9–13.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **5. Hyphenation and word order: “the 256-bits first …”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/merkle-update.mdx?plain=1#L10

Use correct compound adjective form and word order. Minimal fix: “the first 256-bit [higher hash] …”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#15-1-language-and-reading
Note: This relies on general English grammar for compound adjectives and modifier order.

---

- [ ] **6. Undefined identifier `c` in bullet**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/merkle-update.mdx?plain=1#L10

The phrase “the [representation hash] of `c`” uses ``c`` without prior definition in this context (the bullet discusses `c1`). Minimal fix: replace ``c`` with ``c1`` to match the subject, or define ``c`` explicitly. If a different object was intended, this needs confirmation from the domain owner.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles-reader-first-answer-first

---

- [ ] **7. Prefer relative paths for internal links**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/merkle-update.mdx?plain=1#L5-L10

Internal links currently use absolute root paths. Prefer relative links for stability. Minimal fixes:
- `/ton/cells/merkle-update-cells` → `../../ton/cells/merkle-update-cells`
- `/tvm/hashes` → `../hashes`
- `/tvm/serialization/cells` → `./cells`

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format

---

- [ ] **8. Deep link to the precise reference section**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/merkle-update.mdx?plain=1#L10

The link “[representation hash](/tvm/serialization/cells)” points to the page top. Cross-section links should jump to the exact anchor. Minimal fix: link to `./cells#standard-cell-representation-and-its-hash` (matches the heading in `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1`).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format

---

- [ ] **9. Verb choice: “determined as” → “determined by”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/merkle-update.mdx?plain=1#L6

Use the idiomatic preposition for this construction. Minimal fix: “is determined by `max{Lvl(c1) - 1, Lvl(c2) - 1, 0}`.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#15-1-language-and-reading
Note: This relies on general English usage for verb–preposition collocations.

---

- [ ] **10. Redundancy/contradiction: “old deleted subtree” and “new deleted subtree”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/merkle-update.mdx?plain=1#L12-L13

“Old deleted subtree” is redundant (“deleted” implies prior/old). “New deleted subtree” is self-contradictory. Minimal fixes (style only):
- Line 12: “the depth of the deleted subtree replaced by reference `c1`”
- Line 13: “the depth of the new subtree referenced by `c2`”

If “deleted” is required for both by domain intent, confirm with the domain owner. Otherwise, remove redundancy/contradiction for clarity.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#15-1-language-and-reading

---

- [ ] **11. Inline math formatting should use math notation**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/merkle-update.mdx?plain=1#L6

The range is written as code with ASCII operators: “`0 <= l < 3`”. The style recommends using KaTeX/LaTeX for inline math when it helps clarity. Minimal fix: “$0 \le l < 3$”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#144-magnitudes-and-math

---

- [ ] **12. Numeral required for technical quantity (“one tag byte”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/merkle-update.mdx?plain=1#L9

Technical quantities must use numerals. Minimal fix: change “one tag byte” to “1 tag byte”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#14-numbers-units-date-and-time

---

- [ ] **13. Numeral for zero in technical comparison**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/merkle-update.mdx?plain=1#L10

“if its level equals zero” should use a numeral for a technical value. Minimal fix: “equals 0”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#14.1-numerals-and-separators