### PR TITLE
[AI] fix: system-contracts.mdx

### DIFF
--- a/ton/system-contracts.mdx
+++ b/ton/system-contracts.mdx
@@ -5,14 +5,12 @@ title: "System contracts"
 import { Aside } from "/snippets/aside.jsx";
 
 <Aside type="note">
-    These are low-level TON Blockchain internals. You do not need to write or deploy these contracts.
+  These are low-level TON Blockchain internals. You do not need to write or deploy these contracts.
 </Aside>
-
 
 <Aside type="note">
-    System contracts are smart contracts and have on‑chain addresses. See [config parameters 1–4](/ton/config). The Config account stores the Config contract address. To track changes, review proposals to the Config contract.
+  System contracts are smart contracts and have on‑chain addresses. See [config parameters 1–4](/ton/config). The Config account stores the Config contract address. To track changes, review proposals to the Config contract.
 </Aside>
-
 
 In TON, a set of special smart contracts controls consensus parameters for node operation — including TON Virtual Machine (TVM), catchain, fees, and chain topology — and how these parameters are stored and updated. Unlike older blockchains that hardcode these parameters, TON enables transparent on‑chain governance. The current governance contracts include the Elector and Config contracts, with expansion plans (for example, the extra‑currency Minter).
 
@@ -40,8 +38,8 @@ The Elector stores:
 To apply, a validator must:
 
 1. Send a message to the Elector with their Abstract Datagram Network Layer (ADNL) address, public key, `max_factor`, and stake (Toncoin amount).
-2. The Elector validates the parameters and either registers the application or refunds the stake.
-<Aside type="note">Only masterchain addresses can apply.</Aside>
+1. The Elector validates the parameters and either registers the application or refunds the stake.
+   <Aside type="note">Only masterchain addresses can apply.</Aside>
 
 ### Conduct elections
 
@@ -50,19 +48,26 @@ The Elector is a special smart contract triggered by **Tick and Tock transaction
 **Process details:**
 
 - Take applications with stake ≥ `min_stake` ([`ConfigParam 17`](https://tonviewer.com/config#17)).
+
 - Arrange candidates by stake in descending order.
+
 - If applicants exceed `max_validators` ([`ConfigParam 16`](https://tonviewer.com/config#16)), discard the lowest-staked candidates.
+
 - For each subset size `i` (from 1 to remaining candidates):
+
   - Assume the `i`-th candidate (lowest in the subset) defines the baseline.
   - Calculate effective stake (`true_stake`) for each `j`-th candidate (`j < i`) as:
 
   Not runnable
+
   ```python
   min(stake[i] * max_factor[j], stake[j])
   ```
 
 - Track the subset with the highest **total effective stake (TES)**.
+
 - Submit the winning validator set to the **Config** contract.
+
 - Return unused stakes and excess amounts (e.g., `stake[j] - min(stake[i] * max_factor[j], stake[j])`) to `credits`.
 
 **Example breakdown**:
@@ -93,8 +98,8 @@ Each validator is periodically assigned the duty to create new blocks, with the 
 To report misbehavior, a user must:
 
 1. Generate a **Merkle proof** demonstrating the validator's failure to produce the expected blocks.
-2. Propose a fine proportional to the severity of the offense.
-3. Submit the proof and fine proposal to the Elector contract, covering the associated storage costs.
+1. Propose a fine proportional to the severity of the offense.
+1. Submit the proof and fine proposal to the Elector contract, covering the associated storage costs.
 
 The Elector registers the complaint in the `past_elections` hashmap. Current round validators then verify the complaint. If the proof is valid and the proposed fine aligns with the severity of the misbehavior, validators vote on the complaint. Approval requires agreement from over **two-thirds of the total validator weight** (not just a majority of participants).
 
@@ -113,17 +118,19 @@ The **Config** contract manages TON’s configuration parameters, validator set 
 1. The **Elector** notifies **Config** of a new validator set.
 1. **Config** stores it in `ConfigParam 36` (_next validators_).
 1. At the scheduled time (`utime_since`), **Config**:
-  - Moves the old set to `ConfigParam 32` (_previous validators_).
-  - Promotes `ConfigParam 36` to `ConfigParam 34` (_current validators_).
+
+- Moves the old set to `ConfigParam 32` (_previous validators_).
+- Promotes `ConfigParam 36` to `ConfigParam 34` (_current validators_).
 
 ### Proposal/voting mechanism
 
 1. **Submit a proposal**: Pay storage fees to propose parameter changes.
 1. **Vote**: Validators (from `ConfigParam 34`) sign approval messages.
 1. **Outcome**:
-  - **Approved**: After `min_wins` rounds (`ConfigParam 11`) with ≥3/4 weighted votes.
-  - **Rejected**: After `max_losses` rounds.
-  - _Critical parameters_ (`ConfigParam 10`) require more rounds.
+
+- **Approved**: After `min_wins` rounds (`ConfigParam 11`) with ≥3/4 weighted votes.
+- **Rejected**: After `max_losses` rounds.
+- _Critical parameters_ (`ConfigParam 10`) require more rounds.
 
 #### Emergency updates
 


### PR DESCRIPTION
- [ ] **1. In‑body H1 present (duplicate title)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/system-contracts.mdx?plain=1#L7

The page includes an in‑body `# System contracts`, but the site renders the title from frontmatter. Pages must not include an in‑body H1; start content at H2. Minimal fix: remove line 7 entirely and keep the frontmatter title, with the first section heading starting at `##`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#71-case-and-form

---

- [ ] **2. Acronym “TVM” not expanded on first use**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/system-contracts.mdx?plain=1#L19

Per acronym rules, the first mention must spell out the term before the acronym. Minimal fix: change “including TVM, catchain, fees…” to “including TON Virtual Machine (TVM), catchain, fees…”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#53-acronyms-and-terms

---

- [ ] **3. Partial snippet labeling and code fence info string**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/system-contracts.mdx?plain=1#L61

The fenced block uses a nonstandard info string “```python not runnable”. Language tags must be the language only, and partial snippets must be labeled above the block as “Not runnable”. Minimal fix: add a preceding line “Not runnable” and change the fence to “```python” (no extra words).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#101-general-rules; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#102-partial-snippets

---

- [ ] **4. Mis‑nested list under “Process details”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/system-contracts.mdx?plain=1#L57–63

The bullets “Assume the i‑th candidate …” and “Calculate effective stake …” are logical sub‑steps of “For each subset size i …” but appear at the top level. Minimal fix: indent these two bullets (and the enclosed code block) by two spaces so they render as nested sub‑bullets under the preceding item.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#82-structure-for-scanning

---

- [ ] **5. Subject‑verb agreement in example result**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/system-contracts.mdx?plain=1#L75

“10,000‑stake candidate are excluded.” should use singular verb. Minimal fix: “10,000‑stake candidate is excluded.” (General English grammar.)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#52-plain-precise-wording

---

- [ ] **6. Inconsistent unit/wording for stake amount**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/system-contracts.mdx?plain=1#L77

“1 candidate stakes 100,000‑stake” is awkward and inconsistent with Case 1’s “stake 100,000 TON”. Minimal fix: “1 candidate stakes 100,000 Toncoin.” (Keeps units explicit and consistent with earlier usage on the page.)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#52-plain-precise-wording; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#53-acronyms-and-terms

---

- [ ] **7. Currency term inconsistency (“TON amount” vs. Toncoin)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/system-contracts.mdx?plain=1#L44

Use “Toncoin” for the currency/unit, not “TON amount”. Minimal fix: change “stake (TON amount)” to “stake (Toncoin amount)”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#b-banned-and-preferred-terms

---

- [ ] **8. External link used where internal reference exists (validator guide)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/system-contracts.mdx?plain=1#L23

Internal links should be relative when an in‑repo canonical page exists. Minimal fix: replace “follow the validator instructions” link target with the internal validator setup guide, e.g., `/ecosystem/node/setup-mytonctrl`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#163-links-and-anchors

---

- [ ] **9. Prefer internal docs link for config parameters 1–4**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/system-contracts.mdx?plain=1#L15

When referencing configuration parameters, link to the in‑repo reference rather than only to an external explorer. Minimal fix: change the link target to the internal page `/ton/config` (or add it alongside the explorer link) to keep readers within the canonical docs.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#163-links-and-anchors; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#171-single-source-of-truth

---

- [ ] **10. Excessive bold usage within a single paragraph**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/system-contracts.mdx?plain=1#L19

The paragraph contains multiple bold spans (`**Elector**`, `**Config**`, `**Minter**`). Bold should be used sparingly (≤1 short span per paragraph). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis. Minimal fix: remove bold from contract names or keep only the first occurrence unbolded (plain text proper nouns), e.g., “the Elector and Config contracts (for example, the extra‑currency minter)”.

---

- [ ] **11. Inline “Note:” should use the Aside component for a callout**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/system-contracts.mdx?plain=1#L46

The inline “_Note:_ Only masterchain addresses can apply.” is a callout but not rendered with the standard component. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#a-admonition-levels-and-usage. Minimal fix: replace the line with an Aside:

```mdx
<Aside type="note">Only masterchain addresses can apply.</Aside>
```

---

- [ ] **12. Ordered lists use literal numbering instead of `1.` autoincrement**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/system-contracts.mdx?plain=1#L35-L125

Three ordered lists number items `1., 2., 3., …`. For consistency and easier maintenance, every item in an ordered list must start with `1.` and let the renderer auto-number. Minimal fix: change each list item marker to `1.` in these sections.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **13. Entire list items are bolded**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/system-contracts.mdx?plain=1#L35-L38

The “Key functions” list bolds the full text of each list item. Do not bold whole list items; use plain text or structure instead. Minimal fix: remove the `**` around each item label so they render as regular list items.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **14. Bolded link text for config parameter and external target**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/system-contracts.mdx?plain=1#L31-L103

The text uses `[**ConfigParam 15**](https://tonviewer.com/config#15)`. Avoid bold for tokens in body text, and prefer internal anchors for canonical references. Minimal fix: change link text to `Param 15` (no bold) and point to the internal page: `/ton/config#param-15-elections-timing`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-3-links-and-anchors

---

- [ ] **15. List item punctuation inconsistent for non-sentence fragments**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/system-contracts.mdx?plain=1#L29-L89

Bulleted items that are noun/phrase fragments end with periods (e.g., “Non-withdrawn Toncoin in the `credits` hashmap.”). For fragments, omit terminal punctuation consistently. Minimal fix: remove trailing periods from these fragment list items.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **16. Grammar: plural noun agreement (“Toncoin” → “Toncoins”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/system-contracts.mdx?plain=1#L29

“Non-withdrawn Toncoin” should be plural to agree with the implied count. Minimal fix: change to “Non-withdrawn Toncoins”. This relies on general English grammar; no domain facts are introduced.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17-4-proofread

---

- [ ] **17. Gerund in procedure heading; prefer imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/system-contracts.mdx?plain=1#L48

Heading “### Conducting elections” uses a gerund in a procedural section. Prefer imperative for task headings. Minimal fix: “### Conduct elections”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-2-gerunds-and-labels

---

- [ ] **18. Mis-nested list under “Example breakdown”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/system-contracts.mdx?plain=1#L73–75,78–80

Bullets describing Case 1/2 details are at the same level as the “Case” items, which breaks the intended hierarchy. Minimal fix: indent the detail bullets under each case by two spaces so they render as sub-items.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#8-2-structure-for-scanning

---

- [ ] **19. Mis-nested substeps in numbered lists**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/system-contracts.mdx?plain=1#L118–119,126–128

The hyphen bullets under numbered steps (“At the scheduled time” and “Outcome”) are not indented, so they render as separate top-level items. Minimal fix: indent these bullets two spaces to nest them under their respective numbered items.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#8-2-structure-for-scanning

---

- [ ] **20. Asides missing explicit supported type**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/system-contracts.mdx?plain=1#L9-L14–16

Both top callouts use `<Aside>` without a supported `type`. Set an explicit `type="note"` for informational notes to ensure consistent rendering. Minimal fix: change to `<Aside type="note">` for both instances.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout

---

- [ ] **21. Use code font for technical identifiers, not bold**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/system-contracts.mdx?plain=1#L31-L128

Technical identifiers like “ConfigParam 15/16/17/34/10/11” are bolded (and sometimes linked). Tokens/identifiers must use code font; when linking, wrap the code span in the link. Minimal fix: replace `**ConfigParam 15**` → `` `ConfigParam 15` `` (and prefer linking to `/ton/config#...`).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **22. Hedge word reduces precision**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/system-contracts.mdx?plain=1#L10

“You typically do not need to write or deploy these contracts.” contains a hedge. Minimal fix: “You do not need to write or deploy these contracts.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **23. Comma splices and agreement issues in examples**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/system-contracts.mdx?plain=1#L71-L77

Grammar-only fixes to improve clarity per basic mechanics:
- Line 71: “9 candidates stake 100,000 TON (…), 1 candidate stakes 10,000.” → add a conjunction to avoid a comma splice: “9 candidates stake 100,000 TON (…), and 1 candidate stakes 10,000.”
- Line 75: “10,000-stake candidate are excluded.” → subject–verb agreement: “10,000‑stake candidate is excluded.”
- Line 77: “1 candidate stakes 100,000-stake (…), 9 stake 10,000.” → remove “-stake”, add noun, and avoid a comma splice: “1 candidate stakes 100,000 (…), and 9 candidates stake 10,000.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons