### PR TITLE
[AI] fix: whitepaper.mdx

### DIFF
--- a/language/fift/whitepaper.mdx
+++ b/language/fift/whitepaper.mdx
@@ -1,43 +1,43 @@
 ---
-title: "Fift: A Brief Introduction"
-sidebarTitle: "Whitepaper"
+title: "Fift: a brief introduction"
+sidebarTitle: "Fift whitepaper"
 description: "Whitepaper by Dr. Nikolai Durov"
-noindex: "true"
+noindex: true
 ---
 
 import { Aside } from '/snippets/aside.jsx';
 
 **Author**: Nikolai Durov <br />
-**Date**: July 4, 2019 <br />
-<Icon icon="file-pdf" size={16} />: [Original whitepaper, PDF](/resources/pdfs/fiftbase.pdf)
+**Date**: 2019-07-04 <br />
+<Icon icon="file-pdf" size={16} />: [Original whitepaper (PDF)](/resources/pdfs/fiftbase.pdf)
 
-## Introduction
+## Overview
 
-This document provides a brief description of Fift, a stack-based general-purpose programming language optimized for creating, debugging, and managing TON Blockchain smart contracts.
+Fift is a stack-based general-purpose programming language optimized for creating, debugging, and managing TON blockchain smart contracts.
 
-Fift has been specifically designed to interact with the TON Virtual Machine (TON VM or TVM) and the  TON Blockchain. In particular, it offers native support for 257-bit integer arithmetic and TVM cell manipulation shared with TVM, as well as an interface to the Ed25519-based cryptography employed by the TON Blockchain. A macro assembler for TVM code, useful for writing new smart contracts, is also included in the Fift distribution.
+Fift has been specifically designed to interact with the TON Virtual Machine (TVM) and the TON blockchain. In particular, it offers native support for 257-bit integer arithmetic and TVM cell manipulation shared with TVM, as well as an interface to the Ed25519-based cryptography employed by the TON blockchain. A macro assembler for TVM code, useful for writing new smart contracts, is also included in the Fift distribution.
 
-Being a stack-based language, Fift is not unlike Forth. Because of the brevity of this text, some knowledge of Forth might be helpful for understanding Fift.1 However, there are significant differences between the two languages. For instance, Fift enforces runtime type-checking, and keeps values of different types (not only integers) in its stack.
+Being a stack-based language, Fift is not unlike Forth. Because of the brevity of this text, some knowledge of Forth might be helpful for understanding Fift. However, there are significant differences between the two languages. For instance, Fift enforces runtime type-checking, and keeps values of different types (not only integers) in its stack.
 
 A list of words (built-in functions, or primitives) defined in Fift, along with their brief descriptions, is presented in _Appendix A_.
 
-Please note that the current version of this document describes a preliminary test version of Fift; some minor details are likely to change in the future.
+This document describes a preliminary test version of Fift; some minor details may change in the future.
 
 ## Contents
 
