### PR TITLE
[AI] fix: benchmarks.mdx

### DIFF
--- a/ecosystem/blueprint/benchmarks.mdx
+++ b/ecosystem/blueprint/benchmarks.mdx
@@ -43,11 +43,9 @@ cd sample
 ```
 
 <Aside type="note">
-
-- The `-y` flag skips prompts and accepts defaults.
-- `--type` specifies the template (e.g., `func-counter`).
-- `--contractName` sets the contract name.
-
+  - The `-y` flag skips prompts and accepts defaults.
+  - `--type` specifies the template (e.g., `func-counter`).
+  - `--contractName` sets the contract name.
 </Aside>
 
 Alternatively, you can run:


### PR DESCRIPTION
- [ ] **1. Ambiguous “we” instead of direct second person**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/benchmarks.mdx?plain=1#L25-L26

“we’ve introduced a reporting system that lets you collect and compare metrics…” uses ambiguous “we.” Prefer direct instructions or neutral phrasing. Minimal fix: “A reporting system lets you collect and compare metrics across versions.” or “Use the reporting system to collect and compare metrics across versions.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#voice-and-tone

---

- [ ] **2. “Note:” label styled with bold instead of an Aside**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/benchmarks.mdx?plain=1#L45-L49

“**Note:**” with a bullet list simulates a callout using bold. Render callouts with the `<Aside>` component. Minimal fix: wrap the bullets in `<Aside type="note">…</Aside>` and drop the bold label.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#a-admonition-levels-and-usage

---

- [ ] **3. Headings must not contain code formatting**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/benchmarks.mdx?plain=1#L279-L303

The H4 headings include backticked filenames: “`jest.config.ts`” and “`gas-report.config.ts`”. Headings must not contain code styling. Minimal fix: remove backticks in headings: “Option 1: update the existing jest.config.ts” and “Option 2: create a separate config gas-report.config.ts”. Keep code styling for these filenames in body text as needed.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#headings-and-titles

---

- [ ] **4. Product name capitalization and unnecessary bolding (“jest”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/benchmarks.mdx?plain=1#L276

“configure **jest** to collect gas metrics.” uses lowercase and bold for the product name. Capitalize proper nouns and avoid decorative bolding. Minimal fix: “configure Jest to collect gas metrics.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#general-casing-rules

---

- [ ] **5. Token styled in bold instead of code font**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/benchmarks.mdx?plain=1#L170

The opcode name is styled as **increase**. Use code font for identifiers. Minimal fix: change to `increase`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#code-styling

---

- [ ] **6. Acronym not expanded on first use (“ABI”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/benchmarks.mdx?plain=1#L30

Spell out on first mention. Minimal fix: “Application Binary Interface (ABI) information from the snapshot …”. This uses general English/industry knowledge of the acronym.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#acronyms-and-terms

---

- [ ] **7. Task heading should be imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/benchmarks.mdx?plain=1#L274

“Project setup instructions” is a noun phrase. For procedure sections, start headings with an imperative verb. Minimal fix: “Set up the project” or “Configure Jest for gas metrics”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#headings-and-titles

---

- [ ] **8. Use stable permalinks instead of ‘main’ for deep links**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/benchmarks.mdx?plain=1#L30-L359

Deep links to GitHub use the moving `main` branch (e.g., `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/.../blob/main/docs/collect-metric-api.md?plain=1#...`). For precision-critical references, link to a versioned permalink (tag or commit). Minimal fix: replace `/blob/main/` with a specific tag or commit permalink in each URL. Domain owner must choose the appropriate version/tag.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#stable-permalinks-situation-aware

---

- [ ] **9. Minor grammar in code comment (“if need”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/benchmarks.mdx?plain=1#L310-L311

The comment reads “use filter tests if need, see …”. Prefer standard phrasing. Minimal fix: “Filter tests if needed; see https://jestjs.io/docs/cli#--testnamepatternregex”. This fix relies on general English grammar.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#grammar-and-usage

---

- [ ] **10. Callout severity: use Note instead of Tip**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/benchmarks.mdx?plain=1#L15-L21

The callout provides auxiliary references, not actionable productivity tips. Use the least severe level; map to `type="note"`. Minimal fix: change `<Aside type="tip">` to `<Aside type="note">`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#a-admonition-levels-and-usage

---

- [ ] **11. Link text not descriptive/mismatched with target**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/benchmarks.mdx?plain=1#L165

Link text “calculator example” points to `/ton/phases-and-fees`, whose page title is “Execution phases and fees” and currently has no “calculator example” section. Make link text descriptive and aligned with the target. Minimal fix: change link text to “Execution phases and fees”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#link-text

---

- [ ] **12. Broken internal link anchor (inline specifier)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/benchmarks.mdx?plain=1#L228

The link points to an anchor that does not exist: [/language/func/functions#inline-specifier]. Anchors must resolve. Minimal fix: link to the page without a nonexistent anchor ("/language/func/functions") or update to the correct existing anchor once confirmed by the domain owner.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format

---

- [ ] **13. Passive voice; rewrite to active**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/benchmarks.mdx?plain=1#L30-L32

"Before running the tests, a store is created... After test execution, the collected metrics are supplemented..., and a report is generated." Use active voice. Minimal fix: "Before running the tests, a store collects metrics from all transactions. After the tests finish, the tooling supplements the metrics with Application Binary Interface (ABI) information and generates a report." (General grammar guidance per standard English usage.)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-1-goals-and-principles-reader-first-answer-first

---

- [ ] **14. Prefer present tense over future in general behavior**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/benchmarks.mdx?plain=1#L248-L249

"this report will include a comparison" uses future tense. Use present for general behavior. Minimal fix: "this report includes a comparison with the previous version."
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-1-goals-and-principles-reader-first-answer-first

---

- [ ] **15. Define acronym on first mention (TON)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/benchmarks.mdx?plain=1#L8

"In TON, a contract's performance..." uses the acronym without expansion. Define on first mention. Minimal fix: "In The Open Network (TON), a contract's performance..." Optionally link "TON" to the Glossary on first useful mention.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **16. Use precise deep links for internal cross-references**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/benchmarks.mdx?plain=1#L18-L165

The links "Transaction fees", "Storage fees", "Forward fees", and "calculator example" point to `/ton/phases-and-fees` without anchors. Prefer deep links to precise anchors when available. Minimal fix: update each to the exact section anchor on that page (requires confirmation once anchors exist).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format

---

- [ ] **17. Partial diff snippets missing required “Not runnable” label**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/benchmarks.mdx?plain=1#L172-L297

Diff code blocks are partial and not runnable. Partial snippets must be labeled clearly above the block. Minimal fix: add a short line above each diff block: "Not runnable".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **18. Avoid time-relative wording (“current”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/benchmarks.mdx?plain=1#L32

The phrase “the current report format includes …” risks staleness. Minimal fix: “the report format includes `gasUsed`, `cells`, and `bits` …”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#172-timelessness

---

- [ ] **19. Expand acronym API on first use**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/benchmarks.mdx?plain=1#L329

“API” appears without expansion. Minimal fix: “low‑level application programming interface (API) from `@ton/sandbox`”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#53-acronyms-and-terms

---

- [ ] **20. Link text capitalization (Jest)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/benchmarks.mdx?plain=1#L299

Use correct casing for proper nouns in link text. The link text says “Sandbox jest config docs”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17-4-proofread. Minimal fix: “Sandbox Jest config docs”. (General knowledge: proper nouns are capitalized.)

---

- [ ] **21. Avoid conversational "Let’s"; use imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/benchmarks.mdx?plain=1#L36-L226

"let’s walk through a complete example", "Let’s now generate...", and "Let’s try a simple optimization" use first-person plural. Use imperative phrasing. Minimal fixes: "Walk through a complete example.", "Generate a gas usage report.", and "Try a simple optimization — add the `inline` specifier...".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#4-voice-and-tone