### PR TITLE
[AI] fix: supported-events.mdx

### DIFF
--- a/ecosystem/tma/analytics/supported-events.mdx
+++ b/ecosystem/tma/analytics/supported-events.mdx
@@ -1,20 +1,20 @@
 ---
 title: "Supported events"
 ---
+
 TON Connect sends events only when you use `@tonconnect/ui-react` version 2.0.3 or later, `@tonconnect/ui` version 2.0.3 or later, or `@tonconnect/sdk` version 3.0.3 or later.
 
-
-| Event name                      | Description                                                                               | TON Connect required |
-|---------------------------------|-------------------------------------------------------------------------------------------| --- |
-| `app-init`                       | Connection attempts and their initiation                                                  | `false` |
-| `app-hide`                       | Hiding the app from the screen                                                            | `false` |
-| `custom-event`                   | The event specified by the user                                                           | `false` |
-| `connection-started`             | The user starts connecting the wallet                                                     | `true` |
-| `connection-completed`           | Successful connection to a wallet                                                         | `true` |
-| `connection-error`               | Errors in connection specifying reasons (for example, user canceled)                      | `true` |
-| `connection-restoring-completed` | The connection was restored successfully                                                  | `true` |
-| `connection-restoring-error`     | Connection restoration failed                                                             | `true` |
-| `transaction-sent-for-signature` | The user submits the transaction for signature                                            | `true` |
-| `transaction-signed`             | The user successfully signs the transaction                                               | `true` |
-| `transaction-signing-failed`     | The user cancels the transaction signature or an error occurs during the signing process  | `true` |
-| `disconnection	user-initiated`   | Disconnection events, specifying scope (dApp or wallet)                                   | `true` |
+| Event name                       | Description                                                                              | TON Connect required |
+| -------------------------------- | ---------------------------------------------------------------------------------------- | -------------------- |
+| `app-init`                       | Connection attempts and their initiation                                                 | `false`              |
+| `app-hide`                       | Hiding the app from the screen                                                           | `false`              |
+| `custom-event`                   | The event specified by the user                                                          | `false`              |
+| `connection-started`             | The user starts connecting the wallet                                                    | `true`               |
+| `connection-completed`           | Successful connection to a wallet                                                        | `true`               |
+| `connection-error`               | Errors in connection specifying reasons (for example, user canceled)                     | `true`               |
+| `connection-restoring-completed` | The connection was restored successfully                                                 | `true`               |
+| `connection-restoring-error`     | Connection restoration failed                                                            | `true`               |
+| `transaction-sent-for-signature` | The user submits the transaction for signature                                           | `true`               |
+| `transaction-signed`             | The user successfully signs the transaction                                              | `true`               |
+| `transaction-signing-failed`     | The user cancels the transaction signature or an error occurs during the signing process | `true`               |
+| `disconnection	user-initiated`   | Disconnection events, specifying scope (dApp or wallet)                                  | `true`               |


### PR DESCRIPTION
- [ ] **1. Opening sentence uses future passive voice, lacks code formatting and Oxford comma**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/supported-events.mdx?plain=1#L4

The sentence uses future passive voice ("will be sent"), is awkwardly phrased ("and higher versions packages"), omits the serial comma in a three-item list, and does not code‑format package identifiers. Minimal fix: "TON Connect sends events only when you use `@tonconnect/ui-react` version 2.0.3 or later, `@tonconnect/ui` version 2.0.3 or later, or `@tonconnect/sdk` version 3.0.3 or later." Add a terminal period.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-1-voice-tense-and-person; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-3-code-styling; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **2. Boolean literals in table are not code-formatted**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/supported-events.mdx?plain=1#L9

In the third column (rows 9–20), true/false values are plain text. Literals must use code formatting. Minimal fix: wrap each boolean in backticks: `true` or `false`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-3-code-styling

---

- [ ] **3. British spelling “cancelled” instead of American “canceled”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/supported-events.mdx?plain=1#L14

The description uses British spelling: "user cancelled". The guide requires American English. Minimal fix: change to "user canceled".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-6-spelling-and-contractions

---

- [ ] **4. Inline code token contains a tab character**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/supported-events.mdx?plain=1#L20

The event name appears as ``disconnection\tuser-initiated`` (contains a literal tab inside a code span). Tokens must be exact and free of unintended whitespace. Minimal fix: replace the tab with the intended character (likely a hyphen), e.g., `disconnection-user-initiated`. Domain decision required to confirm the exact token.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-3-code-styling

---

- [ ] **5. Inconsistent “dApp” casing in prose**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/supported-events.mdx?plain=1#L20

The phrase "dapp or wallet" uses "dapp" (all lowercase). Prevailing usage across the docs is "dApp". Minimal fix: change "dapp" to "dApp". Cross-doc usage: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1#how-to-integrate-a-decentralized-application-dapp-with-ton.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#15-2-structure-and-tables; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-1-term-bank-canonical-source

---

- [ ] **6. Tab characters in table cells may break Markdown table rendering**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/supported-events.mdx?plain=1#L7

There are embedded tab characters ("\t") in multiple cells, including within code spans. Tabs in Markdown tables are brittle and can render inconsistently. Replace tabs with single spaces to keep cells scannable and accessible. The guide is silent on tabs; prefer consistency with nearby pages that use spaces in tables.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#152-structure-and-tables
Note: The style guide is silent on tabs specifically; this change follows the repository’s consistency norm for tables.

---

- [ ] **7. Replace Latinism “e.g.” with “for example”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/supported-events.mdx?plain=1#L14

Prefer common words over Latinisms. Minimal fix in the `connection-error` description: replace “e.g.,” with “for example,”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#52-plain-precise-wording

---

- [ ] **8. Tautology in description (“Connection attempts and their initiation”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/supported-events.mdx?plain=1#L9

The phrase is redundant; “attempts” and “their initiation” duplicate meaning. Minimal fix: shorten to a single precise concept, for example: “Connection initiation.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#57-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **9. Prefer concise, present‑tense descriptions in table**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/analytics/supported-events.mdx?plain=1#L9–19

Several description cells start with gerunds or passive phrasing (e.g., “Hiding the app from the screen”). The guide prefers present tense and active voice for general behavior. Minimal fix example: “Hides the app from the screen.” Apply similar present‑tense, active‑voice adjustments across descriptions while keeping semantics unchanged.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.1-voice-tense-and-person; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#8.1-paragraphs-and-sentences