### PR TITLE
[AI] fix: develop.mdx

### DIFF
--- a/ecosystem/blueprint/develop.mdx
+++ b/ecosystem/blueprint/develop.mdx
@@ -6,11 +6,11 @@ import { Aside } from "/snippets/aside.jsx";
 
 Ensure your current directory is the root of the project initialized with `npm create ton@latest`.
 
-## Contract creation
+## Create a contract
 
 Use Blueprint to create a new contract.
 
-### Interactive mode
+### Interactive mode (create)
 
 To launch a guided prompt to create a contract step by step, use:
 
@@ -18,7 +18,7 @@ To launch a guided prompt to create a contract step by step, use:
 npx blueprint create
 ```
 
-### Non-interactive mode
+### Non-interactive mode (create)
 
 To create a contract without prompts, provide the contract name and template type:
 
@@ -26,8 +26,8 @@ To create a contract without prompts, provide the contract name and template typ
 npx blueprint create <CONTRACT> --type <TYPE>
 ```
 
-- `<CONTRACT>`- contract name
-- `<TYPE>`- template type, e.g., tolk-empty, func-empty, tact-empty, tolk-counter, func-counter, tact-counter
+- `<CONTRACT>`: contract name
+- `<TYPE>`: template type, e.g., `tolk-empty`, `func-empty`, `tact-empty`, `tolk-counter`, `func-counter`, `tact-counter`
 
 **Example:**
 
@@ -35,17 +35,17 @@ npx blueprint create <CONTRACT> --type <TYPE>
 npx blueprint create MyNewContract --type tolk-empty
 ```
 
-## Contract code writing
+## Write contract code
 
 After creation, contracts are placed in the `contracts/` folder.
 Each file uses the extension that matches its language.
 For example, creating a Tolk contract `MyNewContract` results in `contracts/my_new_contract.tolk`.
 
-## Building
+## Build contracts
 
 Blueprint compiles your contracts into build artifacts.
 
-### Interactive mode
+### Interactive mode (build)
 
 Run without arguments to select contracts from a prompt:
 
@@ -53,7 +53,7 @@ Run without arguments to select contracts from a prompt:
 npx blueprint build
 ```
 
-### Non-interactive mode
+### Non-interactive mode (build)
 
 Specify a contract name or use flags to skip prompts:
 
@@ -72,7 +72,7 @@ npx blueprint build --all # build all contracts
 
 Compiled outputs are stored in the `build/` directory.
 
-- `build/<CONTRACT>.compiled.json`- serialized contract representation used for deployment and testing.
+- `build/<CONTRACT>.compiled.json` — serialized contract representation used for deployment and testing.
 
   Each file contains three fields:
 
@@ -82,7 +82,9 @@ Compiled outputs are stored in the `build/` directory.
 
   Example:
 
-  ```json title='<CONTRACT>.compiled.json'
+  The following example truncates long values for brevity.
+
+  ```json title="<CONTRACT>.compiled.json"
   {
       "hash":"21eabd3331276c532778ad3fdcb5b78e5cf2ffefbc0a6dc...",
       "hashBase64":"Ieq9MzEnbFMneK0/3LW3jlzy/++8Cm3Dxkt+I3yRe...",
@@ -104,18 +106,18 @@ When you create a new contract with Blueprint, you need to write your own wrappe
 >
   Methods that send messages should start with `send` (e.g., `sendDeploy`, `sendIncrement`), and methods that read data should start with `get` (e.g., `getCounter`).
 
-  This convention works seamlessly with `open()` method, which automatically provides the `ContractProvider` as the first argument to your wrapper methods.
+  This convention works seamlessly with the `open()` method, which automatically provides the `ContractProvider` as the first argument to your wrapper methods.
 </Aside>
 
-### Static creating methods
+### Static creation methods
 
 Wrappers typically include two main static methods for creating contract instances:
 
-#### `createFromAddress(address: Address)`
+#### createFromAddress
 
 Creates a wrapper instance for an **already deployed** contract using its address. This method is used when you want to interact with an existing contract on the blockchain.
 
-```typescript title="./wrappers/Counter.ts"
+```typescript title="./wrappers/counter.ts"
 import { Address, Cell, Contract } from '@ton/core';
 
 export class Counter implements Contract {
@@ -127,11 +129,11 @@ export class Counter implements Contract {
 }
 ```
 
-#### `createFromConfig(config, code, workchain)`
+#### Create from config
 
 Creates a wrapper instance for a **new contract** that hasn't been deployed yet. This method calculates the contract's future address based on its initial state and code.
 
-```typescript title="./wrappers/Counter.ts"
+```typescript title="./wrappers/counter.ts"
 import { Address, beginCell, Cell, Contract, contractAddress } from '@ton/core';
 
 export type CounterConfig = {
@@ -156,21 +158,21 @@ export class Counter implements Contract {
 
 **Parameters:**
 
-- `config` - Initial configuration data for your contract
-- `code` - Compiled contract code (usually loaded from build artifacts)
-- `workchain` - workchain ID (0 for basechain, -1 for masterchain)
+- `config`: Initial configuration data for your contract
+- `code`: Compiled contract code (usually loaded from build artifacts)
+- `workchain`: workchain ID (0 for basechain, -1 for masterchain)
 
 <Aside type="tip">
   Contracts created with `createFromAddress()` cannot be deployed since they lack the `init` data required for deployment. Use `createFromConfig()` for new contracts that need to be deployed.
 </Aside>
 
-### Sending messages
+### Send messages
 
-Message sending methods allow your application to trigger contract execution by sending [internal or external messages](/ton/transaction). These methods handle the construction of message bodies and transaction parameters.
+Message sending methods allow your application to trigger contract execution by sending [internal or external messages](../../ton/transaction). These methods handle the construction of message bodies and transaction parameters.
 
 All sending methods follow a similar pattern and should start with `send`:
 
-```typescript title="./wrappers/Counter.ts"
+```typescript title="./wrappers/counter.ts"
 import { ContractProvider, Sender, SendMode, beginCell, Cell } from '@ton/core';
 
 export class Counter implements Contract {
@@ -201,17 +203,17 @@ export class Counter implements Contract {
 
 **Parameters:**
 
-- `provider` - `ContractProvider` instance that handles blockchain communication
-- `via` - `Sender` object representing the transaction sender
-- `opts` - Options object containing transaction value and method-specific parameters
+- `provider`: `ContractProvider` instance that handles blockchain communication
+- `via`: `Sender` object representing the transaction sender
+- `opts`: Options object containing transaction value and method-specific parameters
 
-### Calling get methods
+### Call get methods
 
 Get methods allow you to read data from smart contracts without creating transactions. These methods are read-only operations that query the contract's current state.
 
-All get methods should start with `get` and return a Promise:
+All get methods should start with `get` and return a `Promise`:
 
-```typescript title="./wrappers/Counter.ts"
+```typescript title="./wrappers/counter.ts"
 import { Contract, ContractProvider } from '@ton/core';
 
 export class Counter implements Contract {
@@ -240,7 +242,7 @@ export class Counter implements Contract {
 
 ### Complete example
 
-```typescript title="./wrappers/Counter.ts" expandable
+```typescript title="./wrappers/new-contract.ts" expandable
 import { Address, beginCell, Cell, Contract, contractAddress, ContractProvider, Sender, SendMode } from '@ton/core';
 
 export type NewContractConfig = {
@@ -330,8 +332,8 @@ export class NewContract implements Contract {
 
 ## Testing
 
-To test contracts, follow the [Smart contract testing](/ecosystem/blueprint/testing/overview).
+To test contracts, follow the [Testing overview](testing/overview).
 
 ## Deployment
 
-To deploy contracts, follow the [Deployment and interaction](/ecosystem/blueprint/deploy#deploying-contracts) section.
+To deploy contracts, follow the [Deployment and interaction](deploy#deploying-contracts) section.


### PR DESCRIPTION
- [ ] **1. Procedural heading uses gerund/noun phrase**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/develop.mdx?plain=1#L38

"## Contract code writing" is not an imperative, which the guide recommends for task/procedure headings. Minimal fix: change to "## Write contract code" to use an imperative verb.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-2-gerunds-and-labels

---

- [ ] **2. Code font used in non-reference headings**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/develop.mdx?plain=1#L114

Heading "#### `createFromAddress(address: Address)`" uses code formatting in a heading on a non-reference page. Minimal fix: remove backticks and pare to a concise identifier, for example: "#### createFromAddress".

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-4-formatting-restrictions

---

- [ ] **3. Silent truncation of hashes in JSON example**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/develop.mdx?plain=1#L85

The JSON example shows values with ellipses (e.g., "21eabd...") which silently truncates hashes. Minimal fix: replace example values with placeholders (`<HASH_HEX>`, `<HASH_BASE64>`, `<CODE_HEX>`) or add a preceding sentence stating that values are truncated for brevity; avoid truncation inside the JSON itself since JSON has no comments.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#14-2-units-and-conventions

---

- [ ] **4. Inconsistent and cramped dash separators in definition bullets**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/develop.mdx?plain=1#L29

Definition bullets use a hyphen with no space (e.g., "`<CONTRACT>`- contract name" at lines 29–30 and "`build/<CONTRACT>.compiled.json`- ..." at line 75), and hyphens instead of the em dash used elsewhere in this section for term–definition lists. Minimal fix: replace the hyphen with an em dash flanked by spaces (" — ") for these items: lines 29, 30, 75, 159–161, and 204–206. This aligns with nearby pages (e.g., https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1) and improves scannability.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#8-2-structure-for-scanning. The guide is silent on dash choice; applying consistency with nearby pages per the review brief.

---

- [ ] **5. Template type literals not in code font**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/develop.mdx?plain=1#L30

The list of template types after "e.g.," shows literals (tolk-empty, func-empty, tact-empty, …) without code formatting. Minimal fix: wrap each literal in backticks: `tolk-empty`, `func-empty`, `tact-empty`, `tolk-counter`, `func-counter`, `tact-counter`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules

---

- [ ] **6. Missing article before a method name**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/develop.mdx?plain=1#L107

"This convention works seamlessly with `open()` method" is missing an article. Minimal fix: "This convention works seamlessly with the `open()` method." General knowledge: English article usage improves clarity.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **7. Type name not in code font**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/develop.mdx?plain=1#L212

"return a Promise" mentions a language type without code formatting. Minimal fix: render as `Promise`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules

---

- [ ] **8. Procedural subheading not imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/develop.mdx?plain=1#L208

"### Calling get methods" uses a gerund for a procedural subsection. Minimal fix: change to "### Call get methods" to use an imperative verb consistent with task sections.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-2-gerunds-and-labels

---

- [ ] **9. Awkward phrasing in section heading**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/develop.mdx?plain=1#L110

"### Static creating methods" is unidiomatic. Minimal fix: change to "### Static creation methods" for plain, precise wording while preserving meaning.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **10. Inconsistent code fence title quoting**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/develop.mdx?plain=1#L85

The code fence uses single quotes in the title attribute (```json title='<CONTRACT>.compiled.json'```), while nearby pages use double quotes (e.g., https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/deploy.mdx?plain=1 uses `title="..."`). Minimal fix: switch to double quotes: ```json title="<CONTRACT>.compiled.json"```. If the guide is silent, prefer consistency with nearby pages.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#8-2-structure-for-scanning. The guide is silent on code‑fence attribute quoting; applying consistency with nearby pages per the review brief.

---

- [ ] **11. Duplicate H3 headings are not unique at same level**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/develop.mdx?plain=1#L13-L56

The headings "Interactive mode" and "Non-interactive mode" appear twice at the H3 level (under Contract creation and Building), violating the rule that headings must be unique at the same nesting level. Minimal fix: qualify each repeated heading so it’s unique, for example, "Interactive mode (create)", "Non-interactive mode (create)", "Interactive mode (build)", and "Non-interactive mode (build)".

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-3-uniqueness-and-linkability

---

- [ ] **12. Inconsistent identifier casing within examples**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/develop.mdx?plain=1#L185-L335

Identifiers mix `queryId` vs `queryID`, and `getId` vs `getID`. Examples should use consistent casing; prefer lower camelCase for JavaScript/TypeScript identifiers for internal consistency and to match earlier examples on this page. Minimal fix: standardize to `queryId` and `getId` across snippets.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17-4-proofread

---

- [ ] **13. Task heading should use imperative (not noun phrase)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/develop.mdx?plain=1#L9

“Contract creation” is a task section and should use an imperative verb for clarity and scanability. Change to “Create a contract”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#71-case-and-form

---

- [ ] **14. Task heading should be imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/develop.mdx?plain=1#L44

“Building” is a gerund; task/procedure headings should be imperative. Change to “Build contracts”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#72-gerunds-and-labels

---

- [ ] **15. Code font used in heading (not allowed on non-reference pages)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/develop.mdx?plain=1#L130

Heading “`createFromConfig(config, code, workchain)`” uses code formatting. Replace with “Create from config”; keep the signature in the code block. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#74-formatting-restrictions

---

- [ ] **16. Gerund in task heading; use imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/develop.mdx?plain=1#L167

“Sending messages” should be “Send messages” to follow task imperative style. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#72-gerunds-and-labels

---

- [ ] **17. Filenames in code block titles should be kebab-case**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/develop.mdx?plain=1#L118-L243

Code block titles use `./wrappers/Counter.ts` (PascalCase). Examples must show kebab-case filenames. Change titles to `./wrappers/counter.ts` (and for the full example, `./wrappers/new-contract.ts`). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#101-general-rules

---

- [ ] **18. Definition bullets use hyphen without spacing; prefer colon for definitions**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/develop.mdx?plain=1#L29-L206

Bullets like “`<CONTRACT>`- contract name” and parameter bullets use a hyphen without spacing. For clarity and mechanics, use a colon for definitions: “`<CONTRACT>`: contract name”, “`provider`: ContractProvider…”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#61-commas-colons-semicolons

---

- [ ] **19. Internal links should be relative, and link text should match target**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/blueprint/develop.mdx?plain=1#L169-L337

Internal links use absolute paths and one link text does not match the target page title. Rules: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-3-links-and-anchors and #7-3-uniqueness-and-linkability (link text clarity). Minimal fixes:
- “internal or external messages” link: change `/ton/transaction` → `../../ton/transaction`.
- “Smart contract testing” link: change text to “Testing overview” and path `/ecosystem/blueprint/testing/overview` → `testing/overview`.
- “Deployment and interaction” link: change `/ecosystem/blueprint/deploy#deploying-contracts` → `deploy#deploying-contracts`.