### PR TITLE
[AI] fix: tvm.mdx

### DIFF
--- a/ton/tvm.mdx
+++ b/ton/tvm.mdx
@@ -1,36 +1,35 @@
 ---
-title: "Telegram Open Network Virtual Machine"
+title: "Telegram Open Network virtual machine"
 sidebarTitle: "TVM"
 description: "Whitepaper by Dr. Nikolai Durov"
 ---
 
 **Author**: Nikolai Durov <br />
-**Date**: March 23, 2020 <br />
-<Icon icon="file-pdf" size={16} />: [Original whitepaper, PDF](/resources/pdfs/tvm.pdf)
+**Date**: 2020-03-23 <br />
+<Icon icon="file-pdf" size={16} />: [Original whitepaper, PDF](../resources/pdfs/tvm.pdf)
 
 ## Abstract
 
-The aim of this text is to provide a description of the Telegram Open Network Virtual Machine (TON VM or TVM), used to execute smart contracts in the TON Blockchain.
+Describes the Telegram Open Network virtual machine (TON VM or TVM), used to execute smart contracts on the TON Blockchain.
 
 ## 1 Introduction
 
-The primary purpose of the Telegram Open Network Virtual Machine (TON VM or TVM) is to execute smart-contract code in the TON Blockchain.
+The primary purpose of the Telegram Open Network Virtual Machine (TON VM or TVM) is to execute smart contract code in the TON Blockchain.
 TVM must support all operations required to parse incoming messages and persistent data, and to create new messages and modify persistent data.
 
 Additionally, TVM must meet the following requirements:
 
 - **Backward compatibility:** It must provide for possible future extensions and improvements while retaining backward compatibility and interoperability, because the code of a smart contract, once committed into the blockchain, must continue working in a predictable manner regardless of any future modifications to the VM.
