### PR TITLE
[AI] fix: merkle-proof-cells.mdx

### DIFF
--- a/ton/cells/merkle-proof-cells.mdx
+++ b/ton/cells/merkle-proof-cells.mdx
@@ -8,6 +8,9 @@ import { Aside } from "/snippets/aside.jsx";
 
 Learn Merkle proof cell types and how to read them.
 
-<Aside type="note" title="Important">
-    This page assumes that you know what a [Merkle tree](https://en.wikipedia.org/wiki/Merkle_tree) is.
+<Aside
+  type="note"
+  title="Important"
+>
+  This page assumes that you know what a [Merkle tree](https://en.wikipedia.org/wiki/Merkle_tree) is.
 </Aside>


### PR DESCRIPTION
- [ ] **1. In-body H1 present; use H2 per template**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/merkle-proof-cells.mdx?plain=1#L7

The page includes an in-body H1 (`# Merkle proof cells`), which duplicates the frontmatter title. Pages must not contain an in-body H1; the first visible heading in content must be an H2. Minimal fix: change `# Merkle proof cells` to `## Merkle proof cells`, or remove the line entirely to rely on the frontmatter title.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.1-case-and-form

---

- [ ] **2. Throat-clearing opener; replace with direct statement**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/merkle-proof-cells.mdx?plain=1#L9

“This page explains Merkle proof cell types and how to read them.” is throat‑clearing/meta. Replace with a direct, actionable statement. Minimal fix: rewrite as “Learn Merkle proof cell types and how to read them.” or remove the sentence and start with content.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.7-avoid-tautology-pleonasm-throat‑clearing-and-circular-references

---

- [ ] **3. Awkward grammar and filler in Aside prerequisite**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/merkle-proof-cells.mdx?plain=1#L12

The phrase “what is a [Merkle tree in general]” is ungrammatical and wordy. Use plain phrasing and remove filler. Minimal fix: “This article assumes that you know what a [Merkle tree](https://en.wikipedia.org/wiki/Merkle_tree) is.” (reorders to “what a … is” and removes “in general”).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording

---

- [ ] **4. Visible placeholder text (“stub.”) in user-facing content**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/merkle-proof-cells.mdx?plain=1#L15

The bare placeholder “stub.” appears to readers and undermines clarity/polish. Remove it until real content is added. Minimal fix: delete the line.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17.4-proofread

---

- [ ] **5. Use internal canonical link instead of Wikipedia**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/merkle-proof-cells.mdx?plain=1#L12

The Aside links to Wikipedia for "Merkle tree" despite internal canonical documentation existing. Prefer official/canonical docs when available. Minimal fix: replace the external link with an internal canonical page (e.g., "/ton/proofs/merkle"). Note: requires domain confirmation of the best internal target ("Merkle proofs" page or the conceptual section in `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/ton.mdx?plain=1`). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#severity-model-release‑blocking

---

- [ ] **6. Terminology: use "page," not "article"**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/merkle-proof-cells.mdx?plain=1#L12

The Aside says "This article assumes…" but the docs define a "Page" as the unit and require consistent terminology. Minimal fix: replace "This article" with "This page". Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **7. Internal link should be relative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/merkle-proof-cells.mdx?plain=1#L12

For internal links, prefer relative paths to improve stability. Minimal fix: use `../proofs/merkle` instead of a root-absolute path.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format

---

- [ ] **8. Aside should use supported type/title for Important prerequisite**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/cells/merkle-proof-cells.mdx?plain=1#L11-L13

Prerequisites should be labeled clearly with a supported `<Aside>` mapping. Minimal fix: set a supported type and title, and streamline the text, e.g., `<Aside type="note" title="Important">Know what a Merkle tree is.</Aside>` (with the internal link applied).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout