### PR TITLE
[AI] fix: mnemonics.mdx

### DIFF
--- a/standard/wallets/mnemonics.mdx
+++ b/standard/wallets/mnemonics.mdx
@@ -5,8 +5,7 @@ sidebarTitle: "Mnemonics"
 
 import { Aside } from '/snippets/aside.jsx';
 
-
-## Key pair 
+## Key pair
 
 The Open Network (TON) blockchain uses asymmetric cryptography, such as the [Ed25519](https://en.wikipedia.org/wiki/EdDSA#Ed25519) signature scheme.
 
@@ -24,15 +23,15 @@ PBKDF2 has [five input parameters](https://en.wikipedia.org/wiki/PBKDF2#Key_deri
 
 The most commonly used values are:
 
-| Parameter  | Description | Value
-| :--------- | :---------- | :----
-| `PRF`      | Pseudo-random function (PRF) of two parameters | [HMAC‑SHA512](https://en.wikipedia.org/wiki/HMAC) (hash‑based message authentication code with SHA‑512)
-| `Password` | Master password from which a derived key is generated | `""`
-| `Salt`     | Sequence of bits, known as a [cryptographic salt](https://en.wikipedia.org/wiki/Salt_(cryptography)) | `"TON default seed"`
-| `c`        | Number of iterations desired | `100000`
-| `dkLen`    | Desired bit-length of the derived key | `64`
+| Parameter  | Description                                                                                            | Value                                                                                                   |
+| :--------- | :----------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------ |
+| `PRF`      | Pseudo-random function (PRF) of two parameters                                                         | [HMAC‑SHA512](https://en.wikipedia.org/wiki/HMAC) (hash‑based message authentication code with SHA‑512) |
+| `Password` | Master password from which a derived key is generated                                                  | `""`                                                                                                    |
+| `Salt`     | Sequence of bits, known as a [cryptographic salt](https://en.wikipedia.org/wiki/Salt_\(cryptography\)) | `"TON default seed"`                                                                                    |
+| `c`        | Number of iterations desired                                                                           | `100000`                                                                                                |
+| `dkLen`    | Desired bit-length of the derived key                                                                  | `64`                                                                                                    |
 
-### Generate a key pair 
+### Generate a key pair
 
 ```typescript title="TypeScript"
 import { mnemonicToPrivateKey, mnemonicNew } from "@ton/crypto";
@@ -49,15 +48,18 @@ console.log("Public Key: " + keyPair.publicKey.toString('hex'));
 
 The private key is needed to sign messages, and the public key is stored in the wallet's [smart contract](/ton/glossary#smart-contract). When new external messages arrive on that smart contract, the public key is used to check the authenticity of the messages signed using the corresponding private key.
 
-<Aside type="note" title="Important">
+<Aside
+  type="note"
+  title="Important"
+>
   Save the generated mnemonic phrase. If you need deterministic behavior during development, print and reuse the exact phrase so the wallet derives the same key pair on every run.
 </Aside>
 
-## Validate a mnemonic 
+## Validate a mnemonic
 
 1. Check that all the words are from the list of [Bitcoin Improvement Proposal 39 (BIP‑39)](https://github.com/ton-org/ton-crypto/blob/c3435833a0da52a96f674c352c4c6f91fcc07f6d/src/mnemonic/wordlist.ts#L9).
-1. If a password is used, the first byte of the derived `seed` computed with `c = 1` and `salt = `"TON fast seed version"` must equal `0`.
-1. If no password is used, the first byte of the derived `seed` computed with `c = floor(100000/256) = 390` and `salt = `"TON seed version"` must equal `1`.
+1. If a password is used, the first byte of the derived `seed` computed with `c = 1` and `salt = `"TON fast seed version"`must equal`0\`.
+1. If no password is used, the first byte of the derived `seed` computed with `c = floor(100000/256) = 390` and `salt = `"TON seed version"`must equal`1\`.
 
 Generate random mnemonic phrases until PBKDF2 yields a seed whose first byte matches the expected version (0 for the `"fast seed"` parameters, 1 for the `"seed version"` parameters). Then return a valid mnemonic.
 


### PR DESCRIPTION
- [ ] **1. First mention of TON lacks expansion**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/wallets/mnemonics.mdx?plain=1#L11

On first mention, spell out the term and follow with the acronym. Replace “TON Blockchain uses …” with “The Open Network (TON) blockchain uses …”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **2. Caution callout lacks required risk/mitigation content**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/wallets/mnemonics.mdx?plain=1#L52-L54

`type="caution"` callouts must include the risk and mitigation/rollback. The current text is an “Important” note without risk/rollback details. Minimal fix: change the callout to `<Aside type="note" title="Important">…</Aside>` to match content severity without adding new domain text.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#19-a-admonition-levels-and-usage; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-safety-callouts

---

- [ ] **3. Example prints a secret (private key)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/wallets/mnemonics.mdx?plain=1#L47

Examples must not expose or encourage exposing secrets. Remove the `console.log` of `secretKey` (private key) or replace with a comment indicating not to print secrets; keep only the public key print.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-4-key-handling-and-storage

---

- [ ] **4. Example prints a secret (mnemonic phrase)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/wallets/mnemonics.mdx?plain=1#L69-L70

Avoid printing sensitive secrets in examples. Remove the `console.log(mnemonicArray)` line, or replace it with a comment indicating to store securely without printing.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-4-key-handling-and-storage

---

- [ ] **5. Literal parameter values in prose use quotes instead of code font**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/wallets/mnemonics.mdx?plain=1#L59-L62

Use code formatting for literal strings and labels in technical prose. Replace 'TON fast seed version' and 'TON seed version' with `TON fast seed version` and `TON seed version`; replace the quoted version labels ('fast seed', 'seed version') with code spans.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **6. Terminology inconsistency: “mnemonic phrase” vs “mnemonic seed phrase”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/wallets/mnemonics.mdx?plain=1#L53(cf. lines 21, 40)

Avoid synonyms for the same concept within a page. Standardize on one term. Minimal fix: change “mnemonic seed phrase” to “mnemonic phrase” to match earlier usage on this page.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **7. Hedging reduces clarity (“would be used”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/wallets/mnemonics.mdx?plain=1#L50

Prefer direct, present-tense wording. Change “the public key would be used to check …” to “the public key is used to check …”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **8. Missing Glossary link for first mention of “smart contract”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/wallets/mnemonics.mdx?plain=1#L50

On first useful mention of a core term, link to the Glossary unless defined on the page. Add a link for “smart contract”: “the wallet’s [smart contract](/ton/glossary#smart-contract)”. Supporting entry: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#smart-contract.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not

---

- [ ] **9. Safety callout severity and content are non-compliant**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/wallets/mnemonics.mdx?plain=1#L52-L54

Mnemonic handling involves keys/funds risk and requires a Warning-level callout with required fields (risk, scope, rollback/mitigation, environment label). Current callout uses `type="caution"` and lacks those elements. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-1-when-a-safety-callout-is-required and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout. Minimal fix: change to `<Aside type="danger" title="Warning">` and include the four required elements. Domain owner confirmation needed for the exact risk/mitigation wording and testnet/mainnet note.

---

- [ ] **10. Acronyms not expanded on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/wallets/mnemonics.mdx?plain=1#L21-L60

PBKDF2 and BIP-39 appear without expansion; `PRF` is used without definition. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms. Minimal fix: write “Password-Based Key Derivation Function 2 (PBKDF2)” at first mention (line 21), “Bitcoin Improvement Proposal 39 (BIP-39)” in item 1 (line 58), and expand `PRF` in the table header description to “Pseudo-random function (PRF) of two parameters.”

---

- [ ] **11. Escaped quotes in code spans and prose for literals**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/wallets/mnemonics.mdx?plain=1#L30-L62

The table escapes quotes inside code spans (e.g., `\"\"`, `\"TON default seed\"`), which renders backslashes and is not copy-pasteable; later, salt/version strings use single quotes in prose. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules. Minimal fix: in the table, use `""` and `"TON default seed"` without backslashes; in lines 59–62, wrap literal salts and version names in code spans: `"TON fast seed version"`, `"TON seed version"`, `"fast seed"`, `"seed version"`.

---

- [ ] **12. Relative reference “Below” — avoid above/below phrasing**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/wallets/mnemonics.mdx?plain=1#L13

“Below is the most common approach …” uses relative positioning. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references (avoid “as mentioned above/below”; prefer explicit phrasing). Minimal fix: “The most common approach in TON is described here.” or “This page describes the most common approach in TON.”

---

- [ ] **13. Capitalization of “TON Blockchain” — use common-noun casing**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/wallets/mnemonics.mdx?plain=1#L11

“TON Blockchain” capitalizes a common noun mid-sentence. The guide’s TON-specific casing examples keep common nouns lowercase (e.g., “smart contract”). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#b-banned-and-preferred-terms and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms. Minimal fix: “The TON blockchain uses asymmetric cryptography, such as the Ed25519 signature scheme.” If corpus-wide conventions differ, confirm and standardize; otherwise prefer lowercase “blockchain.”

---

- [ ] **14. Long sentence with semicolon; split for scannability**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/wallets/mnemonics.mdx?plain=1#L62

The sentence uses a semicolon to join two complete clauses. Prefer two sentences. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons. Minimal fix: “Random mnemonic phrases are generated until PBKDF2 yields a seed whose first byte matches the expected version (0 for the `fast seed` parameters, 1 for the `seed version` parameters). Then a valid mnemonic is returned.”

---

- [ ] **15. One-word generic page title — not context-free**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/wallets/mnemonics.mdx?plain=1#L2-L3

The frontmatter `title` is a one-word generic (“Mnemonics”), which the guide discourages except at top level or for proper names. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-2-navigation-labels (Title vs sidebar semantics). Minimal fix: set `title: "Mnemonic phrases"` (sentence case, context-free) and keep `sidebarTitle: "Mnemonics"` for brevity.

---

- [ ] **16. Vague “see note below” reference in code comment**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/wallets/mnemonics.mdx?plain=1#L40

The comment references a note “below” without a link/anchor. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references (avoid above/below; link to the exact anchor). Minimal fix: remove “(see note below)” or replace with a direct link to the relevant callout’s anchor, if one exists.

---

- [ ] **17. Numeric literals in table should use code formatting**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/wallets/mnemonics.mdx?plain=1#L32-L33

The values `100000` and `64` are literals but not formatted as code. Wrap each in backticks for consistency with adjacent code-styled values: `100000`, `64`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-3-code-styling

---

- [ ] **18. Ordered list should use `1.` for all items**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/wallets/mnemonics.mdx?plain=1#L58-L60

Items are numbered `1.`, `2.`, `3.`. Use `1.` for every item and let MDX auto-number. Minimal fix: change lines starting with `2.` and `3.` to `1.`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **19. Full-sentence list item missing terminal period**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/wallets/mnemonics.mdx?plain=1#L58

Item 1 is a complete sentence but lacks a period. Add a period at the end for consistency with items 2 and 3.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **20. Colon after dependent clause; prefer comma**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/wallets/mnemonics.mdx?plain=1#L59-L60

“If a password is used:” and “If no password is used:” use a colon after a dependent clause. Prefer a comma (or rewrite) after introductory dependent clauses. Minimal fix: replace the colon with a comma in both items.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **21. Expand HMAC on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/wallets/mnemonics.mdx?plain=1#L29

The value “HMAC‑SHA512” uses the acronym without expansion. Minimal fix: update the cell text to “HMAC‑SHA512 (hash‑based message authentication code with SHA‑512)”. Keep the existing link.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **22. Code fence language alias consistency**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/wallets/mnemonics.mdx?plain=1#L37-L71

Fenced blocks use `ts`; nearby pages use `typescript` (e.g., `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-mint.mdx?plain=1`). For consistency, prefer `typescript`. Minimal fix: change “```ts” to “```typescript” in both blocks. Note: the guide is silent on alias preference; this aligns with nearby pages for consistency.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **23. Procedural heading should use imperative mood**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/wallets/mnemonics.mdx?plain=1#L56

Heading “Mnemonic validation” introduces a numbered procedure, so it should start with an imperative verb. Minimal fix: change to “Validate a mnemonic”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form

---

- [ ] **24. Prefer active voice**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/wallets/mnemonics.mdx?plain=1#L62

“Random mnemonic phrases are generated … then a valid mnemonic is returned.” uses passive voice. Use active voice. Minimal fix: “Generate random mnemonic phrases until PBKDF2 yields the expected version. Then return a valid mnemonic.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-1-voice-tense-and-person

---

- [ ] **25. Safety callout for mnemonics missing required elements**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/wallets/mnemonics.mdx?plain=1#L52-L54

The callout addresses mnemonic handling (a secret) but omits the required items (risk, scope, rollback/mitigation, and environment label). Minimal fix: expand the `<Aside type="caution" title="Important">` text to briefly include (a) risk: exposure/loss can lead to fund loss; (b) scope: affects the wallet derived from this mnemonic; (c) rollback/mitigation: securely back up, rotate/regenerate if exposed; (d) environment label: prefer testnet during development.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout

---

- [ ] **26. Missing explicit Aside type**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/wallets/mnemonics.mdx?plain=1#L15

The callout uses `<Aside>` without an explicit `type`, which may render inconsistently. Set a supported `type` for clarity. Minimal fix: change `<Aside>` to `<Aside type="note">`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout