### PR TITLE
[AI] fix: pruned.mdx

### DIFF
--- a/tvm/serialization/pruned.mdx
+++ b/tvm/serialization/pruned.mdx
@@ -6,6 +6,7 @@ Pruned branch cells represent deleted subtrees of a tree of cells. See [Pruned b
 
 A pruned branch cell may have any level between 1 and 3, which equals the level of the root of the pruned subtree plus one.
 Each pruned branch cell is serialized as follows:
+
 - A 1-byte tag that always equals `1` is stored.
 - A byte contains the pruned branch level mask (`1 <= mask <= 7`). The number of hashes stored equals the number of 1 bits in the mask.
 - Next, `h * 32` bytes store [representation hashes](tvm/serialization/cells#standard-cell-representation-and-its-hash) of the roots of the pruned subtrees, starting from the last one (where `h` is the number of 1 bits in the mask). For example, if the mask equals `3` (binary `011`), then the pruned branch cell contains representation hashes of the second and the first pruned subtrees in that order, but not the third one.


### PR DESCRIPTION
- [ ] **1. Intro sentence: grammar, comma splice, and non-descriptive link text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/pruned.mdx?plain=1#L5

The sentence is ungrammatical ("Pruned branches cells" and missing article), uses a comma splice, and the link text is non-descriptive. Minimal fix: "Pruned branch cells represent deleted subtrees of a tree of cells. See [Pruned branch cells](ton/cells/prunned-branch-cells)." Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons; Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text; Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording.

---

- [ ] **2. Page title terminology consistency**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/pruned.mdx?plain=1#L2

The frontmatter title "Pruned branches" conflicts with the canonical term used elsewhere ("pruned branch cell"), e.g., https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/tvm.mdx?plain=1 and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/prunned-branch-cells.mdx?plain=1. Minimal fix: change the title to "Pruned branch cells" to align terminology. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms.

---

- [ ] **3. Sentence fragment: missing subject and article**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/pruned.mdx?plain=1#L7

Begins with "May have" and lacks a subject; also missing "the" before "root". Minimal fix: "A pruned branch cell may have any level between `1` and `3`, which equals the level of the root of the pruned subtree plus one." Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording.

---

- [ ] **4. List introduction needs a complete clause and colon**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/pruned.mdx?plain=1#L8

"Each of a pruned branch cell serialized as follows." is ungrammatical and lacks a colon before a list. Minimal fix: "Each pruned branch cell is serialized as follows:" Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons; Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording.

---

- [ ] **5. List item fragments; make items full sentences or drop periods**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/pruned.mdx?plain=1#L9-L15

List items are sentence fragments but end with periods, violating list rules. Either make each a full sentence or remove terminal periods consistently. Minimal fix (full sentences):
- "A 1-byte tag that always equals `1` is stored."
- "A byte contains the pruned branch level mask (`1 <= mask <= 7`). The number of hashes stored equals the number of `1` bits in the mask."
- "Next, `h * 32` bytes store representation hashes of the roots of the pruned subtrees, starting from the last one."
- "Finally, `h * 2` bytes store the depths of the pruned subtrees, starting from the last one."
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists; Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording.

---

- [ ] **6. Pluralization and precise deep link**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/pruned.mdx?plain=1#L12

"representations hashes" should be "representation hashes"; also link to the exact anchor for the hash definition and use a relative path. Minimal fix: change to "[representation hashes](tvm/serialization/cells#standard-cell-representation-and-its-hash)". Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format; Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording.

---

- [ ] **7. Terminology consistency: "pruned tree cell" → "pruned branch cell"**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/pruned.mdx?plain=1#L13

Use consistent terminology across the docs ("pruned branch cell" is used elsewhere). Minimal fix: replace "pruned tree cell" with "pruned branch cell". Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms.

---

- [ ] **8. Define variable `h` on first use**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/pruned.mdx?plain=1#L12-L15

`h` is used without definition. Minimal fix: add a parenthetical at first mention: "(where `h` is the number of `1` bits in the mask)". Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording.

---

- [ ] **9. Remove pleonasm: "sequential order"**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/pruned.mdx?plain=1#L13-L14

"in sequential order" is redundant; "in order" or "in that order" is sufficient. Minimal fix: change to "in that order". Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references.

---

- [ ] **10. Link slug spelling “prunned” (typo) vs American English**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/pruned.mdx?plain=1#L5

The link target slug uses “prunned-branch-cells”, which doesn’t follow American English spelling (“pruned”). This is user-facing in the URL. Minimal local change is to keep the link working but note that the canonical slug should be corrected and redirected site-wide to avoid broken links. Domain decision required: confirm the canonical slug and add a redirect before changing this page’s href. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-6-spelling-and-contractions.

---

- [ ] **11. Minor grammar: missing article and “the”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/pruned.mdx?plain=1#L5-L11

Add “a” in “subtrees of a tree of cells” (line 5) and “the” in “in the mask” (line 11) for correctness. Minimal fixes: “subtrees of a tree of cells”; “in the mask”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording.

---

- [ ] **12. Sentence fragment and unnecessary code font for numerals**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/pruned.mdx?plain=1#L7

The sentence starts with "May have" (missing subject) and wraps plain numerals in code font. Rules: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-1-procedural-voice-and-tense and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-3-code-styling. Minimal fix: "A pruned branch cell may have any level between 1 and 3; it equals the level of the root of the pruned subtree plus one." (Remove backticks from numerals; add subject.)

---

- [ ] **13. Unnecessary code formatting for non‑code term**

`https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/pruned.mdx?plain=1#L11`

Backticks around “`1-bits`” imply code, but this is plain English. Remove backticks: “the number of 1‑bits in the mask.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **14. Prefer relative internal link (SHOULD)**

`https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/serialization/pruned.mdx?plain=1#L5`

Internal links should be relative. Consider changing “`/ton/cells/prunned-branch-cells`” to a relative path like “`../../ton/cells/prunned-branch-cells`”. This is optional but improves portability. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format

---

- [ ] **15. Link slug contains a spelling error ("prunned")**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860//ton/cells/prunned-branch-cells.mdx?plain=1

The URL path uses "prunned" (double "n"), which is a misspelling and conflicts with American English spelling required by the guide and with usage on this page ("pruned"). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-6-spelling-and-contractions. Minimal fix (requires a domain decision): rename the slug to `/ton/cells/pruned-branch-cells` and add redirects; in this page, update the link target accordingly. If renaming is out of scope here, acknowledge the inconsistency and plan a follow-up.