-- **Code density:** It must strive to attain high “(virtual) machine code” density, so that the code of a typical smart contract occupies as little persistent blockchain storage as possible.
+- **Code density:** It must strive to attain high (virtual) machine code density, so that the code of a typical smart contract occupies as little persistent blockchain storage as possible.
 - **Determinism:** It must be completely deterministic. In other words, each run of the same code with the same input data must produce the same result, regardless of specific software and hardware used. <sup>[1](#footnote-1)</sup>
 
 The design of TVM is guided by these requirements. While this document describes a preliminary and experimental version of TVM, <sup>[2](#footnote-2)</sup>, the backward compatibility mechanisms built into the system allow us to be relatively unconcerned with the efficiency of the operation encoding used for TVM code in this preliminary version.
 
-TVM is not intended to be implemented in hardware (e.g., in a specialized microprocessor chip); rather, it should be implemented in software running on conventional hardware. This consideration lets us incorporate some high-level concepts and operations in TVM that would require convoluted microcode in a hardware implementation but pose no significant problems for a software implementation. Such operations are useful for achieving high code density and minimizing the byte (or storage cell) profile of smart-contract code when deployed in the TON Blockchain.
+TVM is not intended to be implemented in hardware (e.g., in a specialized microprocessor chip); rather, it should be implemented in software running on conventional hardware. This consideration lets us incorporate some high-level concepts and operations in TVM that would require convoluted microcode in a hardware implementation but pose no significant problems for a software implementation. Such operations are useful for achieving high code density and minimizing the byte (or storage cell) profile of smart contract code when deployed in the TON Blockchain.
 
----
-# 1 Overview
+## 1 Overview
 
-This chapter provides an overview of the main features and design principles of TVM. More detail on each topic is provided in subsequent chapters.
+Overview of the main features and design principles of TVM. More detail on each topic is provided in subsequent chapters.
 
 ## 1.0 Notation for bitstrings
 
@@ -49,7 +48,7 @@ If the length of a binary string is not divisible by four, we augment it by one 
 
 The reverse transformation (applied if the completion tag is present) consists in first replacing each hexadecimal digit by four corresponding bits, and then removing all trailing zeroes (if any) and the last `1` immediately preceding them (if the resulting bitstring is non-empty at this point).
 
-Notice that there are several admissible hexadecimal representations for the same bitstring. Among them, the shortest one is “canonical”. It can be deterministically obtained by the above procedure.
+Notice that there are several admissible hexadecimal representations for the same bitstring. Among them, the shortest one is canonical. It can be deterministically obtained by the above procedure.
 
 For example:
 - `8A` corresponds to binary string `10001010`.
@@ -67,7 +66,7 @@ This should not be confused with hexadecimal numbers, usually prepended by `0x` 
 
 When a bitstring needs to be represented as a sequence of 8-bit bytes (octets), which take values in integers 0…255, this is achieved essentially in the same fashion as above: we split the bitstring into groups of eight bits and interpret each group as the binary representation of an integer 0…255.
 
-If the length of the bitstring is not a multiple of eight, the bitstring is augmented by a binary `1` and up to seven binary `0`s before being split into groups. The fact that such a completion has been applied is usually reflected by a “completion tag” bit.
+If the length of the bitstring is not a multiple of eight, the bitstring is augmented by a binary `1` and up to seven binary `0`s before being split into groups. The fact that such a completion has been applied is usually reflected by a completion tag bit.
 
 For instance, `00101101100` corresponds to the sequence of two octets `(0x2d, 0x90)` (hexadecimal), or `(45, 144)` (decimal), along with a completion tag bit equal to 1 (meaning that the completion has been applied), which must be stored separately.
 
@@ -77,13 +76,13 @@ In some cases, it is more convenient to assume the completion is enabled by defa
 
 ## 1.1 TVM is a stack machine
 
-First of all, TVM is a stack machine. This means that, instead of keeping values in some “variables” or “general-purpose registers”, they are kept in a (LIFO) stack, at least from the “low-level” (TVM) perspective.<sup>[3](#footnote-3)</sup>
+First of all, TVM is a stack machine. This means that, instead of keeping values in some variables or general-purpose registers, they are kept in a (LIFO) stack, at least from the “low-level” (TVM) perspective.<sup>[3](#footnote-3)</sup>
 
 Most operations and user-defined functions take their arguments from the top of the stack, and replace them with their result. For example, the integer addition primitive (built-in operation) `ADD` does not take any arguments describing which registers or immediate values should be added together and where the result should be stored. Instead, the two top values are taken from the stack, they are added together, and their sum is pushed into the stack in their place.
 
 ### 1.1.1 TVM values
 
-The entities that can be stored in the TVM stack will be called **TVM values**, or simply **values** for brevity. They belong to one of several predefined value types. Each value belongs to exactly one value type.
+The entities that can be stored in the TVM stack will be called **TVM values**, or **values** for brevity. They belong to one of several predefined value types. Each value belongs to exactly one value type.
 
 The values are always kept on the stack along with tags uniquely determining their types, and all built-in TVM operations (or primitives) only accept values of predefined types.
 
@@ -91,7 +90,7 @@ For example, the integer addition primitive `ADD` accepts only two integer value
 
 ### 1.1.2 Static typing, dynamic typing, and run-time type checking
 
-In some respects TVM performs a kind of dynamic typing using run-time type checking. However, this does not make the TVM code a “dynamically typed language” like PHP or Javascript, because all primitives accept values and return results of predefined (value) types, each value belongs to strictly one type, and values are never implicitly converted from one type to another.
+In some respects TVM performs a kind of dynamic typing using run-time type checking. However, this does not make the TVM code a dynamically typed language like PHP or Javascript, because all primitives accept values and return results of predefined (value) types, each value belongs to strictly one type, and values are never implicitly converted from one type to another.
 
 If, on the other hand, one compares the TVM code to the conventional microprocessor machine code, one sees that the TVM mechanism of value tagging prevents, for example, using the address of a string as a number—or, potentially even more disastrously, using a number as the address of a string—thus eliminating the possibility of all sorts of bugs and security vulnerabilities related to invalid memory accesses, usually leading to memory corruption and segmentation faults.
 
@@ -107,13 +106,13 @@ All type tags attached to values processed by TVM will always have expected valu
 
 A preliminary list of value types supported by TVM is as follows:
 
-- **Integer** — Signed 257-bit integers, representing integer numbers in the range `−2²⁵⁶ … 2²⁵⁶ − 1`, as well as a special “not-a-number” value `NaN`.
+- **Integer** — Signed 257-bit integers, representing integer numbers in the range `−2²⁵⁶ … 2²⁵⁶ − 1`, as well as a special not-a-number value `NaN`.
 - **Cell** — A TVM cell consists of at most 1023 bits of data, and of at most four references to other cells. All persistent data (including TVM code) in the TON Blockchain is represented as a collection of TVM cells (cf. [1](#reference-1) 2.5.14]).
 - **Tuple** — An ordered collection of up to 255 components, having arbitrary value types, possibly distinct. May be used to represent nonpersistent values of arbitrary algebraic data types.
 - **Null** — A type with exactly one value `⊥`, used for representing empty lists, empty branches of binary trees, absence of return value in some situations, and so on.
-- **Slice** — A TVM cell slice, or slice for short, is a contiguous “sub-cell” of an existing cell, containing some of its bits of data and some of its references. Essentially, a slice is a read-only view for a subcell of a cell. Slices are used for unpacking data previously stored (or serialized) in a cell or a tree of cells.
-- **Builder** — A TVM cell builder, or builder for short, is an “incomplete” cell that supports fast operations of appending bitstrings and cell references at its end. Builders are used for packing (or serializing) data from the top of the stack into new cells (e.g., before transferring them to persistent storage).
-- **Continuation** — Represents an “execution token” for TVM, which may be invoked (executed) later. As such, it generalizes function addresses (i.e., function pointers and references), subroutine return addresses, instruction pointer addresses, exception handler addresses, closures, partial applications, anonymous functions, and so on.
+- **Slice** — A TVM cell slice, or slice for short, is a contiguous sub-cell of an existing cell, containing some of its bits of data and some of its references. Essentially, a slice is a read-only view for a subcell of a cell. Slices are used for unpacking data previously stored (or serialized) in a cell or a tree of cells.
+- **Builder** — A TVM cell builder, or builder for short, is an incomplete cell that supports fast operations of appending bitstrings and cell references at its end. Builders are used for packing (or serializing) data from the top of the stack into new cells (e.g., before transferring them to persistent storage).
+- **Continuation** — Represents an execution token for TVM, which may be invoked (executed) later. As such, it generalizes function addresses (i.e., function pointers and references), subroutine return addresses, instruction pointer addresses, exception handler addresses, closures, partial applications, anonymous functions, and so on.
 
 This list of value types is incomplete and may be extended in future revisions of TVM without breaking the old TVM code, due mostly to the fact that all originally defined primitives accept only values of types known to them and will fail (generate a type-checking exception) if invoked on values of new types.
 
@@ -133,7 +132,7 @@ They fall into several categories, depending on the types of values (cf. [1.1.3]
 - **Tuple (manipulation) primitives** — Construct, modify, and decompose Tuples. Similarly to the stack primitives, they are polymorphic.
 - **Constant or literal primitives** — Push into the stack some “constant” or “literal” values embedded into the TVM code itself, thus providing arguments to the other primitives. They are somewhat similar to stack primitives, but are less generic because they work with values of specific types.
 - **Arithmetic primitives** — Perform the usual integer arithmetic operations on values of type `Integer`.
-- **Cell (manipulation) primitives** — Create new cells and store data in them (cell creation primitives) or read data from previously created cells (cell parsing primitives). Because all memory and persistent storage of TVM consists of cells, these cell manipulation primitives actually correspond to “memory access instructions” of other architectures. Cell creation primitives usually work with values of type `Builder`, while cell parsing primitives work with `Slices`.
+- **Cell (manipulation) primitives** — Create new cells and store data in them (cell creation primitives) or read data from previously created cells (cell parsing primitives). Because all memory and persistent storage of TVM consists of cells, these cell manipulation primitives actually correspond to memory access instructions of other architectures. Cell creation primitives usually work with values of type `Builder`, while cell parsing primitives work with `Slices`.
 - **Continuation and control flow primitives** — Create and modify `Continuations`, as well as execute existing `Continuations` in different ways, including conditional and repeated execution.
 - **Custom or application-specific primitives** — Efficiently perform specific high-level actions required by the application (in our case, the TON Blockchain), such as computing hash functions, performing elliptic curve cryptography, sending new blockchain messages, creating new smart contracts, and so on. These primitives correspond to standard library functions rather than microprocessor instructions.
 
@@ -176,13 +175,13 @@ The total state of TVM consists of the following components:
 
 Notice that there is no “return stack” containing the return addresses of all previously called but unfinished functions. Instead, only control register `c0` is used. The reason for this will be explained later in [4.1.9](#4-1-9-subroutine-calls%3A-callx-or-execute-primitives).
 
-Also notice that there are no general-purpose registers, because TVM is a stack machine (cf. [1.1](#1-1-tvm-is-a-stack-machine)). So the above list, which can be summarized as **“stack, control, continuation, codepage, and gas” (SCCCG)**, similarly to the classical SECD machine state (“stack, environment, control, dump”), is indeed the total state of TVM.<sup>[5](#footnote-5)</sup>
+Also notice that there are no general-purpose registers, because TVM is a stack machine (cf. [1.1](#1-1-tvm-is-a-stack-machine)). So the above list, which can be summarized as **stack, control, continuation, codepage, and gas (SCCCG)**, similarly to the classical SECD machine state (stack, environment, control, dump), is indeed the total state of TVM.<sup>[5](#footnote-5)</sup>
 
 ---
 
 ## 1.5 Integer arithmetic
 
-All arithmetic primitives of TVM operate on several arguments of type `Integer`, taken from the top of the stack, and return their results, of the same type, into the stack. Recall that `Integer` represents all integer values in the range `−2²⁵⁶ ≤ x < 2²⁵⁶`, and additionally contains a special value `NaN` (“not-a-number”).
+All arithmetic primitives of TVM operate on several arguments of type `Integer`, taken from the top of the stack, and return their results, of the same type, into the stack. Recall that `Integer` represents all integer values in the range `−2²⁵⁶ ≤ x < 2²⁵⁶`, and additionally contains a special value `NaN` (not-a-number).
 
 If one of the results does not fit into the supported range of integers—or if one of the arguments is a `NaN`—then this result or all of the results are replaced by a `NaN`, and (by default) an integer overflow exception is generated. However, special “quiet” versions of arithmetic operations will simply produce `NaN`s and keep going. If these `NaN`s end up being used in a “non-quiet” arithmetic operation, or in a non-arithmetic operation, an integer overflow exception will occur.
 
@@ -234,9 +233,9 @@ If `c` is zero or if the quotient does not fit into `Integer`, either two `NaN`s
 
 ---
 
-# 2 The stack
+## 2 The stack
 
-This chapter contains a general discussion and comparison of register and stack machines, expanded further in [Appendix C](#c-code-density-of-stack-and-register-machines), and describes the two main classes of stack manipulation primitives employed by TVM: the basic and the compound stack manipulation primitives. An informal explanation of their sufficiency for all stack reordering required for correctly invoking other primitives and user-defined functions is also provided. Finally, the problem of efficiently implementing TVM stack manipulation primitives is discussed in [2.3](#2-3-...).
+This chapter contains a general discussion and comparison of register and stack machines, expanded further in [Appendix C](#c-code-density-of-stack-and-register-machines), and describes the two main classes of stack manipulation primitives employed by TVM: the basic and the compound stack manipulation primitives. An informal explanation of their sufficiency for all stack reordering required for correctly invoking other primitives and user-defined functions is also provided. Finally, the problem of efficiently implementing TVM stack manipulation primitives is discussed in [2.3](#2-3-efficiency-of-stack-manipulation-primitives).
 
 ## 2.1 Stack calling conventions
 
@@ -402,7 +401,7 @@ For example, `SWAP` always interchanges the two top values of the stack, even if
 
 Stack manipulation primitives employed by a stack machine, such as TVM, have to be implemented very efficiently, because they constitute more than half of all the instructions used in a typical program. In fact, TVM performs all these instructions in a (small) constant time, regardless of the values involved (even if they represent very large integers or very large trees of cells).
 
-### 2.3.1 Implementation of stack manipulation primitives: using references for operations instead of objects
+### 2.3.1 Implementation: use references instead of objects
 
 The efficiency of TVM’s implementation of stack manipulation primitives results from the fact that a typical TVM implementation keeps in the stack not the value objects themselves, but only the references (pointers) to such objects.
 
@@ -440,7 +439,7 @@ This property also applies to all other data structures: for instance, the absen
 
 ---
 
-# 3 Cells, memory, and persistent storage
+## 3 Cells, memory, and persistent storage
 
 This chapter briefly describes TVM cells, used to represent all data structures inside the TVM memory and its persistent storage, and the basic operations used to create cells, write (or serialize) data into them, and read (or deserialize) data from them.
 
@@ -488,9 +487,9 @@ When a cell needs to be transferred by a network protocol or stored in a disk fi
   * Byte `d₁` equals `r + 8s + 32ℓ`, where `0 ≤ r ≤ 4` is the quantity of cell references contained in the cell, `0 ≤ ℓ ≤ 3` is the level of the cell, and `0 ≤ s ≤ 1` is `1` for exotic cells and `0` for ordinary cells.
   * Byte `d₂` equals `⌊b / 8⌋ + ⌈b / 8⌉`, where `0 ≤ b ≤ 1023` is the quantity of data bits in `c`.
 
-2. Then the data bits are serialized as `⌈b/8⌉` 8-bit octets (bytes). If `b` is not a multiple of eight, a binary `1` and up to six binary `0`s are appended to the data bits. After that, the data is split into `⌈b/8⌉` eight-bit groups, and each group is interpreted as an unsigned big-endian integer 0…255 and stored into an octet.
+1. Then the data bits are serialized as `⌈b/8⌉` 8-bit octets (bytes). If `b` is not a multiple of eight, a binary `1` and up to six binary `0`s are appended to the data bits. After that, the data is split into `⌈b/8⌉` eight-bit groups, and each group is interpreted as an unsigned big-endian integer 0…255 and stored into an octet.
 
-3. Finally, each of the `r` cell references is represented by 32 bytes containing the 256-bit representation hash `Hash(cᵢ)` (explained in [3.1.5](#3-1-5-the-representation-hash-of-a-cell)) of the cell `cᵢ` referred to.
+1. Finally, each of the `r` cell references is represented by 32 bytes containing the 256-bit representation hash `Hash(cᵢ)` (explained in [3.1.5](#3-1-5-the-representation-hash-of-a-cell)) of the cell `cᵢ` referred to.
 
 In this way, `2 + ⌈b/8⌉ + 32r` bytes of `CellRepr(c)` are obtained.
 
@@ -514,17 +513,17 @@ By convention, we set `Hash∞(c) := Hash(c)`, and `Hashᵢ(c) := Hash∞(c) = H
 
 TVM currently supports the following cell types:
 
-* **Type −1: Ordinary cell** — Contains up to 1023 bits of data and up to four cell references.
+ - **Type −1: Ordinary cell** — Contains up to 1023 bits of data and up to four cell references.
 
-* **Type 1: Pruned branch cell `c`** — May have any level `1 ≤ ℓ ≤ 3`.
+ - **Type 1: Pruned branch cell `c`** — May have any level `1 ≤ ℓ ≤ 3`.
   Contains exactly `8 + 256ℓ` data bits: first an 8-bit integer equal to `1` (the cell’s type), then its `ℓ` higher hashes `Hash₁(c), …, Hashℓ(c)`.
   The level `ℓ` may be called its **de Brujn index**, because it determines the outer Merkle proof or Merkle update during which the branch has been pruned.
   An attempt to load a pruned branch cell usually leads to an exception.
 
-* **Type 2: Library reference cell** — Always has level 0, and contains `8 + 256` data bits, including its 8-bit type integer `2` and the representation hash `Hash(c₀)` of the library cell being referred to.
+ - **Type 2: Library reference cell** — Always has level 0, and contains `8 + 256` data bits, including its 8-bit type integer `2` and the representation hash `Hash(c₀)` of the library cell being referred to.
   When loaded, a library reference cell may be transparently replaced by the cell it refers to, if found in the current library context.
 
-* **Type 3: Merkle proof cell `c`** — Has exactly one reference `c₁` and level `0 ≤ ℓ ≤ 3`, which must be one less than the level of its only child `c₁`:
+ - **Type 3: Merkle proof cell `c`** — Has exactly one reference `c₁` and level `0 ≤ ℓ ≤ 3`, which must be one less than the level of its only child `c₁`:
 
   ```math
   Lvl(c) = max(Lvl(c₁) − 1, 0)
@@ -535,7 +534,7 @@ TVM currently supports the following cell types:
   The higher hashes `Hashᵢ(c)` of `c` are computed similarly to the higher hashes of an ordinary cell, but with `Hashᵢ₊₁(c₁)` used instead of `Hashᵢ(c₁)`.
   When loaded, a Merkle proof cell is replaced by `c₁`.
 
-* **Type 4: Merkle update cell `c`** — Has two children `c₁` and `c₂`. Its level `0 ≤ ℓ ≤ 3` is given by:
+ - **Type 4: Merkle update cell `c`** — Has two children `c₁` and `c₂`. Its level `0 ≤ ℓ ≤ 3` is given by:
 
   ```math
   Lvl(c) = max(Lvl(c₁) − 1, Lvl(c₂) − 1, 0)
@@ -763,9 +762,9 @@ On the other hand, if `m > 0`, a value of type `HashmapNode m X` corresponds to 
 
 There are several ways to serialize a label of length at most `n`, if its exact length is `ℓ ≤ n` (recall that the exact length must be deducible from the serialization of the label itself, while the upper bound `n` is known before the label is serialized or deserialized). These ways are described by the three constructors `hml_short`, `hml_long`, and `hml_same` of type `HmLabel ~l n`:
 
-* **`hml_short`** — Describes a way to serialize “short” labels, of small length `ℓ ≤ n`. Such a serialization consists of a binary `0` (the constructor tag of `hml_short`), followed by `l` binary `1`s and one binary `0` (the unary representation of the length `l`), followed by `l` bits comprising the label itself.
-* **`hml_long`** — Describes a way to serialize “long” labels, of arbitrary length `ℓ ≤ n`. Such a serialization consists of a binary `10` (the constructor tag of `hml_long`), followed by the big-endian binary representation of the length `0 ≤ l ≤ n` in `⌈log2(n + 1)⌉` bits, followed by `l` bits comprising the label itself.
-* **`hml_same`** — Describes a way to serialize “long” labels, consisting of `ℓ` repetitions of the same bit `v`. Such a serialization consists of `11` (the constructor tag of `hml_same`), followed by the bit `v`, followed by the length `l` stored in `⌈log2(n + 1)⌉` bits as before.
+ - `hml_short` — Describes a way to serialize “short” labels, of small length `ℓ ≤ n`. Such a serialization consists of a binary `0` (the constructor tag of `hml_short`), followed by `l` binary `1`s and one binary `0` (the unary representation of the length `l`), followed by `l` bits comprising the label itself.
+ - `hml_long` — Describes a way to serialize “long” labels, of arbitrary length `ℓ ≤ n`. Such a serialization consists of a binary `10` (the constructor tag of `hml_long`), followed by the big-endian binary representation of the length `0 ≤ l ≤ n` in `⌈log2(n + 1)⌉` bits, followed by `l` bits comprising the label itself.
+ - `hml_same` — Describes a way to serialize “long” labels, consisting of `ℓ` repetitions of the same bit `v`. Such a serialization consists of `11` (the constructor tag of `hml_same`), followed by the bit `v`, followed by the length `l` stored in `⌈log2(n + 1)⌉` bits as before.
 
 Each label can always be serialized in at least two different fashions, using `hml_short` or `hml_long` constructors. Usually the shortest serialization (and in the case of a tie—the lexicographically smallest among the shortest) is preferred and is generated by TVM hashmap primitives, while the other variants are still considered valid.
 
@@ -868,15 +867,13 @@ Let us present a classification of basic operations with dictionaries (i.e., val
 
 The dictionary primitives, described in detail in [A.10](#a-10), can be classified according to the following categories:
 
-* Which dictionary operation (cf. [3.3.10](#3-3-10-basic-dictionary-operations)) do they perform?
-* Are they specialized for the case `X = ^Y`? If so, do they represent values of type `Y` by `Cell`s or by `Slice`s? (Generic versions always represent values of type `X` as `Slice`s.)
-* Are the dictionaries themselves passed and returned as `Cell`s or as `Slice`s? (Most primitives represent dictionaries as `Slice`s.)
-* Is the key length `n` fixed inside the primitive, or is it passed in the stack?
-* Are the keys represented by `Slice`s, or by signed or unsigned `Integer`s?
+- Which dictionary operation (cf. [3.3.10](#3-3-10-basic-dictionary-operations)) do they perform?
+- Are they specialized for the case `X = ^Y`? If so, do they represent values of type `Y` by `Cell`s or by `Slice`s? (Generic versions always represent values of type `X` as `Slice`s.)
+- Are the dictionaries themselves passed and returned as `Cell`s or as `Slice`s? (Most primitives represent dictionaries as `Slice`s.)
+- Is the key length `n` fixed inside the primitive, or is it passed in the stack?
+- Are the keys represented by `Slice`s, or by signed or unsigned `Integer`s?
 
 In addition, TVM includes special serialization/deserialization primitives, such as `STDICT`, `LDDICT`, and `PLDDICT`. They can be used to extract a dictionary from a serialization of an encompassing object, or to insert a dictionary into such a serialization.
-
----
 
 ## 3.4 Hashmaps with variable-length keys
 
@@ -909,8 +906,6 @@ vhme_empty$0 {n:#} {X:Type} = VarHashmapE n X;
 vhme_root$1 {n:#} {X:Type} root:^(VarHashmap n X)
 = VarHashmapE n X;
 ```
----
-
 ### 3.4.2. Serialization of prefix codes
 
 One special case of a dictionary with variable-length keys is that of a **prefix code**, where the keys cannot be prefixes of each other. Values in such dictionaries may occur only in the leaves of a Patricia tree.
@@ -934,7 +929,7 @@ phme_root$1 {n:#} {X:Type} root:^(PfxHashmap n X)
 ```
 ---
 
-# 4 Control flow, continuations, and exceptions
+## 4 Control flow, continuations, and exceptions
 
 This chapter describes continuations, which may represent execution tokens and exception handlers in TVM. Continuations are deeply involved with the control flow of a TVM program; in particular, subroutine calls and conditional and iterated execution are implemented in TVM using special primitives that accept one or more continuations as their arguments.
 
@@ -1014,7 +1009,7 @@ Apart from doing the stack manipulations described in [4.1.6](#4-1-6-switching-t
 
 In this way, the called subroutine can return control to the caller by switching the current continuation to the return continuation saved in `c0`. Nested subroutine calls work correctly because the previous value of `c0` ends up saved into the new `c0`’s control register savelist `c0.save`, from which it is restored later.
 
-### 4.1.10 Determining the number of arguments passed to and/or return values accepted from a subroutine
+### 4.1.10 Determining the number of arguments passed to and return values accepted from a subroutine
 
 Similarly to `JMPX` and `RET`, `CALLX` also has special (rarely used) forms, which allow us to explicitly specify the number `n''` of arguments passed from the current stack to the called subroutine (by default, `n''` equals the depth of the current stack, i.e., it is passed in its entirety). Furthermore, a second number `n'''` can be specified, used to set `nargs` of the modified `cc` continuation before storing it into the new `c0`; the new `nargs` equals the depth of the old stack minus `n''` plus `n'''`.
 
@@ -1162,7 +1157,7 @@ Every exception is characterized by two arguments: the **exception number** (an 
 
 There are several special primitives used for throwing an exception. The most general of them, `THROWANY`, takes two arguments, `v` and `0 ≤ n < 2¹⁶` from the stack, and throws the exception with number `n` and value `v`.
 
-There are variants of this primitive that assume `v` to be a zero integer, store `n` as a literal value, and/or are conditional on an integer value taken from the stack. User-defined exceptions may use arbitrary values as `v` (e.g., trees of cells) if needed.
+There are variants of this primitive that assume `v` to be a zero integer, store `n` as a literal value, or both are conditional on an integer value taken from the stack. User-defined exceptions may use arbitrary values as `v` (e.g., trees of cells) if needed.
 
 ### 4.5.3. Exceptions generated by TVM
 
@@ -1338,7 +1333,7 @@ Yet another alternative is to use a Hashmap (cf. [3.3](#3-3-hashmaps%2C-or-dicti
 
 ---
 
-# 5 Codepages and instruction encoding
+## 5 Codepages and instruction encoding
 
 This chapter describes the codepage mechanism, which allows TVM to be flexible and extendable while preserving backward compatibility with respect to previously generated code.
 
@@ -1480,7 +1475,7 @@ The list of all instructions available in codepage zero, along with their encodi
 
 ---
 
-# A Instructions and opcodes
+## A Instructions and opcodes
 This appendix lists all instructions available in the (experimental) codepage zero of TVM, as explained in [5.3](#5-3-instruction-encoding-in-codepage-zero).
 We list the instructions in lexicographical opcode order. However, the opcode space is distributed in such way as to make all instructions in each category (e.g., arithmetic primitives) have neighboring opcodes. So we first list a number of stack manipulation primitives, then constant primitives, arithmetic primitives, comparison primitives, cell primitives, continuation primitives, dictionary primitives, and finally application-specific primitives.
 
@@ -2767,7 +2762,7 @@ Most of the loop primitives listed below are implemented with the aid of extraor
 
 ---
 
-# A.10 Dictionary manipulation primitives
+## A.10 Dictionary manipulation primitives
 
 TVM’s dictionary support is discussed at length in [3.3](#3-3-hashmaps%2C-or-dictionaries). The basic operations with dictionaries are listed in [3.3.10](#3-3-10-basic-dictionary-operations), while the taxonomy of dictionary manipulation primitives is provided in [3.3.11](#3-3-11-taxonomy-of-dictionary-primitives). Here we use the concepts and notation introduced in those sections.
 
@@ -3528,7 +3523,7 @@ The following primitives, which begin with byte `FF`, typically are used at the 
 * `FFF0` — `SETCPX` `(c – )`, selects codepage `c` with `−−2¹⁵ ≤ c < 2¹⁵` passed in the top of the stack.
 ---
 
-# B Formal properties and specifications of TVM
+## B Formal properties and specifications of TVM
 
 This appendix discusses certain formal properties of TVM that are necessary for executing smart contracts in the TON Blockchain and validating such executions afterwards.
 
@@ -3679,7 +3674,7 @@ All 64-bit arithmetic used in codepage −1 would then need to be defined by mea
 
 ---
 
-# C Code density of stack and register machines
+## C Code density of stack and register machines
 
 This appendix extends the general consideration of stack manipulation primitives provided in [2.2](#2-2-stack-manipulation-primitives), explaining the choice of such primitives for TVM, with a comparison of stack machines and register machines in terms of the quantity of primitives used and the code density. We do this by comparing the machine code that might be generated by an optimizing compiler for the same source files, for different (abstract) stack and register machines.
 
@@ -3928,7 +3923,7 @@ It is interesting to note that this version of stack machine code contains only 
 
 ----
 
-# C.2 Comparison of machine code for sample leaf function
+## C.2 Comparison of machine code for sample leaf function
 
 Table&nbsp;1 summarizes the properties of machine code corresponding to the same source file described in [C.1.1](#c-1-1-sample-source-file-for-a-leaf-function), generated for a hypothetical three-address register machine (cf. [C.1.2](#c-1-2-three-address-register-machine)), with both “optimistic” and “realistic” instruction encodings; a two-address machine (cf. [C.1.3](#c-1-3-two-address-register-machine)); a one-address machine (cf. [C.1.4](#c-1-4-one-address-register-machine)); and a stack machine, similar to TVM, using either only the basic stack manipulation primitives (cf. [C.1.5](#c-1-5-stack-machine-with-basic-primitives)) or both the basic and the composite stack primitives (cf. [C.1.7](#c-1-7-stack-machine-with-compound-primitives)).
 
@@ -4097,7 +4092,7 @@ This time we can use fractions of bytes to encode instructions, so as to match o
 
 ---
 
-# C.3 Sample non-leaf function
+## C.3 Sample non-leaf function
 
 This section compares the machine code for different register machines for a sample non-leaf function. Again, we assume that either `m = 0`, `m = 8`, or `m = 16` registers are preserved by called functions, with `m = 8` representing the compromise made by most modern compilers and operating systems.
 


### PR DESCRIPTION
- [ ] **1. Broken deep links to compute/action anchors**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/exit-codes.mdx?plain=1#L69

The reference links `[c]` and `[a]` target `/tvm/overview#compute-phase` and `/tvm/overview#action-phase`, but `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/overview.mdx?plain=1` has no such anchors, so these links do not resolve. Minimal fix: change `[c]` and `[a]` to `/tvm/overview` (page top) or update them to valid anchors once they exist. Example: `[c]: /tvm/overview` and `[a]: /tvm/overview`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12.3-link-targets-and-format

---

- [ ] **2. Heading contains quotation marks**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/exit-codes.mdx?plain=1#L361

Heading `### 11: "Unknown" error` uses quotation marks in a heading, which the guide prohibits. Minimal fix: remove quotes → `### 11: Unknown error`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#headings-and-titles

---

- [ ] **3. “etc.” used in a list**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/exit-codes.mdx?plain=1#L435

The sentence ends with “etc.” in a list context: “invalid message, unsupported action, etc.” The guide says not to use “etc.” in lists. Minimal fix: remove “etc.” or replace with “for example” and stop. Suggested: “invalid message or unsupported action.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **4. Acronym not expanded on first mention (TON)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/exit-codes.mdx?plain=1#L9

First mention is “TON Blockchain” without expanding the acronym. Minimal fix: “The Open Network (TON) Blockchain”. Optionally link TON on first useful mention to the Glossary.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms

---

- [ ] **5. Acronym not expanded on first mention (TVM)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/exit-codes.mdx?plain=1#L33

First mention is “Invalid TVM opcode” without expanding TVM. Minimal fix: “Invalid TON Virtual Machine (TVM) opcode” on first mention; use TVM thereafter.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms

---

- [ ] **6. Non-inclusive/humorous comment in code**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/exit-codes.mdx?plain=1#L153

Comment: “Remember kids, don't try to overflow the stack at home!” violates the guidance to avoid idioms and humor in instructional comments. Minimal fix: replace with a neutral, instructional comment such as “Do not attempt to overflow the stack.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10.5-comments-and-omissions; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.5-global-and-inclusive-language

---

- [ ] **7. Hedging/filler phrasing (“Often enough”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/exit-codes.mdx?plain=1#L65

Phrase “Often enough, you might encounter…” is hedging/filler. Minimal fix: “You might encounter exit code 65535 (or `0xffff`)…” or “You may encounter…”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording

---

- [ ] **8. Broken internal anchor `#blueprint`**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/exit-codes.mdx?plain=1#L417

Link text “Sandbox and Blueprint” points to `#blueprint`, but no such anchor exists on this page. Minimal fix: link to the canonical page `(/ecosystem/blueprint/overview)` or to the local section `(#exit-codes-in-blueprint-projects)` if the intent is to jump within the page.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12.3-link-targets-and-format

---

- [ ] **9. Quotation punctuation inside closing quotes (table cell)**

`https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/exit-codes.mdx?plain=1#L38`

The table text ends with a period inside the closing quote: “Unknown error, may be thrown by user programs.” Per house style, punctuation should be outside unless part of the quoted string. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis. Minimal fix: move the period outside: `… "Unknown error, may be thrown by user programs".`

---

- [ ] **10. Quotation punctuation inside closing quotes (body text)**

`https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/exit-codes.mdx?plain=1#L363`

The sentence places a comma inside the closing quote: “… described as "Unknown error, may be thrown by user programs," although …”. Per house style, punctuation must remain outside unless part of the quoted text. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis. Minimal fix: `… "Unknown error, may be thrown by user programs", although …`.

---

- [ ] **11. Cultural/idiomatic strings in examples**

`https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/exit-codes.mdx?plain=1#L132-L347`

Example receiver strings use a cultural reference: “I solemnly swear that I'm up to no good”. Avoid idioms and culture‑specific phrases; use neutral, descriptive text. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#15-1-language-and-reading. Minimal fix: replace with a neutral literal, e.g., `"example"` or `"test message"`.

---

- [ ] **12. Idiomatic phrasing in explanation (“trenches”)**

`https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/exit-codes.mdx?plain=1#L151`

Phrase “unless you're deep in the … trenches” is an idiom. Use plain, international English. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#15-1-language-and-reading. Minimal fix: “This occurs rarely unless you are working directly with Fift and TVM assembly.”

---

- [ ] **13. Non‑canonical unit name casing (“nanoToncoin[s]”)**

`https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/exit-codes.mdx?plain=1#L426-L435`

The term appears as “nanoToncoins” and “nanoToncoin” (mixed casing). Terminology must follow the term bank/prevailing usage; elsewhere we use “nanotoncoins”. Cross‑doc: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/stdlib.mdx?plain=1#L277“nanotoncoins”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules; Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-4-ton‑specific-examples. Minimal fix: change both to “nanotoncoins”.

---

- [ ] **14. Likely broken cross‑page anchor to config parameter 43**

`https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/exit-codes.mdx?plain=1#L514`

Link uses `/ton/config#param-43`, but the target heading is “Param 43: account and message limits”, whose slug typically includes the full phrase. Internal anchors must resolve. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format. Minimal fix: update to `/ton/config#param-43-account-and-message-limits` (matches the heading text), or confirm the generated slug and adjust accordingly.

---

- [ ] **15. Broken self‑link to undefined “exit code 130”**

`https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/exit-codes.mdx?plain=1#L65`

The aside links to `#130%3A-…` but this page does not define exit code 130. Broken/missing anchors are release‑blocking. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#severity-model-release‑blocking; Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format. Minimal fix: remove the self‑anchor and leave plain text “exit code 130”, or link to the canonical location if/when one exists.

---

- [ ] **16. Table/link anchor must match updated heading (Unknown error)**

`https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/exit-codes.mdx?plain=1#L38-L361`

If heading quotes are removed (see item 2), the table link target `#11%3A-%22unknown%22-error` will no longer match. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-3-uniqueness-and-linkability; Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format. Minimal fix: update the table link to `#11%3A-unknown-error` in the “Table of exit codes”.

---

- [ ] **17. Minor grammar issue (exit code 38 section)**

`https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/exit-codes.mdx?plain=1#L471`

Sentence reads: “When there is not enough extra currency to send the specified amount is already reserved, an exit code 38 is thrown…”. This is ungrammatical. General English grammar: add a conjunction or remove the stray clause. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording. Minimal fix: “When there is not enough extra currency to send the specified amount, or the amount is already reserved, exit code 38 is thrown: …”.

---

- [ ] **18. Broken in-page anchors for compute/action**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/exit-codes.mdx?plain=1#L9

Links use `#compute` and `#action`, but the page headings are `## Compute phase` and `## Action phase` (anchors resolve to `#compute-phase` and `#action-phase`). Replace `[compute](#compute)` with `[compute phase](#compute-phase)` and `[action](#action)` with `[action phase](#action-phase)`. Apply this fix to all occurrences: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/exit-codes.mdx?plain=1#L9-L533

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-3-links-and-anchors

---

- [ ] **19. Inconsistent capitalization of “action phase” mid-sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/exit-codes.mdx?plain=1#L440

Inline comment uses “Action phase” mid-sentence; common nouns should be lowercase mid‑sentence. Change to “action phase” for consistency with usage across the page.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-6-banned-and-preferred-terms

---

- [ ] **20. Unit name pluralization inconsistent (“nanoToncoins”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/exit-codes.mdx?plain=1#L426-L435

Use consistent unit naming; prefer the singular unit label used across the corpus. Change “nanoToncoins” → “nanoToncoin” to match usage elsewhere in the docs (see `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1#L251`, `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/guidebook/dapp.mdx?plain=1#L252`) and within this page. The guide is silent on singular vs. plural unit names; this fix follows corpus consistency.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#14-2-units-and-conventions

---

- [ ] **21. Vague phrasing “a couple of” in instructions**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/tvm/exit-codes.mdx?plain=1#L86

“you'll have to perform a couple of type checks” is imprecise. Be exact: “you'll have to perform two type checks”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording