### PR TITLE
[AI] fix: message-lookup.mdx

### DIFF
--- a/ecosystem/ton-connect/message-lookup.mdx
+++ b/ecosystem/ton-connect/message-lookup.mdx
@@ -4,8 +4,10 @@ title: "Message lookup"
 
 import { Aside } from "/snippets/aside.jsx";
 
-<Aside type="danger">
-Do not use external message tracking for payment processing. Check out [payment processing](/guidebook/payment) for more details.
+<Aside
+  type="danger"
+>
+  Do not use external message tracking for payment processing. Check out [payment processing](/guidebook/payment) for more details.
 </Aside>
 
 ## Message lookup overview
@@ -23,9 +25,9 @@ To address this, the ecosystem defines a standard that ensures consistent hash c
 The normalized hash is computed by applying the following standardization rules to an external-in message:
 
 1. **Source Address (`src`)**: set to `addr_none$00`
-2. **Import Fee (`import_fee`)**: set to `0`
-3. **InitState (`init`)**: set to an empty value
-4. **Body**: always stored as a reference
+1. **Import Fee (`import_fee`)**: set to `0`
+1. **InitState (`init`)**: set to an empty value
+1. **Body**: always stored as a reference
 
 ## Look up a transaction using a TON Connect external message
 
@@ -272,6 +274,6 @@ if (tx) {
 
 ## See also
 
-* [TEP-467: Normalized Message Hash](https://github.com/ton-blockchain/TEPs/blob/8b3beda2d8611c90ec02a18bec946f5e33a80091/text/0467-normalized-message-hash.md)
-* [Messages and transactions](/ton/transaction)
-* [TON Connect overview](/ecosystem/ton-connect/index)
+- [TEP-467: Normalized Message Hash](https://github.com/ton-blockchain/TEPs/blob/8b3beda2d8611c90ec02a18bec946f5e33a80091/text/0467-normalized-message-hash.md)
+- [Messages and transactions](/ton/transaction)
+- [TON Connect overview](/ecosystem/ton-connect/index)


### PR DESCRIPTION
- [ ] **1. Safety callout lacks required details**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/message-lookup.mdx?plain=1

The opening Warning callout uses `<Aside type="danger">` but does not include the required elements (risk, scope, rollback/mitigation, and environment label). Provide a concise list covering what can go wrong, what is affected, how to mitigate/rollback, and whether to use testnet vs mainnet by default. If exact risk/mitigation details depend on product policy, this requires input from the domain owner.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout

---

- [ ] **2. Generic “Introduction” heading; use a specific, linkable label**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/message-lookup.mdx?plain=1

The H2 heading “Introduction” is generic. Replace with a specific, self‑describing heading (for example, “Message lookup overview”) to make deep links meaningful and avoid repeated “Introduction” sections across pages.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-3-uniqueness-and-linkability

---

- [ ] **3. Task headings use gerunds; switch to imperative form**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/message-lookup.mdx?plain=1

Revise task/procedural headings to start with an imperative verb:
- “Transaction lookup using external message from TON Connect” → “Look up a transaction using a TON Connect external message” (or similar imperative phrasing).
- “Retrying API calls” → “Retry API calls”.
- “Waiting for transaction confirmation” → “Wait for transaction confirmation”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-2-gerunds-and-labels

---

- [ ] **4. Duplicate “Example” headings at H3; make them unique**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/message-lookup.mdx?plain=1

There are multiple H3 headings titled “Example,” which creates duplicate anchors at the same nesting level. Make each unique and descriptive, e.g., “Example: getTransactionByInMessage” and “Example: waitForTransaction”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-3-uniqueness-and-linkability

---

- [ ] **5. Acronyms not defined on first mention (UX, RPC, API, BoC)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/message-lookup.mdx?plain=1

Expand acronyms at first use, then use the acronym thereafter:
- “UX” → “user experience (UX)”.
- “RPC” → “Remote Procedure Call (RPC)”.
- “API” → “Application Programming Interface (API)”.
- “BoC/boc” → “Bag of Cells (BoC)”. Also ensure casing “BoC” per TON‑specific casing.

Rules: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#b-banned-and-preferred-terms

---

- [ ] **6. Casing and grammar in prose: “api failures” and wordiness**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/message-lookup.mdx?plain=1

Fix casing and streamline wording: “Use `retry` function presented below to deal with api failures:” → “Use the `retry` function to handle API failures:”. This corrects acronym casing, adds the article, and removes filler (“presented below”).

Rules: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-6-spelling-and-contractions; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **7. Incomplete sentence in “Wait for transaction confirmation” section**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/message-lookup.mdx?plain=1

“The function `waitForTransaction` to poll the blockchain and wait for the corresponding transaction should be used in this case:” is missing a main verb. Replace with: “Use the `waitForTransaction` function to poll the blockchain and wait for the corresponding transaction:”. (General grammar correction.)

Rule: General grammar (basic English sentence structure); also aligns with https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-language-and-wording for clarity and directness

---

- [ ] **8. Placeholder style inside code string; avoid literal ellipses**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/message-lookup.mdx?plain=1

Replace the string sentinel `'te6ccgEBAQEA...your-base64-message...'` with a neutral placeholder inside the string, e.g., `'BASE64_BOC'`, and define it at first use. Avoid literal `...` in code, and follow placeholder conventions.

Rules: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-examples-and-placeholder-conventions; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-5-comments-and-omissions

---

- [ ] **9. Partial snippets are not labeled “Not runnable”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/message-lookup.mdx?plain=1

Several code blocks are excerpts that are not runnable as‑is (e.g., they depend on imports/environment like `TonClient`, `beginCell`, `useTonConnectUI`). Precede such blocks with “Not runnable” per the partial snippet rule.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **10. Prefer canonical TEP link over PR link**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/message-lookup.mdx?plain=1

In “Message normalization,” replace the link to the TEP PR with the canonical TEP document URL (already used elsewhere on the page) to cite the stable spec instead of a pull request.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not

---

- [ ] **11. Use safer defaults note for endpoints (testnet first)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/message-lookup.mdx?plain=1

Examples use a mainnet‑like endpoint. Add a brief note or placeholder to prefer testnet by default, or parameterize the endpoint (e.g., `<RPC_URL>`), then define it at first use. If exact testnet URL varies by provider, this needs domain confirmation.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-3-safer-defaults

---

- [ ] **12. **2. Hedgey phrasing in warning; prefer direct imperative****

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/message-lookup.mdx?plain=1

Text: “You should never use external message tracking for payment processing purposes.” Replace with a direct, imperative form to remove hedging. Minimal fix: “Do not use external message tracking for payment processing.” If a mandatory prohibition is intended, use “MUST NOT”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#0-purpose-scope-and-normative-terms

---

- [ ] **13. **7. Bold label used as a pseudo‑heading****

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/message-lookup.mdx?plain=1

Text: “**How normalization works:**” uses bold to introduce a section. Prefer structure over emphasis. Minimal fix: convert to a proper subheading (e.g., “### How normalization works”) or keep it as plain text without bold: “How normalization works:”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **14. **10. See also: link text should match target or deep‑link****

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/message-lookup.mdx?plain=1

Item: “TON Connect: Sending messages” links to `/ecosystem/ton-connect/index`, whose title is “TON Connect overview” and does not have a “Sending messages” section. Minimal fix: change link text to “TON Connect overview” or deep‑link to the precise target section if “Sending messages” exists elsewhere.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format

---

- [ ] **15. **12. Avoid filler “just”****

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/message-lookup.mdx?plain=1

Text: “If you’ve just sent a message…” The word “just” is listed as filler; prefer a precise alternative or remove it. Minimal fix: “If you’ve recently sent a message…” or “If you’ve sent a message recently…”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#b-banned-and-preferred-terms

---

- [ ] **16. Inconsistent TypeScript code fence language tags (`ts` vs `typescript`)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/message-lookup.mdx?plain=1#L232

One code block uses ```typescript while others use ```ts. Minimal fix: align all TypeScript code fences on this page to a single tag (e.g., ```ts) for consistency. The guide is silent on preferred tag; this follows the "prefer consistency" principle across the page. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#8.2-structure-for-scanning

---

- [ ] **17. Redundant phrasing (“Normalization is a standardization process…”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/message-lookup.mdx?plain=1#L17

This sentence contains pleonasm and can be tightened without changing meaning. Minimal fix: "Normalization converts different external-in message representations into a consistent format." Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.7-avoid-tautology-pleonasm-throat-clearing-and-circular-references; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording

---

- [ ] **18. Remove time‑relative wording for timelessness**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/message-lookup.mdx?plain=1#L19

“Message lookup by its normalized hash is already implemented …” uses time‑relative wording. Minimal fix: remove “already”: “Message lookup by its normalized hash is implemented in most TON RPC providers.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17.2-timelessness