### PR TITLE
[AI] fix: validator.mdx

### DIFF
--- a/ecosystem/node/mytonctrl/validator.mdx
+++ b/ecosystem/node/mytonctrl/validator.mdx
@@ -14,9 +14,11 @@ description: "Validator mode automates governance voting, election participation
 ### vo
 
 #### Purpose
+
 Vote for one or more governance offers (configuration proposals) using the validator wallet.
 
 #### Syntax
+
 Not runnable
 
 ```mytonctrl
@@ -38,9 +40,11 @@ vo xKF+2Cj4wP6w2y... xKF+2Cj4wP6w2y...
 ### ve
 
 #### Purpose
+
 Cast the validator election entry for the upcoming round.
 
 #### Syntax
+
 Not runnable
 
 ```mytonctrl
@@ -56,9 +60,11 @@ ve
 ### vc
 
 #### Purpose
+
 Vote on a validator complaint by pairing the election round with the complaint hash.
 
 #### Syntax
+
 Not runnable
 
 ```mytonctrl
@@ -79,12 +85,14 @@ vc 345678901234567890 xFFmZ...Y
 
 ## Performance diagnostics
 
-### check_ef
+### check\_ef
 
 #### Purpose
+
 Review validator efficiency for the previous and current validation rounds.
 
 #### Syntax
+
 Not runnable
 
 ```mytonctrl
@@ -99,12 +107,14 @@ check_ef
 
 ## Local collator registry
 
-### add_collator
+### add\_collator
 
 #### Purpose
+
 Add a collator entry to the validator console’s collator list and configure optional behaviors.
 
 #### Syntax
+
 Not runnable
 
 ```mytonctrl
@@ -124,12 +134,14 @@ add_collator <adnl-id> <workchain>:<shard_hex> [--self-collate true|false] [--se
 add_collator 2F3C7A...B91 0:2000000000000000 --self-collate true --select-mode ordered
 ```
 
-### delete_collators
+### delete\_collators
 
 #### Purpose
+
 Remove one or more collator entries from the validator console list.
 
 #### Syntax
+
 Not runnable
 
 ```mytonctrl
@@ -149,12 +161,14 @@ delete_collator 0:2000000000000000 2F3C7A...B91
 delete_collator 2F3C7A...B91
 ```
 
-### print_collators
+### print\_collators
 
 #### Purpose
+
 Inspect the current collator list and optional liveness information.
 
 #### Syntax
+
 Not runnable
 
 ```mytonctrl
@@ -173,12 +187,14 @@ print_collators
 print_collators --json
 ```
 
-### reset_collators
+### reset\_collators
 
 #### Purpose
+
 Clear the entire collator list stored in the validator console.
 
 #### Syntax
+
 Not runnable
 
 ```mytonctrl
@@ -188,4 +204,4 @@ reset_collators
 #### Behavior
 
 - Calls `clear-collators-list` and removes all shard/ADNL mappings.
-- Reports an error if the console rejects the reset; otherwise prints "reset_collators - OK".
+- Reports an error if the console rejects the reset; otherwise prints "reset\_collators - OK".


### PR DESCRIPTION
- [ ] **1. Page title uses Title Case instead of sentence case**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/validator.mdx?plain=1#L2

The style guide requires sentence case for all headings, including page titles. Change `title: "Validator"` to `title: "Validator"` or, if treated as a heading, to sentence case per rule. Minimal fix: ensure headings follow sentence case; if frontmatter `title` mirrors visible H1, convert to sentence case (e.g., `Validator` → `Validator`).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.-headings-and-titles

---

- [ ] **2. Headings contain code formatting; rule allows only in reference pages**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/validator.mdx?plain=1#L14-L162

Headings include code font around command names (e.g., `### `vo``). The guide forbids styling in headings except that reference pages may include code font for identifiers. If this page is not a formal reference, remove backticks from headings: `### vo`, `### ve`, `### vc`, `### check_ef`, `### add_collator`, `### delete_collator`, `### print_collators`, `### reset_collators`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.-headings-and-titles

---

- [ ] **3. Inconsistent placeholder style in examples**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/validator.mdx?plain=1#L21-L169

Placeholders must use `<ANGLE_CASE>`. Current examples use hyphenated forms like `<offer-hash>`, `<election-id>`, `<complaint-hash>`, `<adnl-id>`, `<workchain>`, `<shard_hex>`. Replace with `<OFFER_HASH>`, `<ELECTION_ID>`, `<COMPLAINT_HASH>`, `<ADNL_ID>`, `<WORKCHAIN>`, `<SHARD_HEX>`. Also define each placeholder on first use.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10.-code-and-command-examples; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13.5-placeholder-names

---

- [ ] **4. Fenced code blocks missing explicit language tags for output**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/validator.mdx?plain=1#L32-L157

All fenced blocks must specify a language. Blocks that show commands use `mytonctrl` (OK if recognized), but output/example blocks like `vc 345678901234567890 xFFmZ...Y` are commands and should carry a shell/CLI tag. Use ` ```bash ` (or the project‑standard for CLI) for commands, and ` ```text ` for plain output.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10.1-general-rules

---

- [ ] **5. Mixed narrative bold usage exceeding emphasis guidance**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/validator.mdx?plain=1#L16-L172

Labels like **Purpose**, **Syntax**, **Behavior**, **Example/Examples** are bolded repeatedly across sections. The guide discourages frequent bold spans and suggests using structure (headings, lists) instead. Replace these with plain text subheadings or transform them into lower‑level headings (e.g., `#### Purpose`). Keep bold use to minimal necessary emphasis.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.2-quotation-marks-and-emphasis

---

- [ ] **6. Hyphenation and casing of terms**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/validator.mdx?plain=1#L10-L96

Use consistent TON terminology casing: workchain, shardchain, masterchain (lowercase mid‑sentence). Also, use hyphen in base terms per guide (e.g., proof‑of‑stake). Ensure terms like “validator console” and “collator” match usage across docs; current usage appears consistent, but confirm lowercasing mid‑sentence (e.g., "validator-side" → "validator side" unless hyphenated compound is needed).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13.-terminology-and-naming

---

- [ ] **7. Missing Oxford comma in three‑item lists**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/validator.mdx?plain=1#L8–10

Lists with three or more items should use the serial comma. For example, “status, lite-client, or governance dashboards” is correct; review other lists for consistency. Fix any occurrences lacking the Oxford comma in similar constructions throughout the page.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.1-commas,-colons,-semicolons

---

- [ ] **8. Use of literal ellipses inside command examples**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/validator.mdx?plain=1#L33

Commands show truncated hashes with literal `...`, which can be mistaken for part of the command. Replace with a clear truncation pattern or brackets that are not pasted, or label as “Not runnable” partial snippet; per guide, avoid literal ellipses that change syntax. Minimal fix: use `<HASH_PART>` placeholders or show a single hash placeholder `<OFFER_HASH>`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10.5-comments-and-omissions

---

- [ ] **9. Headings start at H2 but section labels could be improved to imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/validator.mdx?plain=1#L12-L92

For task/procedure headings, prefer imperatives. “Governance and elections” and “Local collator registry” are category labels; if these sections contain procedures, consider imperative phrasing like “Vote on governance and elections” or keep as concept labels if intended as grouping. Requires doc owner decision; minimal change may be to keep as is if treated as grouping.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7.-headings-and-titles

---

- [ ] **10. Potential safety callouts missing for validator‑affecting operations**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/validator.mdx?plain=1#L96–175

Commands modify validator configuration and election behavior. The guide requires Caution/Warning callouts where validator/network state is affected. Add an appropriate `<Aside type="caution" title="Validator state change">` summarizing risk, scope, and mitigation (e.g., backup config and keys, test on testnet).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11.1-when-a-safety-callout-is-required; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11.2-how-to-write-the-callout

---

- [ ] **11. Use of non‑standard language tag `mytonctrl` in code fences**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/validator.mdx?plain=1#L20-L168

Fenced blocks must specify a language, but custom tags may not be recognized by tooling. Prefer `bash` for commands unless the docs renderer defines `mytonctrl`. If `mytonctrl` is a documented custom lexer across the repo, keep it; otherwise change to `bash`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10.1-general-rules

---

- [ ] **12. UI/log messages styled as code instead of quoted strings**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/validator.mdx?plain=1#L50-L175

UI/log output must appear verbatim in quotation marks (international style), not code font. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis. Minimal fix:
- Line 50: Prints “VoteElectionEntry - OK”.
- Line 175: prints “reset_collators - OK”.

---

- [ ] **13. “etc.” in list; prefer precise wording**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/validator.mdx?plain=1#L49

Using “etc.” in lists leaves scope ambiguous. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references. Minimal fix: replace with a closed phrase, for example: “Reuses configuration stored in the local database (stake amount, elector parameters, and related settings).”

---

- [ ] **14. Acronym not expanded on first mention (ADNL)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/validator.mdx?plain=1#L88

Per acronym rule, first mention should spell out the term with the acronym in parentheses. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms. Minimal fix: “locates the local Abstract Datagram Network Layer (ADNL) address …”

---

- [ ] **15. First mention of JSON not expanded**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/validator.mdx?plain=1

“JSON” appears without first-mention expansion (for example, in `print_collators` behavior). Expand once as “JavaScript Object Notation (JSON)”, then use “JSON” thereafter. Minimal fix: “With `--json`, returns the parsed collator list in JavaScript Object Notation (JSON) format, …”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **16. Syntax blocks are partial but not labeled “Not runnable”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/validator.mdx?plain=1#L18

Each “Syntax” block shows a prototype (with placeholders and optional elements), which is not copy‑pasteable. Partial snippets must be labeled. Minimal fix: insert a line “Not runnable” immediately above every Syntax code fence.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets