### PR TITLE
[AI] fix: cells.mdx

### DIFF
--- a/tvm/serialization/cells.mdx
+++ b/tvm/serialization/cells.mdx
@@ -92,6 +92,7 @@ To build a cell, you use the `beginCell()` function. While the cell is open, you
 When you're done, you close the cell with the `endCell()` function.
 
 Not runnable
+
 ```typescript
 import { Address, beginCell } from "@ton/core";
 
@@ -105,6 +106,7 @@ const cell = beginCell()
 Each cell has a 1023-bit limit. If you exceed this, an error occurs:
 
 Not runnable
+
 ```typescript
 // This will fail due to overflow
 const cell = beginCell()
@@ -118,6 +120,7 @@ const cell = beginCell()
 To store more data, cells can reference up to 4 other cells. You can use the `storeRef()` function to create nested cells:
 
 Not runnable
+
 ```typescript
 const cell = beginCell()
   .storeUint(1, 256)
@@ -129,6 +132,7 @@ const cell = beginCell()
 You can store optional (nullable) values in cells by using the `storeMaybe*` helpers:
 
 Not runnable
+
 ```typescript
 const cell = beginCell()
   .storeMaybeInt(null, 64) // Optionally stores an int
@@ -144,6 +148,7 @@ To read data from a cell, you first convert it into a slice using the `beginPars
 Then, you can extract various data types with `load...()` functions. You read data in the same order it was stored.
 
 Not runnable
+
 ```typescript
 const slice = cell.beginParse();
 const uint = slice.loadUint(64);
@@ -154,6 +159,7 @@ const coins = slice.loadCoins();
 To load a referenced (nested) cell, use `loadRef()`:
 
 Not runnable
+
 ```typescript
 const slice = cell.beginParse();
 const uint1 = slice.loadUint(256);
@@ -166,6 +172,7 @@ const uint4 = innerSlice.loadUint(256);
 You can parse optional values using the corresponding `loadMaybe...()` functions. Returned values are nullable. Check for null before use.
 
 Not runnable
+
 ```typescript
 const slice = cell.beginParse();
 const maybeInt = slice.loadMaybeInt(64);


### PR DESCRIPTION
- [ ] **1. One-word generic title violates title rules**

`https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1#L2`

The frontmatter `title` is a single generic word ("Cells"). One-word generic titles MUST NOT be used except on top-level pages or proper names; nested pages should use a descriptive, sentence‑case title. Minimal fix: change to a descriptive title, for example `title: "TVM cells"` or `title: "Cells in TVM"`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-1-files-and-titles

---

- [ ] **2. Bullet list punctuation inconsistent (use no terminal punctuation for fragments)**

`https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1#L9-L10` and `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1#L37-L40`

Unordered list items that are fragments end with semicolons or a period. For fragment bullets, omit terminal punctuation consistently. Minimal fix: remove `;` and the final `.` from these bullets.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **3. Admonition uses unsupported component (`<Note>`)**

`https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1#L12-L14`

Callouts MUST use the `<Aside>` component with a supported `type`. Minimal fix: import Aside and replace with `<Aside type="note">Circular references are forbidden and cannot be created by means of TVM.</Aside>`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout

---

- [ ] **4. Words instead of numerals for technical quantities**

`https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1#L21-L118`

Technical quantities MUST use numerals. Instances of “four” should be `4`. Minimal fix: change “four” → `4` in “up to four cell references”, “supports four types”, and “reference up to four other cells”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#14-1-numerals-and-separators

---

- [ ] **5. Inconsistent formatting of the same number (1023 vs 1,023)**

`https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1#L7-L106` vs `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1#L32`

The same quantity appears as `1023` and `1,023`. Use a consistent format on the page. Since separators are only recommended for ≥ 10,000, prefer `1023` everywhere here. Minimal fix: change `1,023` → `1023`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#14-1-numerals-and-separators

---

- [ ] **6. Article error: “an byte” → “a byte”**

`https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1#L67`

Grammatical error reduces clarity. Minimal fix: “stored into an byte” → “stored into a byte”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **7. Full-sentence bolding in body text**

`https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1#L142`

Entire sentence is bolded, which is discouraged. Use normal text or structure instead. Minimal fix: remove bold: “You read data in the same order it was stored.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **8. Package names should use code font**

`https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1#L88`