-1. [**Overview**](#1-overview)
+1. [Overview](#1-overview)
 
-2. [**Fift basics**](#2-fift-basics)
+1. [Fift basics](#2-fift-basics)
    1. [List of Fift stack value types](#2-1-list-of-fift-stack-value-types)
-   2. [Comments](#2-2-comments)
-   3. [Terminating Fift](#2-3-terminating-fift)
-   4. [Simple integer arithmetic](#2-4-simple-integer-arithmetic)
-   5. [Stack manipulation words](#2-5-stack-manipulation-words)
-   6. [Defining new words](#2-6-defining-new-words)
-   7. [Named constants](#2-7-named-constants)
-   8. [Integer and fractional constants, or literals](#2-8-integer-and-fractional-constants-or-literals)
-   9. [String literals](#2-9-string-literals)
-   10. [Simple string manipulation](#2-10-simple-string-manipulation)
+   1. [Comments](#2-2-comments)
+   1. [Terminating Fift](#2-3-terminating-fift)
+   1. [Simple integer arithmetic](#2-4-simple-integer-arithmetic)
+   1. [Stack manipulation words](#2-5-stack-manipulation-words)
+   1. [Defining new words](#2-6-defining-new-words)
+   1. [Named constants](#2-7-named-constants)
+   1. [Integer and fractional constants, or literals](#2-8-integer-and-fractional-constants-or-literals)
+   1. [String literals](#2-9-string-literals)
+   1. [Simple string manipulation](#2-10-simple-string-manipulation)
    11. [Boolean expressions, or flags](#2-11-boolean-expressions-or-flags)
    12. [Integer comparison operations](#2-12-integer-comparison-operations)
    13. [String comparison operations](#2-13-string-comparison-operations)
@@ -45,54 +45,54 @@ Please note that the current version of this document describes a preliminary te
    15. [Tuples and arrays](#2-15-tuples-and-arrays)
    16. [Lists](#2-16-lists)
    17. [Atoms](#2-17-atoms)
-   18. [Command line arguments in script mode](#2-18-command-line-arguments-in-script-mode)
+   18. [Command-line arguments in script mode](#2-18-command-line-arguments-in-script-mode)
 
-3. [**Blocks, loops, and conditionals**](#3-blocks-loops-and-conditionals)
+1. [Blocks, loops, and conditionals](#3-blocks-loops-and-conditionals)
    1. [Defining and executing blocks](#3-1-defining-and-executing-blocks)
-   2. [Conditional execution of blocks](#3-2-conditional-execution-of-blocks)
-   3. [Simple loops](#3-3-simple-loops)
-   4. [Loops with an exit condition](#3-4-loops-with-an-exit-condition)
-   5. [Recursion](#3-5-recursion)
-   6. [Throwing exceptions](#3-6-throwing-exceptions)
+   1. [Conditional execution of blocks](#3-2-conditional-execution-of-blocks)
+   1. [Simple loops](#3-3-simple-loops)
+   1. [Loops with an exit condition](#3-4-loops-with-an-exit-condition)
+   1. [Recursion](#3-5-recursion)
+   1. [Throwing exceptions](#3-6-throwing-exceptions)
 
-4. [**Dictionary, interpreter, and compiler**](#4-dictionary-interpreter-and-compiler)
+1. [Dictionary, interpreter, and compiler](#4-dictionary-interpreter-and-compiler)
    1. [The state of the Fift interpreter](#4-1-the-state-of-the-fift-interpreter)
-   2. [Active and ordinary words](#4-2-active-and-ordinary-words)
-   3. [Compiling literals](#4-3-compiling-literals)
-   4. [Defining new active words](#4-4-defining-new-active-words)
-   5. [Defining words and dictionary manipulation](#4-5-defining-words-and-dictionary-manipulation)
-   6. [Dictionary lookup](#4-6-dictionary-lookup)
-   7. [Creating and manipulating word lists](#4-7-creating-and-manipulating-word-lists)
-   8. [Custom defining words](#4-8-custom-defining-words)
+   1. [Active and ordinary words](#4-2-active-and-ordinary-words)
+   1. [Compiling literals](#4-3-compiling-literals)
+   1. [Defining new active words](#4-4-defining-new-active-words)
+   1. [Defining words and dictionary manipulation](#4-5-defining-words-and-dictionary-manipulation)
+   1. [Dictionary lookup](#4-6-dictionary-lookup)
+   1. [Creating and manipulating word lists](#4-7-creating-and-manipulating-word-lists)
+   1. [Custom defining words](#4-8-custom-defining-words)
 
-5. [**Cell manipulation**](#5-cell-manipulation)
+1. [Cell manipulation](#5-cell-manipulation)
    1. [Slice literals](#5-1-slice-literals)
-   2. [Builder primitives](#5-2-builder-primitives)
-   3. [Slice primitives](#5-3-slice-primitives)
-   4. [Cell hash operations](#5-4-cell-hash-operations)
-   5. [Bag-of-cells operations](#5-5-bag-of-cells-operations)
-   6. [Binary file I/O and Bytes manipulation](#5-6-binary-file-i-o-and-bytes-manipulation)
+   1. [Builder primitives](#5-2-builder-primitives)
+   1. [Slice primitives](#5-3-slice-primitives)
+   1. [Cell hash operations](#5-4-cell-hash-operations)
+   1. [Bag-of-cells operations](#5-5-bag-of-cells-operations)
+   1. [Binary file I/O and Bytes manipulation](#5-6-binary-file-i-o-and-bytes-manipulation)
 
-6. [**TON-specific operations**](#6-ton-specific-operations)
+1. [TON-specific operations](#6-ton-specific-operations)
    1. [Ed25519 cryptography](#6-1-ed25519-cryptography)
-   2. [Smart-contract address parser](#6-2-smart-contract-address-parser)
-   3. [Dictionary manipulation](#6-3-dictionary-manipulation)
-   4. [Invoking TVM from Fift](#6-4-invoking-t-v-m-from-fift)
+   1. [Smart contract address parser](#6-2-smart-contract-address-parser)
+   1. [Dictionary manipulation](#6-3-dictionary-manipulation)
+   1. [Invoking TVM from Fift](#6-4-invoking-tvm-from-fift)
 
-7. [**Using the Fift assembler**](#7-using-the-fift-assembler)
+1. [Using the Fift assembler](#7-using-the-fift-assembler)
    1. [Loading the Fift assembler](#7-1-loading-the-fift-assembler)
-   2. [Fift assembler basics](#7-2-fift-assembler-basics)
-   3. [Pushing integer constants](#7-3-pushing-integer-constants)
-   4. [Immediate arguments](#7-4-immediate-arguments)
-   5. [Immediate continuations](#7-5-immediate-continuations)
-   6. [Control flow: loops and conditionals](#7-6-control-flow-loops-and-conditionals)
-   7. [Macro definitions](#7-7-macro-definitions)
-   8. [Larger programs and subroutines](#7-8-larger-programs-and-subroutines)
+   1. [Fift assembler basics](#7-2-fift-assembler-basics)
+   1. [Pushing integer constants](#7-3-pushing-integer-constants)
+   1. [Immediate arguments](#7-4-immediate-arguments)
+   1. [Immediate continuations](#7-5-immediate-continuations)
+   1. [Control flow: loops and conditionals](#7-6-control-flow-loops-and-conditionals)
+   1. [Macro definitions](#7-7-macro-definitions)
+   1. [Larger programs and subroutines](#7-8-larger-programs-and-subroutines)
 
-8. [**References**](#references)
-9. [**Appendix A: List of Fift words**](#appendix-a%3A-list-of-fift-words)
+1. [References](#references)
+1. [Appendix A: List of Fift words](#appendix-a%3A-list-of-fift-words)
 
-## 1 Overview
+## 1 overview
 
 Fift is a simple stack-based programming language designed for testing and debugging the TON Virtual Machine and the TON Blockchain, but potentially useful for other purposes as well. When Fift is invoked (usually by executing a binary file called `fift`), it either reads, parses, and interprets one or several source files indicated in the command line, or enters the interactive mode and interprets Fift commands read and parsed from the standard input. There is also a "script mode", activated by command line switch `-s`, in which all command line arguments except the first one are passed to the Fift program by means of the variables `$n` and `$#`. In this way, Fift can be used both for interactive experimentation and debugging as well as for writing simple scripts.
 
@@ -814,7 +814,7 @@ variable ')
 { anon dup ') @ 2 { ') ! list-until-marker } does ') ! } : (
 ```
 
-### 2.18 Command line arguments in script mode
+### 2.18 Command-line arguments in script mode
 
 The Fift interpreter can be invoked in script mode by passing `-s` as a command line option. In this mode, all further command line arguments are not scanned for Fift startup command line options. Rather, the next argument after `-s` is used as the filename of the Fift source file, and all further command line arguments are passed to the Fift program by means of special words `$n` and `$#`:
 
@@ -839,17 +839,17 @@ $2 (number)` 1- `?usage
 
 is saved into a file `cmd`line`.fif` in the current directory, and its execution bit is set (e.g., by `chmod 755 cmdline.fif`), then it can be invoked from the shell or any other program, provided the Fift interpreter is installed as `/usr/bin/fift`, and its standard library `Fift.fif` is installed as `/usr/lib/fift/Fift.fif`:
 
-```shell
+```bash
 ./cmdline.fif 12 -5
 ```
 
 prints
 
-```shell
+```text
 -60
 ```
 
-when invoked from a *ix shell such as the Bourne–again shell (Bash).
+when invoked from a Unix-like shell such as the Bourne–again shell (Bash).
 
 ## 3 Blocks, loops, and conditionals
 
@@ -1570,7 +1570,7 @@ Fift offers an interface to the same Ed25519 elliptic curve cryptography used by
 | **`ed25519_sign_uint`** | _`(x B' – B'')`_ | converts a big-endian unsigned 256-bit integer `x` into a 32-byte sequence and signs it using the Ed25519 private key `B'` similarly to `ed25519_sign`. Equivalent to `swap 256 u>B swap ed25519_sign`. The integer `x` to be signed is typically computed as the hash of some data.
 | **`ed25519_chksign`** | _`(B B' B'' – ?)`_ | checks whether `B'` is a valid Ed25519 signature of data `B` with the public key `B''` .
 
-### 6.2 Smart-contract address parser
+### 6.2 Smart contract address parser
 
 Two special words can be used to parse TON smart-contract addresses in human-readable (base64 or base64url) forms:
 


### PR DESCRIPTION
- [ ] **1. Quotation marks used for emphasis (legacy/outdated)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/whitepapers.mdx?plain=1#L10

Quotation marks are used for emphasis around legacy and outdated, which violates the rule to reserve quotes for literal UI/log strings. Minimal fix: remove the quotes and keep plain words: legacy here does not mean outdated, but rather less up to date than regular pages.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **2. Throat-clearing filler (Notice that)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/whitepapers.mdx?plain=1#L10

The sentence begins with Notice that, which the guide classifies as throat‑clearing/filler. Minimal fix: remove the opener and start directly with the statement: Here, legacy does not mean outdated, but rather less up to date than regular pages.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **3. Hedge phrase (holds some truth)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/whitepapers.mdx?plain=1#L10

Phrase holds some truth is a hedge. Minimal fix: drop some to remove the hedge while preserving the original claim scope: While most of the information described in the original PDFs holds true, …. This avoids introducing new domain facts.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **4. Word choice: utilize → use**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/whitepapers.mdx?plain=1#L63

Utilized is legalese; the guide prefers common words. Minimal fix: change utilized by the TON Blockchain to used by the TON Blockchain.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **5. Missing articles (grammar) in two sentences**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/whitepapers.mdx?plain=1#L63-L71

- Add the before TON Blockchain: … used by the TON Blockchain for block creation.
- Add a before deep connection: … with a deep connection to the TVM.
These are basic English grammar fixes to improve readability; no domain facts are introduced.
Rule: general knowledge of English grammar (articles); the style guide is silent on articles.

---

- [ ] **6. Awkward phrasing: less kept up to date**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/whitepapers.mdx?plain=1#L10

Less kept up to date is awkward. Minimal fix: replace with less up to date: … but rather less up to date than regular pages.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **7. Internal links should be relative (PDF cards)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/whitepapers.mdx?plain=1#L43-L69

Internal links use absolute site‑root paths (/resources/…). The guide recommends relative paths for stability. Minimal fix: change to relative paths from this file: ../resources/pdfs/ton.pdf, ../resources/pdfs/tvm.pdf, ../resources/pdfs/tblkch.pdf, ../resources/pdfs/catchain.pdf, ../resources/pdfs/fiftbase.pdf.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format

---

- [ ] **8. Sidebar label should mirror page topic**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/whitepapers.mdx?plain=1#L3

Sidebar label Overview is generic and does not mirror a page heading. Minimal fix: set sidebarTitle to Whitepapers to mirror the page topic and improve nav clarity.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles

---

- [ ] **9. Misused colon in “see: [Pages]”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/whitepapers.mdx?plain=1#L36

“see: [Pages]” uses a colon after a non‑clausal lead‑in. Colons should follow a complete clause. Minimal fix: remove the colon: “see [Pages]”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#commas-colons-semicolons

---

- [ ] **10. Missing articles in sentence fragment**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/whitepapers.mdx?plain=1#L71

“Tacit stack-based programming language with deep connection to the TVM.” is missing articles and reads as a fragment. Minimal fix: “A tacit, stack‑based programming language with a deep connection to the TVM.” (General English grammar: countable noun phrases require articles.)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#language-and-tone

---

- [ ] **11. Use "White paper" per glossary, not "whitepapers"**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/whitepapers.mdx?plain=1#L2

The page title and several occurrences use “whitepapers” as a single word, but the term bank uses “White paper” (two words). Minimal fix: change `title: "White papers"` and replace “whitepapers” → “white papers” in body and link text (e.g., lines 8, 36, 107–109). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms. Supporting usage: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#white-paper.

---

- [ ] **12. First mention of TON lacks expansion**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/whitepapers.mdx?plain=1#L8

On first use, spell out the term and follow with the acronym. Minimal fix: “The original The Open Network (TON) documentation was written …”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms.

---

- [ ] **13. Literal tokens should use code font, not quotes (gram/nanogram)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/whitepapers.mdx?plain=1#L13

When referring to exact tokens/identifiers seen in code or comments, use code font and avoid quotation marks. Minimal fix: “may reference `gram` and `nanogram`.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis.

---

- [ ] **14. Missing article before “Gram cryptocurrency”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/whitepapers.mdx?plain=1#L13

Add the definite article for correct grammar. Minimal fix: “The Gram cryptocurrency was never issued.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording. General knowledge: standard English article usage.

---

- [ ] **15. First mention of “PDF” not expanded**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/whitepapers.mdx?plain=1#L10

On first mention, spell out the term and follow with the acronym. Minimal fix: “original Portable Document Format (PDF) files”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms.

---

- [ ] **16. Hyphenate and lowercase “fault tolerant” compound**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/whitepapers.mdx?plain=1#L63

“Byzantine Fault Tolerant (BFT)” is a generic adjective phrase and should be lowercased mid‑sentence and hyphenated as a compound modifier. Minimal fix: “Byzantine fault‑tolerant (BFT) consensus protocol …”. Hyphenation follows general English for compound modifiers.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#132-general-casing-rules

---

- [ ] **17. Non-descriptive heading “Pages” (make descriptive)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/whitepapers.mdx?plain=1#L75

Headings must make sense out of context; Pages is generic. Minimal fix: rename the H2 to a descriptive noun phrase in sentence case, for example: Documentation pages.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-3-uniqueness-and-linkability

---

- [ ] **18. Non-descriptive link text “Pages” (make link text meaningful)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/whitepapers.mdx?plain=1#L36

Link text must be descriptive; Pages is generic and not informative when read out of context. Minimal fix: change the link text to documentation pages while keeping the same anchor. Example: For documentation pages ported from the whitepapers, see [documentation pages](#pages). If the heading in Item 6 is renamed, update the anchor accordingly.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text

---

- [ ] **19. Pleonasm “comprehensive overview of all aspects”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/whitepapers.mdx?plain=1#L8-L9

Comprehensive and of all aspects duplicate meaning. Minimal fix: remove redundancy. Examples: They provided an overview of TON. or They provided a comprehensive overview of TON.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **20. Wordiness “actual documentation pages”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/whitepapers.mdx?plain=1#L10

Actual documentation pages is redundant; documentation pages suffices. Minimal fix: remove actual. Example: … integration of their contents into documentation pages.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references