### PR TITLE
[AI] fix: liquid_staking.mdx

### DIFF
--- a/ecosystem/node/mytonctrl/liquid_staking.mdx
+++ b/ecosystem/node/mytonctrl/liquid_staking.mdx
@@ -8,7 +8,7 @@ description: "Liquid staking mode orchestrates controller deployment and mainten
 - Liquid staking controllers rely on the validator wallet and liquid pool contracts. Keep the wallet funded and the pool address (`liquid_pool_addr`) set via `set liquid_pool_addr <address>` before deploying controllers.
 - Pending withdrawals are stored in the local database when a controller is busy (non-zero `state`). MyTonCtrl processes them automatically as soon as the controller returns to the ready state.
 - The jetton pool contracts must be available under `/usr/src/mytonctrl/contracts/jetton_pool/`. The first run of `create_controllers` downloads them if necessary.
-- Commands interacting with the TON HTTP API assume the service listens on `127.0.0.1:8801` (the default when this mode is enabled).
+- Commands interacting with the TON HTTP Application Programming Interface (API) assume the service listens on `127.0.0.1:8801` (the default when this mode is enabled).
 
 ## Controller deployment and discovery
 
@@ -25,7 +25,7 @@ create_controllers
 **Behavior**
 
 - Compares the controller addresses returned by the pool (`GetControllers`) with the addresses stored in the local database.
-- If they differ, downloads the jetton pool deployment scripts (on first run), signs the deployment BOCs with the validator wallet, and sends them to the liquid pool with a small attach value.
+- If they differ, downloads the jetton pool deployment scripts (on first run), signs the deployment Bag of Cells (BoC) files with the validator wallet, and sends them to the liquid pool with an attached value.
 - Stores the newly active controllers under `using_controllers` so subsequent staking and voting commands target the fresh contracts.
 
 ### `update_controllers`
@@ -40,7 +40,7 @@ update_controllers
 
 **Behavior**
 
-- Alias for `create_controllers`; useful after pool upgrades or migration, forcing MyTonCtrl to redeploy controllers when the contract-address mapping changes.
+- Alias for `create_controllers`. Useful after pool upgrades or migration, forcing MyTonCtrl to redeploy controllers when the contract-address mapping changes.
 
 ### `controllers_list`
 
@@ -70,8 +70,8 @@ add_controller <controller-addr>
 
 **Behavior**
 
-- Adds `<controller-addr>` to the `user_controllers` list and removes it from the stop list if present, enabling future staking or updates through MyTonCtrl.
-- Accepts base64 controller addresses.
+- Adds `<CONTROLLER_ADDR>` to the `user_controllers` list and removes it from the stop list if present, enabling future staking or updates through MyTonCtrl.
+- `<CONTROLLER_ADDR>` accepts a base64 controller address.
 
 **Example**
 
@@ -93,8 +93,8 @@ deposit_to_controller <controller-addr> <amount-ton>
 
 **Behavior**
 
-- Signs the `top-up.boc` script with the validator wallet and sends `<amount-ton>` TON to `<controller-addr>`.
-- Use decimal TON amounts; the command handles the nanoTON conversion internally.
+- Signs the `top-up.boc` script with the validator wallet and sends `<AMOUNT_TON>` TON to `<CONTROLLER_ADDR>`.
+- Use decimal TON amounts. The command handles conversion to nanotons internally.
 
 **Example**
 
@@ -115,7 +115,7 @@ withdraw_from_controller <controller-addr> [amount-ton]
 **Behavior**
 
 - Requests an immediate withdrawal when the controller state permits it, otherwise queues a pending withdrawal handled automatically later.
-- If `[amount-ton]` is omitted, MyTonCtrl withdraws nearly the entire balance (leaving \~10 TON to cover rent).
+- If `<AMOUNT_TON>` is omitted, MyTonCtrl withdraws nearly the entire balance (leaving \~10 TON to cover rent).
 
 **Examples**
 
@@ -136,7 +136,7 @@ stop_controller <controller-addr>
 
 **Behavior**
 
-- Adds `<controller-addr>` to the local stop list and removes it from the user or active lists. The contract remains on-chain but is ignored by automated workflows.
+- Adds `<CONTROLLER_ADDR>` to the local stop list and removes it from the user or active lists. The contract remains on-chain but is ignored by automated workflows.
 
 **Example**
 
@@ -157,7 +157,7 @@ stop_and_withdraw_controller <controller-addr> [amount-ton]
 **Behavior**
 
 - Flags the controller as stopped (same as `stop_controller`).
-- Triggers a withdrawal for `[amount-ton]` TON; when omitted, withdraws almost the full balance (balance minus \~10.1 TON to keep the contract alive).
+- Triggers a withdrawal for `<AMOUNT_TON>` TON; when omitted, withdraws almost the full balance (balance minus \~10.1 TON to keep the contract alive).
 
 **Example**
 
@@ -179,7 +179,7 @@ controller_update_validator_set <controller-addr>
 
 **Behavior**
 
-- Calls the controller’s `update_validator_set` method so it picks up the latest validator ADNL IDs from the pool.
+- Calls the controller’s `update_validator_set` method so it picks up the latest validator Abstract Datagram Network Layer (ADNL) IDs from the pool.
 - Use after elections or whenever the pool indicates mismatched validator sets.
 
 **Example**
@@ -207,7 +207,7 @@ check_liquid_pool
 
 ### `get_controller_data`
 
-**Purpose:** Dump the full controller status JSON for inspection.
+**Purpose:** Dump the full controller status in JavaScript Object Notation (JSON) for inspection.
 
 **Syntax**
 
@@ -238,7 +238,7 @@ calculate_annual_controller_percentage [percent-per-round]
 
 **Behavior**
 