Code identifiers/literals must use code formatting. Minimal fix: wrap link text in code font: [`@ton/core`](https://github.com/ton-core/ton) and [`@ton-community/assets-sdk`](https://github.com/ton-community/assets-sdk).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-3-code-styling

---

- [ ] **9. Ellipsis used in inline code identifier**

`https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1#L128`

Literal ellipses in code-like tokens can mislead readers and are disallowed in examples. Minimal fix: replace “`storeMaybe...()` helpers” with “the `storeMaybe*` helpers” or “the `storeMaybe`‑prefixed helpers”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-5-comments-and-omissions

---

- [ ] **10. Partial code snippets missing required “Not runnable” label**

`https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1#L96-L104; 108-116; 120-126; 130-137; 144-149; 153-160; 164-172`

These examples are partial excerpts and may not run standalone. Partial snippets MUST be labeled. Minimal fix: add a `Not runnable` line immediately above each affected code block.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **11. Link text should be more direct/descriptive**

`https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1#L45`

Link text SHOULD be descriptive. “see the section on hashes” is indirect. Minimal fix: change to “see [Hashes](/tvm/hashes) for details.” (use the page name as the link text).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text

---

- [ ] **12. Comma splice between independent clauses**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1#L45

The sentence joins two independent clauses with a comma: “A cell's level affects the number of higher hashes it has, see the section on hashes for details.” Minimal fix: split into two sentences: “A cell's level affects the number of higher hashes it has. See the section on hashes for details.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **13. Latinism “i.e.” in explanatory prose**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1#L68

Uses “i.e.” in “i.e. the number of cells …”. Prefer plain wording. Minimal fix: replace “i.e.” with “that is,”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **14. Hedging tone: “so‑called”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1#L59

The phrase “so‑called standard cell representation” adds hedging tone. Minimal fix: drop “so‑called” → “the standard cell representation”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **15. Shorthand “refs” instead of defined term**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1#L68

Uses “refs” as shorthand for “references.” Prefer full terms to avoid ambiguity. Minimal fix: change “depth of the refs” to “depth of the references”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **16. Marketing adjective in neutral technical context**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1#L88

“provide efficient cell handling” reads as marketing tone. Prefer neutral, factual wording. Minimal fix: “provide utilities for cell handling” or “provide cell handling APIs”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles-reader-first-answer-first

---

- [ ] **17. Wordy phrasing “Thus, we got …”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1#L75

Informal/wordy phrasing: “Thus, we got the serialization of `c`.” Minimal fix: “This yields the serialization of `c`.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **18. Internal links should be relative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1#L45

Internal links use absolute paths (`/tvm/hashes`, `/tvm/serialization/boc`, `/tvm/builders-and-slices`). Prefer relative, stable links. Minimal fix: change `/tvm/hashes` → `../hashes`, `/tvm/serialization/boc` → `./boc`, and `/tvm/builders-and-slices` → `../builders-and-slices`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format

---

- [ ] **19. Acronym not expanded on first mention (TL-B)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1#L22

The acronym "TL-B" appears without expansion. On first mention, spell out the term and follow with the acronym. Minimal fix: "… even though Type Language Binary (TL-B) schemes appear to suggest such an order." Optionally link to the overview page.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **20. Comma splice; split into two sentences**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1#L77

“However, the serialization of trees … is arranged differently, see [bag of cells] …” is a comma splice. End the sentence before “see …”.
Minimal fix: “However, the serialization of trees formed by cells is arranged differently. See [bag of cells] …”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.1-commas-colons-semicolons

---

- [ ] **21. Present tense for general behavior (“will fail” → “fails”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1#L109

In the comment, use present tense: “This fails due to overflow,” not “This will fail …”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.1-goals-and-principles-reader-first-answer-first

---

- [ ] **22. Imperative, direct instruction (“do not forget to” → “Check …”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1#L162

Use direct imperative wording instead of “do not forget to …”. Minimal fix: “Returned values are nullable. Check for null before use.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.1-goals-and-principles-reader-first-answer-first

---

- [ ] **23. Single-item list ends with period; omit for fragment**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1#L177

In “References,” the single bullet is a fragment and ends with a period. Remove the trailing period.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.4-lists

---

- [ ] **24. List punctuation: remove periods in “Cell manipulation” list**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1#L83

These bullets are not full sentences but end with periods. Remove terminal periods (or convert items to full sentences). Minimal fix: drop the periods.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **25. Use a standard range notation (ellipsis) instead of spaced dots**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1#L66

“0 . . . 255” uses spaced dots. Use a proper ellipsis for ranges to match the notation style used elsewhere on this page: “0…255”. (General typography and internal consistency.)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17-4-proofread

---

- [ ] **26. Use lowercase “blockchain” in “TON blockchain”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1#L29

The phrase “TON Blockchain” capitalizes “Blockchain,” but the term should be a common noun (“TON blockchain”). Minimal fix: change “TON Blockchain” → “TON blockchain”. Supporting usage: `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#L438` uses “TON blockchain”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-1-term-bank-canonical-source

---

- [ ] **27. Remove hedge “essentially” (clarity and tone)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1#L20

“a cell essentially is a couple…” uses the hedge “essentially.” Remove the hedge for direct, precise tone. Minimal fix: “a cell is a …”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **28. Replace filler “Note that …” with direct statement**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/cells.mdx?plain=1#L72

“Note that cyclic cell references are not allowed…” is filler. Use a direct statement. Minimal fix: “Cyclic cell references are not allowed, so this algorithm always terminates.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.7-avoid-tautology-pleonasm-throat-clearing-and-circular-references