### PR TITLE
[AI] fix: glossary.mdx

### DIFF
--- a/ton/glossary.mdx
+++ b/ton/glossary.mdx
@@ -20,7 +20,6 @@ A mechanism that allows two programs to interact through a series of protocols.
 
 A calculated yearly interest rate for a given asset.
 
-
 ## B
 
 ### Bearish
@@ -59,7 +58,6 @@ The term bullish is used to describe an asset whose value is appreciating. (Bull
 
 The act of permanently removing tokens from circulating and total supply.
 
-
 ## C
 
 ### Centralized exchange (CEX)
@@ -81,7 +79,6 @@ A peer-to-peer (P2P) bot service for buying, trading, and selling Toncoin and ot
 ### Custodial
 
 A type of crypto wallet where a third party stores cryptocurrencies, and not their true owner.
-
 
 ## D
 
@@ -135,7 +132,6 @@ Nikolai Durov is Pavel's brother, who helped develop VK, Telegram, and TON.
 
 The process by which you do research on a project, company, or cryptocurrency before deciding to invest.
 
-
 ## E
 
 ### Ethereum Virtual Machine (EVM)
@@ -145,7 +141,6 @@ A machine that behaves like a decentralized computer; it computes the state of t
 ### Exchange
 
 A place for trading and using other market instruments.
-
 
 ## F
 
@@ -177,7 +172,6 @@ A computer on the blockchain that synchronizes and copies the entire blockchain.
 
 The smart contract language on TON.
 
-
 ## G
 
 ### Gas
@@ -187,7 +181,6 @@ The fee paid for transactions on the blockchain.
 ### GitHub
 
 A platform for hosting code and collaborating via Git repositories.
-
 
 ## H
 
@@ -207,7 +200,6 @@ The indication of how much computational power is being used on a network for cr
 
 Saving — that is, not selling — an asset or assets from your portfolio.
 
-
 ## I
 
 ### Initial coin offering (ICO)
@@ -222,13 +214,11 @@ A method of attracting capital when launching a cryptocurrency or token on a dec
 
 The process when the value of a currency — for example, the U.S. dollar or the euro — decreases. Toncoin has predictable issuance and a low inflation rate.
 
-
 ## K
 
 ### Know Your Customer (KYC)
 
 The process by which a user verifies their identity when creating an account for a crypto service.
-
 
 ## L
 
@@ -239,7 +229,6 @@ A platform for crypto startups that brings investors and projects together.
 ### Liquidity pool
 
 Grouping together crypto assets and freezing them in a smart contract. Liquidity pools are used for decentralized trading, loans, and other endeavors.
-
 
 ## M
 
@@ -263,7 +252,6 @@ A digital universe similar to a video game where users create avatars and intera
 
 A crypto term that describes a crypto asset's vertical trajectory on a price chart — that is, it quickly gains value.
 
-
 ## N
 
 ### Not financial advice (NFA)
@@ -282,7 +270,6 @@ Those who provide financial resources to validators so the latter can confirm bl
 
 A kind of crypto wallet that gives full control over assets to the owner/user.
 
-
 ## O
 
 ### Off-ramp
@@ -296,7 +283,6 @@ Ways to convert (buy) cryptocurrency by spending fiat money.
 ### Onion routing
 
 A technology similar to Tor that allows anonymous interactions on a network. All messages are encrypted in various layers akin to an onion. TON Proxy applies such a technique.
-
 
 ## P
 
@@ -324,7 +310,6 @@ Artificially inflating the price of a cryptocurrency or asset.
 
 Transactions among users without the help of a third party or intermediary.
 
-
 ## R
 
 ### Roadmap
@@ -334,7 +319,6 @@ A project's strategic plan that displays when its products, services, and update
 ### Return on investment (ROI)
 
 The profits made from investments.
-
 
 ## S
 
@@ -373,7 +357,6 @@ A way for users to earn a passive income by storing coins or tokens in a proof-o
 ### Swap
 
 The exchange of two financial assets — for example, Toncoin for USDT.
-
 
 ## T
 
@@ -421,13 +404,11 @@ The total value of assets currently locked (for example, staked) in a specific p
 
 A machine that behaves like a decentralized computer. It computes the state of the TON Blockchain after each new block and executes smart contracts.
 
-
 ## V
 
 ### Validator
 
 Those who verify new blocks on TON Blockchain.
-
 
 ## W
 
@@ -458,7 +439,6 @@ A customizable list of cryptocurrencies whose price action an investor wishes to
 ### Workchain
 
 Secondary chains that connect to the masterchain. They can contain a massive number of different connected chains that have their own consensus rules. They can also contain address and transaction information and virtual machines for smart contracts. Additionally, they can be compatible with the masterchain and interact with one another.
-
 
 ## Y
 


### PR DESCRIPTION
- [ ] **1. Horizontal rules used as separators**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#L23

The page uses thematic breaks (`---`) throughout to separate sections (e.g., lines 23, 63, 87, …). The style guide forbids horizontal rules in content. Minimal fix: remove all in‑body `---` separators and rely on headings/whitespace already present.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.5 Thematic breaks

---

- [ ] **2. Sentences start with lowercase letters**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#L9

Multiple definition sentences begin with a lowercase article/pronoun (e.g., lines 9, 13, 17, 21, 29, 37, 41). Minimal fix: capitalize the first letter of each sentence (e.g., “a free…” → “A free…”). This follows standard English grammar for sentence casing.

Rule: General English grammar (basic rule; the style guide assumes correct sentence mechanics)

---

- [ ] **3. Quotation marks used for emphasis on terms**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#L29

Curly quotes are used to emphasize terms in body text (e.g., “bearish”, “bullish” on lines 29 and 57) and in the NFA heading (line 281). Quotes must be reserved for literal UI/log/error strings, not emphasis. Minimal fix: remove quotation marks around terms and keep plain text (e.g., bearish, bullish; Not financial advice (NFA)).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.2 Quotation marks and emphasis; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.4 Formatting restrictions

---

- [ ] **4. Heading casing not in sentence case (acronym expansions)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#L15

Several multi‑word H3 headings use Title Case instead of sentence case, and one has inconsistent capitalization:
- Line 15: “Application Programming Interface (API)” → “Application programming interface (API)”
- Line 19: “Annual Percentage Yield (APY)” → “Annual percentage yield (APY)”
- Line 221: “Initial Coin Offering (ICO)” → “Initial coin offering (ICO)”
- Line 225: “Initial Decentralized exchange Offering (IDO)” → “Initial decentralized exchange offering (IDO)” (also fixes internal inconsistency)
- Line 137: “Do Your Own Research (DYOR)” → “Do your own research (DYOR)”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.1 Case and form (All headings must use sentence case.)

---

- [ ] **5. Ambiguous link text “Website” and “Article”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#L33

Link text like “Website” and “Article” is not descriptive for screen readers or scanning (e.g., lines 33, 73, 77, 367, 45, 53, 259). Minimal fix: replace with descriptive link text:
- Line 33: “Binance website”
- Line 73: “CoinMarketCap website”
- Line 77: “Coinbase website”
- Line 367: “SEC website”
- Line 45: “Bag of Cells (BoC)”
- Line 53: “Oracles & bridges”
- Line 259: “TON overview”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#15.1 Language and reading (Link text and headings must be descriptive.)

---

- [ ] **6. Internal link uses source file extension**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#L53

The “Bridge” entry links to “https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860//ecosystem/oracles.mdx?plain=1”. Internal links should follow repo conventions; elsewhere links omit file extensions (e.g., “/ton/cells/boc”, “/ton/overview”). Minimal fix: change to “/ecosystem/oracles”. If a different canonical route is configured, align to that consistently.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16.3 Links and anchors (consistency for internal links). The guide is silent on extensions; following repo consistency is RECOMMENDED.

---

- [ ] **7. Comma splice in EVM definition**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#L147

“a machine behaving like a decentralized computer, it computes…” joins two independent clauses with a comma. Minimal fix: split into two sentences or use a semicolon: “a machine that behaves like a decentralized computer; it computes…”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.1 Commas, colons, semicolons (Comma splices must not occur.)

---

- [ ] **8. Missing comma after “e.g.”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#L117

Examples omit the comma after “e.g.” (e.g., lines 117 and 117 for domain/IP; 407 for ticker; 435 for TVL). Minimal fix: add a comma: “e.g., ton.org”, “e.g., 192.0.2.44”, “e.g., TON”, “e.g., staked”.

Rule: General American English convention; the style guide defers to standard punctuation where unspecified.

---

- [ ] **9. Bold styling inside link text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#L37

The Bitcoin entry uses bolded link text “[**Wikipedia**]”, which is decorative emphasis. Minimal fix: remove bold: “[Wikipedia]”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.2 Emphasis (use sparingly; prefer structure over visual emphasis in body text)

---

- [ ] **10. Pleonasm: “interact with each other”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#L49

“interact with each other” is redundant. Minimal fix: “interact” (e.g., “to interact — e.g., The Open Network and Telegram”).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.7 Avoid tautology and pleonasm

---

- [ ] **11. Missing article in “Full node” definition**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#L179

“a computer on blockchain” misses the article. Minimal fix: “a computer on the blockchain” (or “on a blockchain,” depending on intended generality).

Rule: General English grammar (basic article usage)

---

- [ ] **12. Inconsistent capitalization of “masterchain” in running text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#L267

Running text uses “Masterchain” (line 267) but elsewhere “masterchain” is lowercase (e.g., line 477 and in other pages, see https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/overview.mdx?plain=1#Network Architecture). Minimal fix: choose one capitalization for running prose and apply consistently (heading can remain “Masterchain” if that is the canonical term). This likely needs a domain decision for the preferred casing.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3 Acronyms and terms (Project terminology must be consistent with the term bank); consistency with nearby pages when the guide is silent.

---

- [ ] **13. Acronym headings not spelled out on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1

Per first-mention rule, spell out the term and follow with the acronym in parentheses. Minimal fixes:
- https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#L103— "DeFi" → "Decentralized finance (DeFi)"
- https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#L173— "FUD" → "Fear, uncertainty, and doubt (FUD)"

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **14. Prefer period over semicolon in TVM definition**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#L439

Semicolons should be rare; prefer shorter sentences. Minimal fix: replace the semicolon with a period — "a machine that behaves like a decentralized computer. It computes the state of the TON blockchain after each new block and executes smart contracts."

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **15. Avoid "etc." in lists**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#L347

Avoid using "etc." in lists; either complete the list or remove the open-ended token. Minimal fix: "… when its products, services, and updates will be released."

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **16. Missing Oxford comma in three-item list**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#L139

Use the serial (Oxford) comma in lists of three or more items. Minimal fix: "… on a project, company, or cryptocurrency …"

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **17. Mis-capitalization in IDO heading**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#L225

“Initial Decentralized exchange Offering (IDO)” mixes cases; “Exchange” should be capitalized for consistency. Rule: general English title casing in headings (style guide is silent on exact casing; apply consistent capitalization per nearby headings). Minimal fix: Initial Decentralized Exchange Offering (IDO).

---

- [ ] **18. Capitalization of “TON Blockchain”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#L291-L447

The term appears as “TON blockchain”; elsewhere in the docs it is capitalized as “TON Blockchain” (proper noun). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms — project terminology must be consistent; cite: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/overview.mdx?plain=1#L6 (“TON Blockchain”). Minimal fix: capitalize to “TON Blockchain” in these occurrences.

---

- [ ] **19. Tautology in Toncoin definition**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#L427

“… pay for fees and services.” repeats “services”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references — remove pleonasm. Minimal fix: “… used to develop services and pay fees.”

---

- [ ] **20. Prefer plain English over Latinisms (e.g., i.e.)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#L49-L421

Latin abbreviations “e.g.” and “i.e.” are used in prose. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording — prefer common words over Latinisms. Minimal fix examples: “for example” instead of “e.g.” (with a comma), and “that is” instead of “i.e.”

---

- [ ] **21. Unnecessary comma in compound clause**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#L125

“… through which people can donate money, and content creators can monetize …” inserts a comma before “and” that splits a compound predicate unnaturally. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons — avoid incorrect comma breaks; prefer shorter, clear sentences. Minimal fix: remove the comma: “… through which people can donate money and content creators can monetize …”.

---

- [ ] **22. Unofficial external link and bolded link text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#L37

The entry links to Wikipedia with bolded link text: [**Wikipedia**](https://en.wikipedia.org/wiki/Bitcoin). Rules: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis — use bold sparingly in body text; and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#severity-model-release-blocking (Global overrides) — avoid unofficial links when an official source exists. Minimal fix: remove bold from the link text, and replace the link with the project’s official site or omit the external link. This requires a domain decision from the content owner.

---

- [ ] **23. Wordy phrasing in “Shard” definition**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1#L371

“… — something which TON blockchain does.” is wordy and uses inconsistent capitalization. Rules: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references — collapse wordy boilerplate; and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms — keep terminology/capitalization consistent. Minimal fix: “… — which the TON Blockchain uses.”