### PR TITLE
[AI] fix: using-onchain-libraries.mdx

### DIFF
--- a/techniques/using-onchain-libraries.mdx
+++ b/techniques/using-onchain-libraries.mdx
@@ -1,34 +1,34 @@
 ---
-title: "Using onchain libraries"
+title: "Using on-chain libraries"
 ---
 
 import { Image } from '/snippets/image.jsx';
 import { Aside } from '/snippets/aside.jsx';
 
-It is recommended to read [Library cells](/ton/cells/library-cells) first.
+Read [Library cells](/ton/cells/library-cells) first.
 
-<Aside type='danger'>
-You should always monitor the balance of the account that hosts the library. It should be sufficient for at least 10 years.
-</Aside>
+<Aside type="danger" title="Funds at risk"> Risk: the library becomes inaccessible if the host account runs out of funds. Scope: contracts using this library. Mitigation: provision balance for ~10 years of storage and monitor regularly. Environment: applies on mainnet and testnet.</Aside>
 
-### Fee savings
+## Fee savings
 
 Library cells help reduce fees in two main ways.
 
-1. Forwarding fees. For example, in [jettons](/standard/tokens/jettons/overview), the StateInit must be forwarded with each transfer, resulting in high forwarding fees. Moving the code into a library cell significantly reduces these fees.
+- Forwarding fees. For example, in [jettons](/standard/tokens/jettons/overview), the `StateInit` must be forwarded with each transfer, resulting in high forwarding fees. Moving the code into a library cell significantly reduces these fees.
 
-2. Storage costs. Because a library must be hosted in the Masterchain, where storage is approximately 1,000 times more expensive than in the Basechain, hosting a copy of the code in the Basechain may be cheaper if there are fewer than 1,000 instances of the contract. The 1,000 factor is not constant and is subject to change. Consult [blockchain config parameter 18](https://tonviewer.com/config#18) for the latest value. However, due to the savings on forwarding fees, you should calculate whether this approach is cost-effective for your specific use case.
+- Storage costs. Because a library must be hosted in the masterchain, where storage is approximately 1,000 times more expensive than in the basechain, hosting a copy of the code in the basechain may be cheaper if there are fewer than 1,000 instances of the contract. The 1,000 factor is not constant and is subject to change. Consult [blockchain config parameter 18](/ton/config#param-18-storage-prices) for the latest value. However, due to the savings on forwarding fees, you should calculate whether this approach is cost-effective for your specific use case.
 
 Everything in TON is stored in cells, even account code. One of the most common use cases for libraries is to store code shared by multiple contracts.
 When a library cell is part of an account’s `code`, it is automatically dereferenced on first access. This allows you to replace part of the contract code—or even the entire code—with a library cell.
 
 Replacing the entire code with a library cell is widely used in TON smart contracts.
 Some common examples:
-1. USDT (and other popular jettons) Jetton wallet contracts
+1. USDT (and other popular jettons) jetton wallet contracts
 2. The Order contract in Multisig v2
 3. NFT item contracts in popular collections
 
 You can check if a contract is using a library as its code by looking into its `code` cell in an explorer.
+
+Not runnable
 
 
 ```txt title="Fragment of USDT jetton-wallet account"
@@ -41,16 +41,18 @@ code:(just
 ...
 ```
 
-While it is not crucial to understand the exact representation shown on https://explorer.toncoin.org/ ([more about explorers](/ecosystem/explorers/overview)), the key point is that there is only one cell in the contract code, tagged as `SPECIAL` (indicating it is an exotic cell). Following this is the hexadecimal representation of the library cell's internals. The first byte equals 2, indicating that it is a library cell, and the remaining bytes contain the hash of the referenced cell.
+While it is not crucial to understand the exact representation shown on [TON Explorer](https://explorer.toncoin.org) ([more about explorers](/ecosystem/explorers/overview)), the key point is that there is only one cell in the contract code, tagged as `SPECIAL` (indicating it is an exotic cell). Following this is the hexadecimal representation of the library cell's internals. The first byte equals 2, indicating that it is a library cell, and the remaining bytes contain the hash of the referenced cell.
 
-Here you can see that the entire contract code consists of the 8‑bit tag equal to 2 and a 256‑bit representation hash of the referenced cell.
+The entire contract code consists of the 8‑bit tag equal to 2 and a 256‑bit representation hash of the referenced cell.
 
-If you don’t want to put the entire code in a library cell, you can make only part of it a library cell. For example, if the same function is used in multiple different contracts, it makes sense to turn it into a library. However, you will likely need to set up the build process for such code yourself.
+If you don’t want to put the entire code in a library cell, you can make only part of it a library cell. For example, if the same function is used in multiple different contracts, it makes sense to turn it into a library. However, you will need to set up the build process for such code yourself.
 
 
-### Using @ton/core
+## Use @ton/core
 
 You can construct a library cell entirely in TypeScript using the `@ton/core` library. Here’s how to do it in a Blueprint project:
+
+Not runnable
 
 ```ts
 import { Cell, beginCell } from '@ton/core';
@@ -61,11 +63,13 @@ const jwalletCode = new Cell({ exotic: true, bits: libPrep.bits, refs: libPrep.r
 
 - [View source](https://github.com/ton-blockchain/stablecoin-contract/blob/de08b905214eb253d27009db6a124fd1feadbf72/sandbox_tests/JettonWallet.spec.ts#L104C1-L105C90)
 
-### Publishing an ordinary cell in the Masterchain library context
+## Publish an ordinary cell in the masterchain library context {#publishing-an-ordinary-cell-in-the-masterchain-library-context}
 
 
 
 The following example was taken from [multisig v2 repository](https://github.com/ton-blockchain/multisig-contract-v2/blob/master/contracts/helper/librarian.func).
+
+Not runnable
 
 ```func
 ;; Simple library keeper
@@ -112,12 +116,12 @@ The core of this contract is the line: `set_lib_code(lib_to_publish, 2);`. This 
 Note that this contract becomes bricked after the cell is published, so no further operations on this contract can be performed.
         
 
-### Testing in Blueprint
+## Test in Blueprint
 
 
 When testing smart contracts locally, there are **two ways to register libraries** in your blockchain environment.
 
-#### Option 1: **Automatic Library Deployment**
+### Option 1: Automatic library deployment
 
 Enable automatic library detection by passing the `autoDeployLibs` flag when creating the blockchain:
 
@@ -125,11 +129,11 @@ Enable automatic library detection by passing the `autoDeployLibs` flag when cre
 const blockchain = await Blockchain.create({ autoDeployLibs: true });
 ```
 
-In your contract, deployed in **Masterchain**, deploy the library using the librarian example above.
+In your contract, deployed in masterchain, deploy the library using the [librarian example](#publishing-an-ordinary-cell-in-the-masterchain-library-context).
 
 This allows the contract to dynamically install and register the library at runtime, with the environment automatically tracking and using it as needed.
 
-#### Option 2: **Manual Library Deployment**
+### Option 2: Manual library deployment
 
 If `autoDeployLibs` is **not enabled**, you'll need to register libraries manually:
 
@@ -147,22 +151,23 @@ blockchain.libs = beginCell().storeDictDirect(libsDict).endCell();
 
 This gives you full control but requires explicitly managing which libraries are available during testing.
 
-An example implementation can be found [here](https://github.com/ton-blockchain/stablecoin-contract/blob/de08b905214eb253d27009db6a124fd1feadbf72/sandbox_tests/JettonWallet.spec.ts#L100C9-L103C32).
+See the [example implementation](https://github.com/ton-blockchain/stablecoin-contract/blob/de08b905214eb253d27009db6a124fd1feadbf72/sandbox_tests/JettonWallet.spec.ts#L100C9-L103C32).
 
-### Get methods for library‑cell‑based contracts
+## Get methods for library‑cell‑based contracts
 
-When working with a Jetton wallet where the code is stored in a library cell, you may need to check its balance. To do so, you must execute a get method in the code.
+When working with a jetton wallet where the code is stored in a library cell, you may need to check its balance. To do so, you must execute a get method in the code.
 
-If you call methods using one of [HTTP APIs](/ecosystem/rpc/overview) or [LiteServer](/ecosystem/node/overview), the library cell will be automatically resolved and the method will be executed.
+If you call methods using one of [HTTP APIs](/ecosystem/rpc/overview) or [liteserver](/ecosystem/node/overview#interacting-with-ton-nodes), the library cell will be automatically resolved and the method will be executed.
 
 Alternatively, you may take the account state to your local system and execute methods there.
 In that case you will need to pull account state and resolve all library cells (in most cases if the contract is using libraries, the whole code of the contract is the library).
-To resolve aa library, the only thing you need is to call [getLibraries method](/ecosystem/rpc/ton-center-v2/blocks/get-smart-contract-libraries)
+To resolve a library, the only thing you need is to call [getLibraries method](/ecosystem/rpc/ton-center-v2/blocks/get-smart-contract-libraries)
 
-#### Retrieving a library cell with LiteServer
+### Retrieve a library cell with liteserver
 
-To retrieve library cells from LiteServer, use the [liteServer.getLibraries](https://github.com/ton-blockchain/ton/blob/4cfe1d1a96acf956e28e2bbc696a143489e23631/tl/generate/scheme/lite_api.tl#L96) method.
+To retrieve library cells from liteserver, use the [liteServer.getLibraries](https://github.com/ton-blockchain/ton/blob/4cfe1d1a96acf956e28e2bbc696a143489e23631/tl/generate/scheme/lite_api.tl#L96) method.
 
+Not runnable
 ```ts
 import { LiteClient, LiteRoundRobinEngine, LiteSingleEngine } from "ton-lite-client";
 import { Cell } from "@ton/core";


### PR DESCRIPTION
- [ ] **1. Title uses unhyphenated “onchain” (should be “on-chain”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/techniques/using-onchain-libraries.mdx?plain=1

The frontmatter title is "Using onchain libraries". Per hyphenation rules, multi-word mechanism terms should be hyphenated (on-chain). Minimal fix: change the title to "Using on-chain libraries". Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-3-hyphenation-and-abbreviations

---

- [ ] **2. First visible heading starts at H3 instead of H2**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/techniques/using-onchain-libraries.mdx?plain=1

Headings begin with `###` (e.g., "### Fee savings"). Pages must not include an in-body H1; the first visible heading in content must be H2. Minimal fix: change all top-level section headings from `###` to `##` and keep subheadings one level deeper accordingly. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form

---

- [ ] **3. Gerunds used in procedural/concept headings**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/techniques/using-onchain-libraries.mdx?plain=1

Examples: "### Using @ton/core", "### Publishing an ordinary cell in the masterchain library context", "### Testing in Blueprint", "#### Retrieving a library cell with liteserver". Task/procedure headings should avoid gerunds; prefer imperative verbs. Minimal fixes:
- "Use @ton/core"
- "Publish an ordinary cell in the masterchain library context"
- "Test in Blueprint"
- "Retrieve a library cell with liteserver"
Apply sentence case. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-2-gerunds-and-labels

---

- [ ] **4. Bold styling inside headings**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/techniques/using-onchain-libraries.mdx?plain=1

Headings include bold text: "#### Option 1: **Automatic Library Deployment**" and "#### Option 2: **Manual Library Deployment**". Headings must not contain styling other than text. Minimal fix: remove bold and use sentence case: "Option 1: Automatic library deployment" and "Option 2: Manual library deployment". Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-4-formatting-restrictions

---

- [ ] **5. Inconsistent casing for TON chain types (Masterchain/Basechain)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/techniques/using-onchain-libraries.mdx?plain=1

Instances use "Masterchain" and "Basechain" mid-sentence (e.g., "Because a library must be hosted in the Masterchain…"). Per term bank examples, these are common nouns and must be lowercase mid-sentence: masterchain, basechain. Minimal fix: change all mid-sentence occurrences to lowercase. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-4-ton-specific-examples

---

- [ ] **6. Bare URL in prose; link text should be descriptive**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/techniques/using-onchain-libraries.mdx?plain=1

Text shows a bare URL: "the exact representation shown on https://explorer.toncoin.org/". Link text must be descriptive; avoid bare URLs. Minimal fix: "the exact representation shown on [TON Explorer](https://explorer.toncoin.org)". Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text

---

- [ ] **7. External link used where internal canonical exists (config parameter 18)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/techniques/using-onchain-libraries.mdx?plain=1

The text links to "[blockchain config parameter 18](https://tonviewer.com/config#18)". Internal pages should be preferred when available. Canonical internal reference exists: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/config.mdx?plain=1 → "Param 18: storage prices". Minimal fix: link to "/ton/config#param-18-storage-prices" (optionally mention the external viewer as supplemental). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references

---

- [ ] **8. Hedging language reduces precision**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/techniques/using-onchain-libraries.mdx?plain=1

Sentence: "However, you will likely need to set up the build process for such code yourself." Avoid hedges; prefer precise wording. Minimal fix: "However, you will need to set up the build process for such code yourself." Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **9. Partial snippets missing required “Not runnable” labels**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/techniques/using-onchain-libraries.mdx?plain=1

Several snippets are partial and not copy-pasteable as-is, but lack the required label above the block:
- Fragment block under "Fragment of USDT jetton-wallet account" (```txt … with ellipses)
- TypeScript example under "Using @ton/core" (references jwalletCodeRaw not defined in the snippet)
- Func contract under "Publishing an ordinary cell…" (includes project-specific imports; not runnable standalone)
- TypeScript liteserver example (depends on external config and libraries; presented as a focused excerpt)
Minimal fix: add a line "Not runnable" immediately above each partial snippet per §10.2. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **10. Unpinned GitHub link to source (moving target)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/techniques/using-onchain-libraries.mdx?plain=1

"The following example was taken from [multisig v2 repository](https://github.com/ton-blockchain/multisig-contract-v2/blob/master/contracts/helper/librarian.func)." Precision-critical references must use stable permalinks (commit/tag) instead of "master". Minimal fix: replace with a commit-pinned URL to the same file. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references

---

- [ ] **11. Unnecessary bold emphasis on common term and casing issue**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/techniques/using-onchain-libraries.mdx?plain=1

Text: "In your contract, deployed in **Masterchain**, …" Bold should not be used to style tokens or common nouns; also "Masterchain" should be lowercase mid-sentence. Minimal fix: "In your contract, deployed in masterchain, …" (remove bold; lowercase). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-4-ton-specific-examples

---

- [ ] **12. Incorrect casing of “LiteServer” (should be “liteserver”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/techniques/using-onchain-libraries.mdx?plain=1

Occurrences in link text and headings use "LiteServer". Per term bank examples, use lowercase "liteserver" mid-sentence. Minimal fix: replace display text with "liteserver" (links remain unchanged). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-4-ton-specific-examples

---

- [ ] **13. Typo: double article “aa”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/techniques/using-onchain-libraries.mdx?plain=1

Sentence: "To resolve aa library, …" Minimal fix: change to "To resolve a library, …" Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **14. Numbered list used for non-procedural items**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/techniques/using-onchain-libraries.mdx?plain=1

Under "Fee savings", reasons are presented as a numbered list (1., 2.) but they are not steps. Use bullets for unordered items. Minimal fix: convert the two items to a bulleted list. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **15. Throat-clearing sentence at the top**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/techniques/using-onchain-libraries.mdx?plain=1#L8

“It is recommended to read [Library cells] … first.” is throat-clearing. Use direct imperative phrasing. Minimal fix: “Read [Library cells](/ton/cells/library-cells) first.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#avoid-throat-clearing

---

- [ ] **16. Safety Aside lacks required structure**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/techniques/using-onchain-libraries.mdx?plain=1#L10-L12

The danger callout warns about long-term balance sufficiency, but it lacks the required elements (risk, scope, mitigation/rollback, and environment label). Minimal fix: add a title and brief structure, for example: `<Aside type="danger" title="Funds at risk"> Risk: the library becomes inaccessible if the host account runs out of funds. Scope: contracts using this library. Mitigation: provision balance for ~10 years of storage and monitor regularly. Environment: applies on mainnet and testnet.</Aside>`. This risk is supported at https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/library-cells.mdx?plain=1#hosting-a-library-cell.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#safety-critical-content

---

- [ ] **17. Code identifier not in code font (“StateInit”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/techniques/using-onchain-libraries.mdx?plain=1#L18

Identifiers must use code font. Minimal fix: change “the StateInit must be forwarded” to “the `StateInit` must be forwarded”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#terminology-and-casing

---

- [ ] **18. Non-descriptive link text (“here”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/techniques/using-onchain-libraries.mdx?plain=1#L150

Link text must be descriptive. Minimal fix: replace “here” with “[example implementation]” or integrate into the sentence (“See the [example implementation](…)”).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#links-and-cross-references

---

- [ ] **19. “Above” cross-reference (use anchor instead)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/techniques/using-onchain-libraries.mdx?plain=1#L128-L130

Avoid relative references like “above/below”. Minimal fix: change “using the librarian example above” to link to the specific section: “using the [librarian example](#publishing-an-ordinary-cell-in-the-masterchain-library-context)”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#avoid-throat-clearing

---

- [ ] **20. Inconsistent casing of common nouns (“Jetton wallet”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/techniques/using-onchain-libraries.mdx?plain=1#L27

Use lowercase for common nouns mid-sentence. Minimal fix: change “Jetton wallet contracts” to “jetton wallet contracts”. This aligns with usage across jetton docs (e.g., https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/overview.mdx?plain=1) and the style guide’s common-noun rule.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#terminology-and-casing

---

- [ ] **21. Throat‑clearing phrase “Here you can see that …”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/techniques/using-onchain-libraries.mdx?plain=1#L46

Avoid throat‑clearing; lead with the fact. Minimal fix: replace the sentence opener with a direct statement: “The entire contract code consists of the 8‑bit tag equal to 2 and a 256‑bit representation hash of the referenced cell.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **22. Link should deep‑link to relevant anchor**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/techniques/using-onchain-libraries.mdx?plain=1#L156

The link text “LiteServer” points to `/ecosystem/node/overview` (page top). Prefer a specific anchor, e.g., `/ecosystem/node/overview#interacting-with-ton-nodes`, which covers liteserver usage. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format.