-- Uses the validators election cycle length from config 15 to compute how many rounds fit into a year and then scales the provided (or configured `max_interest_percent`) rate.
+- Uses the validator election cycle length from [config 15](../../../ton/config.mdx#param-15-elections-timing) to compute how many rounds fit into a year and then scales the provided (or configured `max_interest_percent`) rate.
 - Prints intermediate values and the final yearly percentage.
 
 **Examples**
@@ -261,4 +261,4 @@ test_calculate_loan_amount
 **Behavior**
 
 - Sends a local HTTP request to the TON HTTP API (`/runGetMethod`) using the configured loan parameters (`min_loan`, `max_loan`, `max_interest_percent`).
-- Prints the raw response (nanoTON value) used to size controller loans.
+- Prints the raw response (value in nanotons) used to size controller loans.


### PR DESCRIPTION
- [ ] **1. Optional arguments shown with square brackets in command syntax**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/liquid_staking.mdx?plain=1

Square brackets are used to indicate optional parameters in copy-pasteable command blocks (e.g., `withdraw_from_controller <controller-addr> [amount-ton]` at https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/liquid_staking.mdx?plain=1#L111`stop_and_withdraw_controller <controller-addr> [amount-ton]` at https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/liquid_staking.mdx?plain=1#L154`calculate_annual_controller_percentage [percent-per-round]` at https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/liquid_staking.mdx?plain=1#L236). This violates the rule banning `{}`/`[]` placeholder syntax in commands. Minimal fix: replace square-bracketed items with angle-case placeholders and state optionality in prose. For example, change syntax to `withdraw_from_controller <CONTROLLER_ADDR> <AMOUNT_TON>` and in Behavior add “`<AMOUNT_TON>` is optional; when omitted …”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **2. Placeholders not in ANGLE_CASE format**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/liquid_staking.mdx?plain=1

Placeholders use hyphenated lowercase (e.g., `<controller-addr>`, `<amount-ton>`, `<percent-per-round>`). The guide requires `<ANGLE_CASE>` with uppercase and underscores, and each placeholder defined on first use. Minimal fix: rename to `<CONTROLLER_ADDR>`, `<AMOUNT_TON>`, `<PERCENT_PER_ROUND>` throughout, and ensure each is briefly defined at first mention in the surrounding prose. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **3. Truncated addresses in examples create copy/paste hazards**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/liquid_staking.mdx?plain=1

Examples use shortened addresses like `EQDf...9A` (see https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/liquid_staking.mdx?plain=1#L79:102, :123, :144, :165, :188, :226). This is a high-severity hazard due to silent truncation of IDs/addresses. Minimal fix: replace truncated samples with a clear placeholder `<CONTROLLER_ADDR>` (ANGLE_CASE), or provide a full-length example address explicitly labeled as an example. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#severity-model-release-blocking

---

- [ ] **4. ADNL acronym not expanded on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/liquid_staking.mdx?plain=1#L182

The first mention reads “validator ADNL IDs” without defining ADNL. Minimal fix: expand at first mention as “Abstract Datagram Network Layer (ADNL) IDs”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **5. BoC acronym not expanded on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/liquid_staking.mdx?plain=1#L28

“deployment BOCs” appears without defining the term. Minimal fix: introduce it on first mention as “Bag of Cells (BoC) files” or “deployment BoCs (Bag of Cells)”. Optionally link to the concept page `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/boc.mdx?plain=1`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **6. JSON acronym not expanded on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/liquid_staking.mdx?plain=1#L210

“Dump the full controller status JSON” uses the acronym without expansion. Minimal fix: “Dump the full controller status in JavaScript Object Notation (JSON) for inspection.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **7. Semicolons used where periods are preferred**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/liquid_staking.mdx?plain=1#L43:97

Semicolons connect independent clauses in two places (e.g., “Alias for `create_controllers`; useful after…”, “Use decimal TON amounts; the command handles…”). The guide recommends preferring shorter sentences and limiting semicolons. Minimal fix: replace semicolons with periods (two sentences) or coordinating conjunctions. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **8. Minor grammar: singular form for “validator election cycle”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/liquid_staking.mdx?plain=1#L241

Text reads “Uses the validators election cycle length…”. Minimal fix: change to “Uses the validator election cycle length…”. This is an obvious grammar correction; general English grammar applies. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **9. Vague intensifier (“small attach value”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/liquid_staking.mdx?plain=1#L28

The phrase “with a small attach value” is vague. The guide recommends replacing hedges/intensifiers with facts or removing them when unnecessary. Minimal fix: remove “small” and write “sends them to the liquid pool with an attached value.” If a precise amount is needed, this requires a domain decision.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **10. Missing deep link for “config 15” reference**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/liquid_staking.mdx?plain=1#L241

Cross‑section references should target specific anchors. “config 15” is mentioned without a link. Minimal fix: link to the parameter section: “from config 15” → “from [config 15](https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/../../../ton/config.mdx?plain=1#param-15-elections-timing)”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-3-links-and-anchors

---

- [ ] **11. Incorrect BoC abbreviation casing**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/liquid_staking.mdx?plain=1#L28

“BOCs” uses all‑caps “BOC”, but the canonical abbreviation is “BoC”. Minimal fix: change “deployment BOCs” to “deployment BoCs” (or “BoC files”). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-4-ton-specific-examples

---

- [ ] **12. Acronym not expanded on first mention (API)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/liquid_staking.mdx?plain=1#L11

“API” appears in “TON HTTP API” without an earlier expansion on the page. Minimal fix: expand on first use as “Application Programming Interface (API)”. Subsequent uses may keep “API”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#application-programming-interface-api

---

- [ ] **13. Grammar: “attach value” should be “attached value”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/liquid_staking.mdx?plain=1#L28

Phrase “sends them to the liquid pool with a small attach value” is ungrammatical. Minimal fix: change to “with a small attached value”. This follows plain, precise wording. (General English grammar used.)

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **14. Terminology consistency: “nanoTON” in prose should be “nanotons”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/liquid_staking.mdx?plain=1#L97

Use “nanotons” in prose to match term bank; reserve `.boc`/identifiers for code. Minimal fix: “handles the nanotons conversion internally” → “handles conversion to nanotons internally”; also update “nanoTON value” → “value in nanotons” at line 264.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/ton.mdx?plain=1#units-and-denominations