### PR TITLE
[AI] fix: instructions.mdx

### DIFF
--- a/tvm/instructions.mdx
+++ b/tvm/instructions.mdx
@@ -1,6 +1,5 @@
----
-title: "Instructions"
-description: "Interactive reference for TVM instructions"
+title: "TVM instructions"
+description: "Interactive reference for TON Virtual Machine (TVM) instructions."
 mode: "wide"
 ---
 import { TvmInstructionTable } from "/snippets/tvm-instruction-table.jsx"
@@ -18,7 +17,7 @@ Category: stack_basic Stack Basic
 Fift: s[i] XCHG0
 Description: Interchanges `s0` with `s[i]`, `1 <= i <= 15`.
 Category: stack_basic Stack Basic
-Alias: SWAP Same as `s1 XCHG0`.
+Alias: `SWAP` Same as `s1 XCHG0`.
 
 #### `1` XCHG_1I
 Fift: s1 s[i] XCHG
@@ -29,15 +28,15 @@ Category: stack_basic Stack Basic
 Fift: s[i] PUSH
 Description: Pushes a copy of the old `s[i]` into the stack.
 Category: stack_basic Stack Basic
-Alias: DUP Same as `s0 PUSH`.
-Alias: OVER Same as `s1 PUSH`.
+Alias: `DUP` Same as `s0 PUSH`.
+Alias: `OVER` Same as `s1 PUSH`.
 
 #### `3` POP
 Fift: s[i] POP
 Description: Pops the old `s0` value into the old `s[i]`.
 Category: stack_basic Stack Basic
-Alias: DROP Same as `s0 POP`, discards the top-of-stack value.
-Alias: NIP Same as `s1 POP`.
+Alias: `DROP` Same as `s0 POP`, discards the top-of-stack value.
+Alias: `NIP` Same as `s1 POP`.
 
 #### `4` XCHG3
 Fift: s[i] s[j] s[k] XCHG3
@@ -99,10 +98,10 @@ Description: Permutes two blocks `s[j+i+1] ... s[j+1]` and `s[j] ... s0`.
 `0 <= i,j <= 15`
 Equivalent to `[i+1] [j+1] REVERSE` `[j+1] 0 REVERSE` `[i+j+2] 0 REVERSE`.
 Category: stack_complex Stack Complex
-Alias: ROT2 Rotates the three topmost pairs of stack entries.
-Alias: ROLL Rotates the top `i+1` stack entries.
+Alias: `ROT2` Rotates the three topmost pairs of stack entries.
+Alias: `ROLL` Rotates the top `i+1` stack entries.
 Equivalent to `1 [i+1] BLKSWAP`.
-Alias: ROLLREV Rotates the top `i+1` stack entries in the other direction.
+Alias: `ROLLREV` Rotates the top `i+1` stack entries in the other direction.
 Equivalent to `[i+1] 1 BLKSWAP`.
 
 #### `56` PUSH_LONG
@@ -123,32 +122,27 @@ Description: Equivalent to `1 2 BLKSWAP` or to `s2 s1 XCHG2`.
 Category: stack_complex Stack Complex
 
 #### `59` ROTREV
-Fift: ROTREV
--ROT
+Fift: ROTREV, `-ROT`
 Description: Equivalent to `2 1 BLKSWAP` or to `s2 s2 XCHG2`.
 Category: stack_complex Stack Complex
 
 #### `5A` SWAP2
-Fift: SWAP2
-2SWAP
+Fift: SWAP2, `2SWAP`
 Description: Equivalent to `2 2 BLKSWAP` or to `s3 s2 XCHG2`.
 Category: stack_complex Stack Complex
 
 #### `5B` DROP2
-Fift: DROP2
-2DROP
+Fift: DROP2, `2DROP`
 Description: Equivalent to `DROP` `DROP`.
 Category: stack_complex Stack Complex
 
 #### `5C` DUP2
-Fift: DUP2
-2DUP
+Fift: DUP2, `2DUP`
 Description: Equivalent to `s1 s0 PUSH2`.
 Category: stack_complex Stack Complex
 
 #### `5D` OVER2
-Fift: OVER2
-2OVER
+Fift: OVER2, `2OVER`
 Description: Equivalent to `s3 s2 PUSH2`.
 Category: stack_complex Stack Complex
 
@@ -164,8 +158,7 @@ Description: Equivalent to `PUSH s(j)` performed `i` times.
 Category: stack_complex Stack Complex
 
 #### `60` PICK
-Fift: PICK
-PUSHX
+Fift: PICK, `PUSHX`
 Description: Pops integer `i` from the stack, then performs `s[i] PUSH`.
 Category: stack_complex Stack Complex
 
@@ -175,19 +168,18 @@ Description: Pops integer `i` from the stack, then performs `1 [i] BLKSWAP`.
 Category: stack_complex Stack Complex
 
 #### `62` -ROLLX
-Fift: -ROLLX
-ROLLREVX
+Fift: -ROLLX, `ROLLREVX`
 Description: Pops integer `i` from the stack, then performs `[i] 1 BLKSWAP`.
 Category: stack_complex Stack Complex
 
 #### `63` BLKSWX
 Fift: BLKSWX
-Description: Pops integers `i`,`j` from the stack, then performs `[i] [j] BLKSWAP`.
+Description: Pops integers `i`, `j` from the stack, then performs `[i] [j] BLKSWAP`.
 Category: stack_complex Stack Complex
 
 #### `64` REVX
 Fift: REVX
-Description: Pops integers `i`,`j` from the stack, then performs `[i] [j] REVERSE`.
+Description: Pops integers `i`, `j` from the stack, then performs `[i] [j] REVERSE`.
 Category: stack_complex Stack Complex
 
 #### `65` DROPX
@@ -237,14 +229,14 @@ Fift: NULL
 PUSHNULL
 Description: Pushes the only value of type _Null_.
 Category: tuple Tuple
-Alias: NEWDICT Returns a new empty dictionary.
-It is an alternative mnemonics for `PUSHNULL`.
+Alias: `NEWDICT` Returns a new empty dictionary.
+It is an alternative mnemonic for `PUSHNULL`.
 
 #### `6E` ISNULL
 Fift: ISNULL
 Description: Checks whether `x` is a _Null_, and returns `-1` or `0` accordingly.
 Category: tuple Tuple
-Alias: DICTEMPTY Checks whether dictionary `D` is empty, and returns `-1` or `0` accordingly.
+Alias: `DICTEMPTY` Checks whether dictionary `D` is empty, and returns `-1` or `0` accordingly.
 It is an alternative mnemonics for `ISNULL`.
 
 #### `80` PUSHINT_8
@@ -256,7 +248,7 @@ Category: const_int Const Int
 #### `81` PUSHINT_16
 Fift: [xxxx] PUSHINT
 [xxxx] INT
-Description: Pushes integer `xxxx`. `-2^15 <= xx < 2^15`.
+Description: Pushes integer `xxxx`. `-2^15 <= xxxx < 2^15`.
 Category: const_int Const Int
 
 #### `82` PUSHINT_LONG
@@ -296,7 +288,7 @@ Category: const_data Const Data
 
 #### `8A` PUSHREFCONT
 Fift: [ref] PUSHREFCONT
-Description: Similar to `PUSHREFSLICE`, but makes a simple ordinary _Continuation_ out of the cell.
+Description: Similar to `PUSHREFSLICE`, but makes an ordinary _Continuation_ out of the cell.
 Category: const_data Const Data
 
 #### `8B` PUSHSLICE
@@ -342,7 +334,7 @@ Category: arithm_basic Arithm Basic
 #### `A3` NEGATE
 Fift: NEGATE
 Description: Equivalent to `-1 MULCONST` or to `ZERO SUBR`.
-Notice that it triggers an integer overflow exception if `x=-2^256`.
+Triggers an integer overflow exception if `x = -2^256`.
 Category: arithm_basic Arithm Basic
 
 #### `A4` INC
@@ -425,7 +417,7 @@ Fift: [cc+1] FITS
 Description: Checks whether `x` is a `cc+1`-bit signed integer for `0 <= cc <= 255` (i.e., whether `-2^cc <= x < 2^cc`).
 If not, either triggers an integer overflow exception, or replaces `x` with a `NaN` (quiet version).
 Category: arithm_logical Arithm Logical
-Alias: CHKBOOL Checks whether `x` is a ''boolean value'' (i.e., either 0 or -1).
+Alias: CHKBOOL Checks whether `x` is a boolean value (i.e., either 0 or -1).
 
 #### `B5` UFITS
 Fift: [cc+1] UFITS
@@ -670,7 +662,7 @@ Category: cont_loops Cont Loops
 
 #### `E8` WHILE
 Fift: WHILE
-Description: Executes `c'` and pops an integer `x` from the resulting stack. If `x` is zero, exists the loop and transfers control to the original `cc`. If `x` is non-zero, executes `c`, and then begins a new iteration.
+Description: Executes `c'` and pops an integer `x` from the resulting stack. If `x` is zero, exits the loop and transfers control to the original `cc`. If `x` is non-zero, executes `c`, and then begins a new iteration.
 Category: cont_loops Cont Loops
 
 #### `E9` WHILEEND


### PR DESCRIPTION
- [ ] **1. Generic page title is not context‑free**

`https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/instructions.mdx?plain=1#L2`

The frontmatter `title` is a one‑word generic “Instructions,” which violates the rule that titles must be context‑free and not generic one‑word labels except on top‑level pages. This page is under `tvm/`, so the title should explicitly name the subject. Minimal fix: change `title: "Instructions"` to `title: "TVM instructions"`. Optionally set `sidebarTitle: "Instructions"` if a shorter nav label is desired. This also aligns with existing cross‑refs that refer to this page as “TVM instructions” (e.g., https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/functions.mdx?plain=1#L418/fift/whitepaper.mdx:1635).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#title-vs-sidebar-semantics

---

- [ ] **2. Code identifiers in Alias lines not in code font**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/instructions.mdx?plain=1#L21

In multiple "Alias:" lines, identifiers such as SWAP, DUP, OVER, DROP, NIP, ROT2, ROLL, ROLLREV, NEWDICT, and DICTEMPTY are plain text. Code identifiers must use code font. Minimal fix: wrap the identifier immediately following "Alias:" in backticks, for example: `Alias: `SWAP` Same as ...` and `Alias: `NEWDICT` Returns a new empty dictionary.` Apply consistently across the page.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules

---

- [ ] **3. Unformatted alternate mnemonics on standalone lines**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/instructions.mdx?plain=1#L127

Several alternative mnemonics appear as standalone plain-text lines (e.g., `-ROT`, `2SWAP`, `2DROP`, `2DUP`, `2OVER`, `PUSHX`, `ROLLREVX`). These should be marked as code identifiers and associated with the Fift mnemonic label for clarity. Minimal fix: either (a) append these to the preceding `Fift:` line separated by commas, e.g., `Fift: ROTREV, -ROT`, or (b) prefix each with `Fift:` and wrap in backticks: `Fift: `2SWAP``. Ensure they are rendered in code font.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules

---

- [ ] **4. Misused quotation marks for emphasis**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/instructions.mdx?plain=1#L428

Text uses doubled single quotes to emphasize “boolean value”: `''boolean value''`. Quotation marks must be used only for exact UI/log strings, not for emphasis. Minimal fix: remove the quotes: “Checks whether `x` is a boolean value (i.e., either 0 or -1).”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **5. Grammar: “mnemonics” → “mnemonic” in alias explanation**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/instructions.mdx?plain=1#L241

The sentence reads “It is an alternative mnemonics for `PUSHNULL`.” The correct singular form is “mnemonic.” Minimal fix: change to “It is an alternative mnemonic for `PUSHNULL`.” This is an obvious grammar correction per general English usage.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **6. Filler/throat-clearing phrase “Notice that”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/instructions.mdx?plain=1#L345

The sentence begins with “Notice that it triggers an integer overflow exception…”. Avoid throat‑clearing; be direct. Minimal fix: “Triggers an integer overflow exception if `x = -2^256`.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **7. Code variable not formatted as code**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/instructions.mdx?plain=1#L247

The phrase “dictionary D” uses `D` as a variable but it’s not in code font. Code identifiers must be rendered in code font. Minimal fix: “dictionary `D`”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules

---

- [ ] **8. Typo: “exists the loop” → “exits the loop”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/instructions.mdx?plain=1#L673

The text says “If `x` is zero, exists the loop…”, which is a typo. Minimal fix: “If `x` is zero, exits the loop and transfers control …”. This is an obvious grammar correction based on general English usage.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **9. Missing space after comma in inline code list**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/instructions.mdx?plain=1#L185

Phrases like “Pops integers `i`,`j` from the stack” omit a space after the comma. Minimal fix: add a space: “`i`, `j`”. Apply wherever this pattern appears.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **10. Inconsistent variable placeholder in inequality**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/instructions.mdx?plain=1#L259

For `PUSHINT_16`, the description uses `xxxx` elsewhere but the inequality shows `-2^15 <= xx < 2^15`. Minimal fix: change `xx` to `xxxx` to match the placeholder used in this entry.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **11. Redundant doublet “simple ordinary”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/instructions.mdx?plain=1#L299

The phrase “makes a simple ordinary _Continuation_” contains a redundant doublet. Minimal fix: “makes an ordinary _Continuation_ …”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **12. Acronym not defined on first use in description**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/instructions.mdx?plain=1#L3

The description uses the acronym "TVM" without expansion on first mention. Minimal fix: "Interactive reference for TON Virtual Machine (TVM) instructions." Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms