### PR TITLE
[AI] fix: redstone.mdx

### DIFF
--- a/ecosystem/interoperability/oracles/redstone.mdx
+++ b/ecosystem/interoperability/oracles/redstone.mdx
@@ -22,6 +22,7 @@ npm install @redstone-finance/ton-connector @redstone-finance/sdk
 
 The following code snippet demonstrates how to fetch price updates and interact with RedStone contracts on TON:
 Not runnable
+
 ```ts
 import { TonPricesContractConnector } from "@redstone-finance/ton-connector";
 import { ContractParamsProvider, getSignersForDataServiceId } from "@redstone-finance/sdk";
@@ -83,15 +84,19 @@ TODO
 RedStone provides several contract types for different use cases:
 
 ### Price manager
+
 Manages multiple price feeds with signature verification and supports both on-the-fly processing and storage persistence.
 
 ### Single feed manager
+
 Simplified version for handling a single price feed, reducing gas costs for single-feed applications.
 
 ### Price feed
+
 Individual feed contract that stores price data for a specific asset.
 
 ### Sample consumer
+
 Example consumer contract that demonstrates how to read data from price feeds.
 
 ## Error handling


### PR DESCRIPTION
- [ ] **1. H2 uses “How to” instead of imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/redstone.mdx?plain=1#L5

The internal task heading uses the “How to …” pattern, which is reserved for page titles. Internal procedure headings must start with an imperative verb in sentence case. Minimal fix: change `## How to use real-time data in TON contracts` to `## Use real-time data in TON contracts`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.-headings-and-titles
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#how-to-titles

---

- [ ] **2. Code example is not runnable and lacks partial label**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/redstone.mdx?plain=1#L25

The snippet references an undefined `network` and an unused API config, so it is not copy-pasteable as shown. Non-runnable excerpts must be labeled. Minimal fix: add a line `Not runnable` immediately above the code block, or make the snippet self-contained.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10.2-partial-snippets

---

- [ ] **3. Placeholder style for API key is non-compliant**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/redstone.mdx?plain=1#L33

Placeholders must use `<ANGLE_CASE>` and be defined on first use. The example uses a natural-language string ("your-api-key-here"). Minimal fix: change to `apiKey: "<API_KEY>"` and, below the code block, define `<API_KEY>` (for example: `<API_KEY>` — your TON Center API token).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10.1-general-rules

---

- [ ] **4. Ordered list numbers should be `1.` for all items**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/redstone.mdx?plain=1#L70

Ordered lists must use `1.` for every item to allow auto-numbering. The list uses `1., 2., 3., …`. Minimal fix: change each item prefix to `1.`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.4-lists

---

- [ ] **5. Subheadings under “Contract types” use Title Case**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/redstone.mdx?plain=1#L85

Headings must use sentence case. Minimal fix: update `### Price Manager` → `### Price manager`, `### Single Feed Manager` → `### Single feed manager`, `### Price Feed` → `### Price feed`, `### Sample Consumer` → `### Sample consumer`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.-headings-and-titles

---

- [ ] **6. Error code ranges styled with bold instead of code font**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/redstone.mdx?plain=1#L101

Error codes and identifiers must use code formatting, not bold. Minimal fix: replace `**300+**` and `**200+**` with `` `300+` `` and `` `200+` ``.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.2-quotation-marks-and-emphasis

---

- [ ] **7. “TODO” placeholder in a published section**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/redstone.mdx?plain=1#L79

Leaving a “TODO” reduces clarity and violates the reader-first, answer-first principle. Minimal fix: replace with complete instructions or remove the section until content is ready.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1.-goals-and-principles-reader‑first,-answer‑first

---

- [ ] **8. Frontmatter title likely mismatched to doc type (How-to pattern)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/redstone.mdx?plain=1#L1

If this page is a How-to (it contains steps and a task flow), the frontmatter title must follow “How to X” and set a concise `sidebarTitle`. Minimal fix: change `title: "RedStone oracle"` to `title: "How to use RedStone oracle"` and add `sidebarTitle: "RedStone oracle"`. If this page is intended as an Explanation, keep the title but remove the “How to …” phrasing from internal headings (see item 1). This requires a doc-type decision from the owner.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#how-to-frontmatter-pattern

---

- [ ] **9. First mention of TON should be expanded**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/redstone.mdx?plain=1

The first mention of “TON” on the page is in a heading but is not expanded. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms. Minimal fix: on the first occurrence, write “The Open Network (TON)”. For example, update the H2 to “## Use real-time data in The Open Network (TON) contracts”.

---

- [ ] **10. H3 not imperative; convert to imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/redstone.mdx?plain=1

The section heading “### Off-chain data fetch and update” is a noun phrase. Task/procedure headings must start with an imperative verb. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.-headings-and-titles. Minimal fix: change to “### Fetch and update off-chain data”.

---

- [ ] **11. Heading missing article (“the”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/redstone.mdx?plain=1

The heading “## Write code to interact with oracle” is missing the definite article, which reduces clarity. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording. Minimal fix: change to “## Write code to interact with the oracle”.

---

- [ ] **12. Acronyms not expanded on first use in prose/snippet**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/redstone.mdx?plain=1

“SDK” and “API” appear without expansion on first use. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms. Minimal fixes:

- Heading: “## Install the RedStone SDK” → “## Install the RedStone software development kit (SDK)” (or expand in the first sentence under the heading).
- Code comment: “// Configure API endpoint” → “// Configure application programming interface (API) endpoint”.

---

- [ ] **13. Placeholder style in code: use UPPER_SNAKE and define on first use**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/redstone.mdx?plain=1#L33-L46

Placeholders in code should be neutral UPPER_SNAKE and defined on first use. Replace `"your-api-key-here"` with `API_KEY`, and the hard-coded contract address with a neutral placeholder (e.g., `EQC_REPLACE_WITH_ADDRESS` or `CONTRACT_ADDR`). Then add a short "Define placeholders (first use)" list after the snippet for `API_KEY`, `CONTRACT_ADDR`/`EQC_REPLACE_WITH_ADDRESS`, and `NETWORK`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#general-rules (placeholders); https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#safety-and-secrets-in-code

---

- [ ] **14. Redundant filler before Additional resources**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/redstone.mdx?plain=1#L107-L108

"You may find these additional resources helpful…" is throat‑clearing/hedging and duplicates the section heading. Minimal fix: remove this sentence and keep the list.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#avoid-tautology-pleonasm-throat-clearing-and-circular-references; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#plain-precise-wording

---

- [ ] **15. Link to moving GitHub branch for constants (needs stable permalink)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/interoperability/oracles/redstone.mdx?plain=1#L103

The "RedStone constants" link points to `main`, which can change over time. For precision-critical references to code, use a tag/commit permalink. Minimal fix: update the URL to a versioned or commit permalink for the same file and path. This requires the domain owner to select the correct tag/commit.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#external-references