### PR TITLE
[AI] fix: compiler-directives.mdx

### DIFF
--- a/language/func/compiler-directives.mdx
+++ b/language/func/compiler-directives.mdx
@@ -131,6 +131,7 @@ Here, the `asm(value index dict key_len)` notation dictates a reordering of argu
 To ensure strict left-to-right computation order, use `#pragma compute-asm-ltr`. With this directive enabled, the same function call:
 
 Not runnable
+
 ```func
 #pragma compute-asm-ltr
 ...


### PR DESCRIPTION
- [ ] **1. Use present tense instead of future ("will …")**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/compiler-directives.mdx?plain=1#L21

Several sentences use future tense for general behavior (e.g., “the compiler will ignore…”, “A warning will be issued…”, “will be evaluated…”, “will contain…”). Use present tense for general behavior and instructions. Minimal fixes: “By default, the compiler ignores redundant inclusions… A warning is issued if the verbosity level is 2 or higher.” Likewise: “is evaluated in the following order”, “contains…”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-1-voice-tense-and-person

---

- [ ] **2. Avoid passive voice when the actor is known**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/compiler-directives.mdx?plain=1#L21

“Files are automatically checked for multiple inclusions.” Use active voice with the actor: “The compiler automatically checks files for multiple inclusions.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-1-voice-tense-and-person

---

- [ ] **3. Code tokens and patterns styled as italics; use code font**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/compiler-directives.mdx?plain=1#L33

Operators and version patterns appear in italics (e.g., “_a.b.c_”, “_=_”, “_>_”, “_>=_”, “_\<_”, “_\<=_”). Render tokens and literals in code font. Minimal fix: use code spans for operators and patterns: `a.b.c`, `=a.b.c`, `>a.b.c`, `>=a.b.c`, `<a.b.c`, `<=a.b.c`, `^a.b`, `^a`. Remove backslash escapes once in code font.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-3-code-styling

---

- [ ] **4. Malformed emphasis and grammar in caret (“^”) examples**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/compiler-directives.mdx?plain=1#L49

Text reads: “_^a.b_—Requires the major compiler version to be \*_equal_ to _a_ part and minor be **no lower** than _b_ part;”. Fix broken Markdown and grammar, avoid bold for emphasis, and use code font for `a`/`b`. Minimal fix: “`^a.b`—Requires the major compiler version to be equal to the `a` part, and the minor is no lower than the `b` part.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-3-code-styling; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **5. List item punctuation: use periods for full sentences**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/compiler-directives.mdx?plain=1#L43

Items under “Supported comparison operators” end with semicolons though they read as full sentences. End full-sentence list items with periods (or make them fragments and omit terminal punctuation consistently). Minimal fix: change trailing semicolons to periods in items at 43–50, and in example bullets at 55–57 and 61–62.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **6. Extra spacing and punctuation inside code tokens**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/compiler-directives.mdx?plain=1#L52

There is an extra space before a comma and terminal punctuation appears inside tokens (e.g., “`a.b.0.`”). Do not add punctuation inside code that isn’t part of the literal, and avoid stray spaces. Minimal fix: remove the space before the comma in “`(_=_, _>_, _>=_, _\<_, _\<=_), omitted`” and move periods outside code spans (e.g., “`a.b.0`.”).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-3-code-styling

---

- [ ] **7. Ordered lists should use `1.` auto-numbering**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/compiler-directives.mdx?plain=1#L118

Numbered sequences use explicit 1., 2., 3., 4. Each ordered list item should start with `1.` and let the renderer auto-number. Minimal fix: change the items at 118–121 and 141–144 to start with `1.`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **8. Bold labels used as pseudo-headings; use real headings**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/compiler-directives.mdx?plain=1#L15

“**Syntax:**” is a bolded label. Do not use bold for structure. Minimal fix: make it a heading `#### Syntax`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles

---

- [ ] **9. Unlabeled partial snippet with ellipsis; label as Not runnable**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/compiler-directives.mdx?plain=1#L133

The code block includes `...`, indicating omitted context, but lacks a “Not runnable” label. Partial snippets must be labeled. Minimal fix: add a line “Not runnable” immediately above the fenced block per §10.2.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **10. Note styled as bold text; use an Aside callout**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/compiler-directives.mdx?plain=1#L150

The line starts with “**Note:**” to call out scope. Use the `<Aside>` component for callouts. Minimal fix: replace with `<Aside type="note"> `#pragma compute-asm-ltr` applies only to code after the directive in the file. </Aside>`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#a-admonition-levels-and-usage

---

- [ ] **11. Redundant repetition of the same scope statement**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/compiler-directives.mdx?plain=1#L148

“`#pragma compute-asm-ltr` works only for code after the pragma.” is repeated again as a Note at line 150. Avoid nearby duplication. Minimal fix: keep one instance (prefer the Aside in item 13) and remove the duplicate sentence.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **12. Remove terminal semicolons in short list fragments**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/compiler-directives.mdx?plain=1#L35-L37

These list items are short fragments (“is the major/minor/patch version;”). Per list punctuation guidance, omit terminal punctuation for non-sentence fragments. Remove the trailing semicolons. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#lists

---

- [ ] **13. Remove duplicate word in example sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/compiler-directives.mdx?plain=1#L56

“and does not match version _a.0.1_ version;” duplicates “version”. Delete the second “version”. Rule: General grammar/typo allowance per task

---

- [ ] **14. Replace literal ellipsis in code with a comment**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/compiler-directives.mdx?plain=1#L135

Literal “...” inside a `func` code fence can make the snippet invalid. Replace with a language-appropriate comment (e.g., `;; …`). This follows the doc rule and FunC comment syntax. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10.5-comments-and-omissions; Supporting syntax: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/comments.mdx?plain=1#single-line-comments

---

- [ ] **15. Make example statements syntactically consistent**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/compiler-directives.mdx?plain=1#L81

The mass-assignment example lacks a terminating semicolon, unlike similar examples on the page (e.g., lines 96 and 136). Add a `;` for consistency and likely validity. Rule: Guide is silent; prefer consistency with nearby pages. Note: If FunC allows omission in this context, retain consistency across examples either with or without `;`.

---

- [ ] **16. Use second person (“you”) instead of “Developers”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/compiler-directives.mdx?plain=1#L41

Change “Developers can specify version constraints…” to “You can specify version constraints…”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#voice-and-tone

---

- [ ] **17. Heading code span should include full identifier**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/compiler-directives.mdx?plain=1

The heading reads “### `#pragma` version”, mixing a code span for only part of the directive. For reference identifiers in headings, use code font for the exact token. Minimal fix: change to “### `#pragma version`”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.-headings-and-titles

---

- [ ] **18. Inconsistent hyphenation for “left-to-right”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/compiler-directives.mdx?plain=1

The page alternates between “left to right” and “left-to-right” when used as a compound adjective. Minimal fix: consistently use the hyphenated form “left-to-right” in both occurrences describing computation order.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13.3-hyphenation-and-abbreviations; general English hyphenation for compound adjectives (general knowledge)

---

- [ ] **19. Frontmatter boolean is quoted as a string**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/compiler-directives.mdx?plain=1

`noindex` should be a YAML boolean, not a quoted string. Change `noindex: "true"` to `noindex: true` to ensure correct parsing. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-file-navigation-and-frontmatter-conventions. This follows general YAML practice for booleans (general knowledge).