### PR TITLE
[AI] fix: index.mdx

### DIFF
--- a/language/fift/index.mdx
+++ b/language/fift/index.mdx
@@ -8,13 +8,13 @@ import { Aside } from '/snippets/aside.jsx';
 
 <Aside>
 
-  The official language of TON Blockchain is [Tolk](/language/tolk), and all other languages are deemed legacy. That said, you can still use them and contribute to the surrounding tooling or documentation.
+  The official language of [The Open Network (TON) Blockchain](/ton/glossary) is [Tolk](/language/tolk), and all other languages are deemed legacy. However, you can still use them and contribute to the surrounding tooling or documentation.
 
 </Aside>
 
 Fift is a [stack-based](https://en.wikipedia.org/wiki/Stack-oriented_programming) general-purpose [tacit](https://en.wikipedia.org/wiki/Tacit_programming) programming language optimized for creating, debugging, and managing smart contracts on TON Blockchain.
 
-It has been specifically designed to interact with TON Virtual Machine (TVM) and TON Blockchain. In particular, it offers native support for 257-bit integer arithmetic and cell manipulation, as well as an interface to the Ed25519-based cryptography employed by TON.
+It was designed to interact with [TON Virtual Machine (TVM)](/ton/glossary#ton-virtual-machine-tvm) and TON Blockchain. In particular, it offers native support for 257-bit integer arithmetic and cell manipulation, as well as an interface to the Ed25519-based cryptography employed by TON.
 
 Fift also includes a macro assembler for TVM code, which is a common intermediate target of higher-level languages such as [Tolk](/language/tolk), [FunC](/language/func), and [Tact](/language/tact), as well as a common textual bitcode representation of smart contracts. For more examples of the latter, see [various blockchain explorers](/ecosystem/explorers/overview) and disassembled smart contracts.
 
@@ -26,18 +26,18 @@ Fift interpreter binaries for Windows, macOS (Intel or Arm64), and Ubuntu can be
 
 Make sure to also download the necessary libraries — download and unpack the `smartcont_lib.zip`. The `lib/` folder inside contains standard libraries of Fift, which must be exposed to it when running the interpreter.
 
-Consider the following example installation steps:
+Install Fift:
 
 <Steps>
   <Step title="Download the latest Fift binary">
     <Tabs>
       <Tab title="Windows">
-        Go to the [latest GitHub release](https://github.com/ton-blockchain/ton/releases/latest), download `fift.exe` and place it somewhere on your `PATH`. To see the current state of the `PATH` variable, run `echo $env:PATH` in the PowerShell.
+        Go to the [latest GitHub release](https://github.com/ton-blockchain/ton/releases/latest), download `fift.exe` and place it somewhere on your `PATH`. To see the current state of the `PATH` variable, run `echo $env:PATH` in PowerShell.
       </Tab>
       <Tab title="Linux">
         Go to the [latest GitHub release](https://github.com/ton-blockchain/ton/releases/latest), download `fift-linux-x86_64` (64-bit, x86 arch) or `fift-linux-arm64` (64-bit, Arm arch), and place it somewhere on your `$PATH` as `fift`. To see the current state of the `$PATH` variable, run `echo $PATH | tr ':' '\n'` in the terminal.
       </Tab>
-      <Tab title="MacOS">
+      <Tab title="macOS">
         Go to the [latest GitHub release](https://github.com/ton-blockchain/ton/releases/latest), download `fift-mac-x86-64` (64-bit, Intel) or `fift-mac-arm64` (64-bit, Apple Silicon), and place it somewhere on your `$PATH` as `fift`. To see the current state of the `$PATH` variable, run `echo $PATH | tr ':' '\n'` in the terminal.
       </Tab>
     </Tabs>
@@ -47,14 +47,17 @@ Consider the following example installation steps:
     - Unzip it and extract the contents.
     - Move the extracted `lib/` folder somewhere convenient. You can also place it under a different name.
       - For example, for Linux and macOS it can be moved to `~/.local/lib/fiftlib`
-      - For Windows, to `~/.fiftlib`
+      - For Windows, to `<USERPROFILE>\\.fiftlib`
+        - `<USERPROFILE>` — user's home directory path on Windows.
   </Step>
   <Step title="Run Fift">
-    To invoke Fift binary you'll need to pass it the standard libraries as such:
+    To run the Fift binary, pass the standard library path:
 
-    ```shell
+    ```bash
     fift -I /path/to/extracted/lib -i Asm.fif
     ```
+    
+    <FIFT_LIB_DIR> — path to the extracted Fift standard libraries directory.
 
     If you see errors or red-colored output lines, double-check the placement of the Fift binary and related libraries from previous steps.
 
@@ -72,12 +75,14 @@ Consider the following example installation steps:
 
 <Aside type="tip">
 
-  For Linux and macOS, it might be convenient to make an alias as such:
+  For Linux and macOS, define an alias:
 
-  ```shell
+  ```bash
   # Within .bash_aliases or .zsh_aliases
   alias fift="/path/to/fift -I /path/to/extracted/lib -i Asm.fif"
   ```
+  
+  <FIFT_LIB_DIR> — path to the extracted Fift standard libraries directory.
 
 </Aside>
 
@@ -85,12 +90,12 @@ Consider the following example installation steps:
 
 #### Extensions and plugins
 
-- [VS Code extension](https://marketplace.visualstudio.com/items?itemName=ton-core.vscode-ton) - powerful and feature-rich extension for Visual Studio Code (VSCode) and VSCode-based editors like VSCodium, Cursor, Windsurf, and others.
+- [VS Code extension](https://marketplace.visualstudio.com/items?itemName=ton-core.vscode-ton) - powerful and feature-rich extension for Visual Studio Code (VSCode) and VSCode-based editors such as VSCodium, Cursor, and Windsurf.
   - Get it on the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=ton-core.vscode-ton).
   - Get it on the [Open VSX Registry](https://open-vsx.org/extension/ton-core/vscode-ton).
   - Or install from the [`.vsix` files in nightly releases](https://github.com/ton-blockchain/ton-language-server/releases).
 - [JetBrains IDEs plugin](https://plugins.jetbrains.com/plugin/23382-ton) - provides syntax highlighting, code navigation, and more.
-- [Language Server (LSP Server)](https://github.com/ton-blockchain/ton-language-server) - supports Sublime Text, (Neo)Vim, Helix, and other editors with LSP support.
+- [Language Server (LSP)](https://github.com/ton-blockchain/ton-language-server) - supports Sublime Text, (Neo)Vim, Helix, and other editors with LSP support.
 
 #### Online utilities
 
@@ -116,11 +121,11 @@ There, `ok` means successful end of execution of the given code snippet.
 
 <Aside type="caution">
 
-  When things go awry, there may still be an `ok` by the end, albeit prefixed with several red lines of cryptic-looking stack traces. Those are how Fift reports errors and this is one of the major reasons why Fift is considered a legacy language.
+  When errors occur, there may still be an `ok` by the end, albeit prefixed with several red lines of cryptic-looking stack traces. That is how Fift reports errors, and this is one of the major reasons why Fift is considered a legacy language.
 
-  **Any errors encountered during execution clear the stack!**
+  Errors clear the stack!
 
-  Hence, to actually know what happened, one needs to preemptively check stack contents. For that, use the ["printf debugging"](https://en.wikipedia.org/wiki/Debugging#printf_debugging) approach with the `.s` word — it dumps current stack contents to the console without modifying the stack.
+  Hence, to know what happened, one needs to preemptively check stack contents. For that, use the [printf debugging](https://en.wikipedia.org/wiki/Debugging#printf_debugging) approach with the `.s` word — it dumps current stack contents to the console without modifying the stack.
 
   ```fift
   "Hello, " .s
@@ -155,7 +160,7 @@ To continue learning Fift, see the [educational materials](#educational-material
     href="/language/fift/multisig"
   />
   <Card
-    title="Whitepapers (see below)"
+    title="Whitepapers"
     href="#whitepapers"
   />
 </Columns>
@@ -166,9 +171,9 @@ To continue learning Fift, see the [educational materials](#educational-material
 
 <Aside>
 
-  While most of the information described there holds some truth, the `fiftbase.pdf` whitepaper is still considered legacy due to lack of updates and gradual integration of their contents into actual documentation pages.
+  While most of the information described there holds some truth, the `fiftbase.pdf` whitepaper is still considered legacy due to lack of updates and gradual integration of its contents into actual documentation pages.
 
-  However, it is the most exhaustive reference manual on Fift to this date, so you can still use it to learn a lot about Fift.
+  However, it is an exhaustive reference manual on Fift to date, so you can still use it to learn a lot about Fift.
 
 </Aside>
 
@@ -222,7 +227,7 @@ To continue learning Fift, see the [educational materials](#educational-material
 
 ## See also
 
-- [Multisignature wallet v2](https://github.com/ton-blockchain/multisig-contract-v2)
+- [Multi-signature wallet v2](https://github.com/ton-blockchain/multisig-contract-v2)
 - [Forth language](https://en.wikipedia.org/wiki/Forth_(programming_language))
 - [Factor language](https://en.wikipedia.org/wiki/Factor_(programming_language))
 - [Uiua language](https://www.uiua.org/)


### PR DESCRIPTION
- [ ] **1. Frontmatter `noindex` must be boolean, not string**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/deep-dive.mdx?plain=1#L2

`noindex: "true"` uses a quoted string. Use a boolean per the guide’s frontmatter rules. Minimal fix: `noindex: true` (unquoted).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-2-navigation-labels

---

- [ ] **2. Acronym “TVM” not expanded on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/deep-dive.mdx?plain=1#L7

Spell out the term on first use, then use the acronym. Minimal fix: “...cells and other TON Virtual Machine (TVM) primitives.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **3. Aside label should use `title` instead of bold text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/deep-dive.mdx?plain=1#L9

The Aside body begins with a bolded label (“**Advanced topic notice** ...”). Use the Aside’s `title` attribute for labels and remove inline bold. Minimal fix: `<Aside type="caution" title="Advanced topic notice">` and drop the bold text inside.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout

---

- [ ] **4. Consider importing `<Aside>` for consistency with MDX usage**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/deep-dive.mdx?plain=1#L6

This page uses `<Aside>` without an explicit import. Nearby pages import it (see `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/index.mdx?plain=1#L7`). For consistency, add `import { Aside } from '/snippets/aside.jsx';` after frontmatter. If the site auto‑registers the component, this is a consistency fix, not a functional change.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#19-appendices-a-admonition-levels-and-usage (implementation guidance); consistency with nearby pages when the guide is silent.

---

- [ ] **5. Mixed command and output in one code block (simple arithmetic)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/deep-dive.mdx?plain=1#L23

Commands and expected output must be in separate fenced blocks. Minimal fix: keep the Fift code in a `fift` block and move `2023 ok` into a following `text` block under an “Expected output” label.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **6. Ordered lists use explicit 1/2/3 instead of `1.` auto-numbering**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/deep-dive.mdx?plain=1#L30

In “This example calculates:” the items are numbered `1.`, `2.`, `3.`. Use `1.` for each item and let MDX auto-number. Minimal fix: change items to `1.` `1.` `1.`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **7. Ordered list numbering in “This defines an opcode that:” should use `1.`**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/deep-dive.mdx?plain=1#L148

Change `1.`/`2.`/`3.` to `1.` for each item to follow auto-numbering.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **8. Literal ellipsis `...` in code block; use a comment marker for omissions**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/deep-dive.mdx?plain=1#L116

Use language-appropriate comments to mark omitted lines; do not include literal `...` that changes syntax. Minimal fix: replace the lone `...` line with a Fift comment such as `// …`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-5-comments-and-omissions

---

- [ ] **9. Term hyphenation: “bag-of-cells” should be “bag of cells”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/deep-dive.mdx?plain=1#L7

Replace “bag-of-cells (BoC)” with “bag of cells (BoC)” per term bank. Also update later occurrences (“You can embed large bag-of-cells ...”).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#b-banned-and-preferred-terms

---

- [ ] **10. Placeholder/path uses `...` inside a string; use a valid placeholder**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/deep-dive.mdx?plain=1#L142

Avoid literal `...` for paths. Use a placeholder that follows the guide. Minimal fix: `"/path/to/contract.boc"` (general convention) or a neutral placeholder like `"CONTRACT_BOC_PATH"` inside the string.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-5-comments-and-omissions

---

- [ ] **11. Typo: stray space before period**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/deep-dive.mdx?plain=1#L66

“Do not require a trailing space .” has an extra space before the period. Minimal fix: “Do not require a trailing space.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-punctuation-and-mechanics

---

- [ ] **12. Misused Caution callout for prerequisites/audience**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/deep-dive.mdx?plain=1

The opening callout uses `<Aside type="caution">` to signal audience/prerequisites, but caution is reserved for potential data loss or non‑recoverable state. Use the least severe level and a supported type with a `title` for “Important”. Minimal fix: change to `<Aside type="note" title="Important">` (or `title="Audience: Advanced"`) and keep the same content.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#a-admonition-levels-and-usage

---

- [ ] **13. Bold styling applied to code identifiers in lists**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/deep-dive.mdx?plain=1

In “Ed25519 cryptography” and “TVM interaction”, identifiers like `newkeypair`, `priv>pub`, and `runvmcode` are wrapped in both bold and code. Tokens must use code font only, not bold. Minimal fix: remove the surrounding `**` so each identifier is rendered as code only.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **14. Subject–verb agreement in bullet**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/deep-dive.mdx?plain=1

In “TVM interaction”: “`runvmcode` and similar commands — Executes TVM…” uses a singular verb with a plural subject. Minimal fix: “`runvmcode` and similar commands — Execute TVM …”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-punctuation-and-mechanics (mechanics/grammar; general English subject–verb agreement)

---

- [ ] **15. Missing article “the” before “TVM stack”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/deep-dive.mdx?plain=1

In “Including cells in contracts” → item 3: “Pushes the cell to TVM stack…” is missing an article. Minimal fix: “Pushes the cell to the TVM stack…”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-punctuation-and-mechanics (mechanics/grammar; general English article usage)

---

- [ ] **16. Entire list item text bolded**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/deep-dive.mdx?plain=1

In “File operations”, the bullet “Save BoC to file” is fully bolded. Entire list items must not be bold. Minimal fix: remove bold from the list item label (“Save BoC to file:”).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **17. Ordered lists use incremental numerals instead of `1.`**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/deep-dive.mdx?plain=1#L30-L157

Use `1.` for each item and let MDX auto-number. Replace `2.`/`3.` with `1.` in these lists. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **18. Heading level skips from H2 to H4**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/deep-dive.mdx?plain=1#L115

Do not skip levels in the hierarchy. Change `#### How comments work` to `### How comments work` under the `## Comments` section. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles

---

- [ ] **19. Inconsistent term: “TVM assembly codes” (plural)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/deep-dive.mdx?plain=1#L127

Use singular for the concept and match earlier usage on this page: “Using Fift for defining TVM assembly code” (or minimally, change “codes” → “code”). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-terminology-and-naming

---

- [ ] **20. Partial snippet not labeled (“Not runnable”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/deep-dive.mdx?plain=1#L129-L138

This excerpt is not runnable and shows only a fragment. Add a short line `Not runnable` immediately above the fence. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **21. Full-sentence list items without terminal periods**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/deep-dive.mdx?plain=1#L41-L124

If a list item is a full sentence, end it with a period. Add periods to the bullets under “Standard output” and to each item in “Breaking down the `//` definition”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **22. Expand acronyms on first mention and link glossary/reference**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/deep-dive.mdx?plain=1#L7

“TVM” and “TON” appear without expansion or first-use links. Minimal fix: change the first occurrences to “TON Virtual Machine (TVM)” and “The Open Network (TON)”, and link the first useful mentions to their canonical internal references (e.g., TON → https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#ton; TVM → https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/ton.mdx?plain=1#ton-virtual-machine or https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#ton-virtual-machine).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not

---

- [ ] **23. Normalize “Bag of Cells” casing and hyphenation; use BoC after first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/deep-dive.mdx?plain=1#L7

The page uses “bag-of-cells (BoC)” and later “bag-of-cells”. Per glossary usage, write “Bag of Cells (BoC)” on first mention (no hyphens), then “BoC” thereafter. Minimal fix: replace “bag-of-cells (BoC)” → “Bag of Cells (BoC)” at first use, and later “bag-of-cells” → “BoC”; add a first-use link to the BoC entry.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not

---

- [ ] **24. Prefer colon over hyphen-as-dash in apposition**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/deep-dive.mdx?plain=1#L98

“takes two arguments - let’s call them …” uses a hyphen as a dash to introduce an appositive. Minimal fix: use a colon: “takes two arguments: let’s call them `cont` and `n` …”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **25. Add missing determiners for clarity**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/deep-dive.mdx?plain=1#L99-L100

“removes head from list present on stack” omits articles. Minimal fix: “removes the head from the list present on the stack.” (General English grammar.)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-punctuation-and-mechanics

---

- [ ] **26. Make step reference explicit**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/deep-dive.mdx?plain=1#L52

“First line defines a word …” should include the article. Minimal fix: “The first line defines a word `increment` that increases `x` by `1`.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-punctuation-and-mechanics

---

- [ ] **27. Mixed command and output in one code block (standard output)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/deep-dive.mdx?plain=1#L36

Split the Fift commands and the resulting output into separate fenced blocks (`fift` then `text`).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **28. Mixed command and output in one code block (conditional execution)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/fift/deep-dive.mdx?plain=1#L81

Separate the Fift code from its output into two code fences (`fift` then `text`) and optionally label the output as “Expected output”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules