### PR TITLE
[AI] fix: tonviewer.mdx

### DIFF
--- a/ecosystem/explorers/tonviewer.mdx
+++ b/ecosystem/explorers/tonviewer.mdx
@@ -68,6 +68,7 @@ Analyze a [jetton transfer](https://tonviewer.com/transaction/d5d50c3e5bde493ddc
 At point **A** (mintmachine.ton), an `external-in` message initiates the operation, instructing a jetton transfer.
 
 1. Identify accounts
+
 - A — sender's wallet contract (mintmachine.ton)
 - B — jetton wallet contract governed by the jetton master
 
@@ -124,6 +125,7 @@ Analyze a [token swap](https://tonviewer.com/transaction/fa8e119f8911d20bb078b9b
 The trace begins at point **A** (the user’s `mintmachine.ton` contract). An `external-in` message initiates the swap attempt.
 
 1. Identify accounts
+
 - A — user's mintmachine.ton account, sending the initial funds
 - B — user's jetton wallet
 - C — DEX jetton wallet


### PR DESCRIPTION
- [ ] **1. Task heading should be imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/wallet.mdx?plain=1#L38

The H2 heading uses a noun phrase ("Integration"). For task/procedure sections, use an imperative verb. Minimal fix: change "## Integration" to "## Integrate".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form

---

- [ ] **2. Throat-clearing opener; start with the action**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/wallet.mdx?plain=1#L8

The page opens with “This guide helps you…”, which is meta and delays the task. Minimal fix: start with the action, e.g., “Integrate a custodial or non-custodial wallet with The Open Network (TON) using TON Connect and WalletKit…”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **3. Pleonasm in opener ("basic fresh … from scratch")**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/wallet.mdx?plain=1#L8

“partially build a basic fresh one from scratch” is redundant. Minimal fix: “build a basic wallet from scratch”. Also simplify “with the help of” → “using”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **4. Expand TON on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/wallet.mdx?plain=1#L8

On first mention on the page, spell out the term and follow with the acronym. Minimal fix: “with The Open Network (TON)”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **5. Expand SDK on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/wallet.mdx?plain=1#L10

Define the acronym on first mention. Minimal fix: “It consists of many supplementary software development kits (SDKs)…”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **6. Expand dApp on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/wallet.mdx?plain=1#L10

Define the acronym on first mention. Minimal fix: “integrations of decentralized applications (dApps) with TON…”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **7. Hyphenation: use “use cases” (not “use-cases”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/wallet.mdx?plain=1#L10

Use the prevailing form in this documentation (“use cases”) for consistency; the style guide delegates this to the term bank. Minimal fix: “two major use cases”. For consistency evidence, see https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/wallets/comparison.mdx?plain=1#L5/explorers/tonviewer.mdx:58.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-1-term-bank-canonical-source

---

- [ ] **8. Prefer plain wording: “supervises” → “covers”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/wallet.mdx?plain=1#L10

Prefer common, direct verbs. Minimal fix: “It … covers two major use cases…”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **9. Articles before proper names: remove unnecessary “the”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/wallet.mdx?plain=1#L10-L59

Avoid unnecessary articles before product names. Minimal fixes:
- “The latter are done via the WalletKit.” → “The latter use WalletKit.”
- “Read more about the TON Connect and WalletKit themselves:” → “Read more about TON Connect and WalletKit:”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **10. Inconsistent casing in link label**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/wallet.mdx?plain=1#L101-L102

“CEX: Centralized EXchange” uses mid-word caps. Use sentence case for generic terms. Minimal fix: “CEX: centralized exchange”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules

---

- [ ] **11. Sidebar title should preserve task meaning**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/wallet.mdx?plain=1#L2-L3

For how-to pages, `sidebarTitle` should be the task (X) from the title and preserve its meaning. Current `sidebarTitle: "Integrate a wallet"` drops “with TON,” reducing clarity in navigation. Minimal fix: set `sidebarTitle: "Integrate a wallet with TON"` (≤ 30 chars per rule).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-2-navigation-labels

---

- [ ] **12. Define acronym “QA” in link text or avoid it**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/wallet.mdx?plain=1#L80-L81

First in-page occurrence of “QA” appears in a Card title. Define on first mention to aid newcomers. Minimal fix: “WalletKit integration quality assurance (QA) guide”. If too long, consider “Integration testing guide” for clarity; confirm with domain owner if renaming is acceptable.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **13. Link core term to Glossary on first useful mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/wallet.mdx?plain=1#L8-L10

On first useful mention of a core TON term, link to the Glossary unless defined on the page. Minimal fix: link “The Open Network (TON)” or “TON” to `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not

---

- [ ] **14. Visible “Stub” placeholders should use a status callout**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/wallet.mdx?plain=1#L16-L40

User‑visible “(Stub)” and “Stub.” degrade clarity and navigation. Minimal fix: replace these with a single status callout at the top using `<Aside>` (e.g., `type="note"` with a clear title like “Work in progress”) and remove inline “Stub” labels.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-4-status-labels
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-safety-and-callouts-implementation

---

- [ ] **15. Heading should be imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/wallet.mdx?plain=1#L42

Heading “Usage” is a noun; task/procedure headings must start with an imperative verb. Minimal fix: “Use WalletKit”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#headings-and-titles

---

- [ ] **16. Throat‑clearing and intensifier: “Additionally, … complete demo wallets”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/wallet.mdx?plain=1#L21

“Additionally,” is throat‑clearing, and “complete” adds no information. Minimal fix: “Explore demo wallets:”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **17. Acronym handling and casing: “CEX: Centralized EXchange”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/wallet.mdx?plain=1#L101

The casing “EXchange” is incorrect, and the acronym is not introduced per first‑mention rules. Minimal fix: change card `title` to “Centralized exchange (CEX)”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#acronyms-and-terms