### PR TITLE
[AI] fix: pools.mdx

### DIFF
--- a/ecosystem/node/mytonctrl/pools.mdx
+++ b/ecosystem/node/mytonctrl/pools.mdx
@@ -62,8 +62,11 @@ delete_pool <pool-name>
 - Deletes the BoC/address files created for `<POOL_NAME>` from the pools directory; on-chain contracts remain untouched.
 - Useful when you migrate a pool to another host or retire a test deployment.
 
-<Aside type="caution" title="Local deletion">
-Deleting a pool removes only local metadata and artifacts (for example, .addr and .boc files). Back up these files before deletion if you may need them later.
+<Aside
+  type="caution"
+  title="Local deletion"
+>
+  Deleting a pool removes only local metadata and artifacts (for example, .addr and .boc files). Back up these files before deletion if you may need them later.
 </Aside>
 
 **Example**
@@ -159,8 +162,11 @@ deposit_to_pool <pool-addr> <amount-ton>
 
 Placeholders: `<POOL_ADDR>` is the pool’s bounceable address; `<AMOUNT_TON>` is the TON amount.
 
-<Aside type="danger" title="Funds at risk">
-Mainnet: transfers are irreversible and affect the specified wallet/pool balance. Testnet: verify the full flow first. There is no on-chain rollback.
+<Aside
+  type="danger"
+  title="Funds at risk"
+>
+  Mainnet: transfers are irreversible and affect the specified wallet/pool balance. Testnet: verify the full flow first. There is no on-chain rollback.
 </Aside>
 
 **Behavior**
@@ -185,8 +191,11 @@ deposit_to_pool EQB1e...6g 1000
 withdraw_from_pool <pool-addr> <amount-ton>
 ```
 
-<Aside type="danger" title="Funds at risk">
-Mainnet: transfers are irreversible and affect the specified wallet/pool balance. Testnet: verify the full flow first. There is no on-chain rollback.
+<Aside
+  type="danger"
+  title="Funds at risk"
+>
+  Mainnet: transfers are irreversible and affect the specified wallet/pool balance. Testnet: verify the full flow first. There is no on-chain rollback.
 </Aside>
 
 **Behavior**
@@ -260,8 +269,11 @@ activate_single_pool vip-client
 withdraw_from_single_pool <pool-addr> <amount-ton>
 ```
 
-<Aside type="danger" title="Funds at risk">
-Mainnet: transfers are irreversible and affect the specified wallet/pool balance. Testnet: verify the full flow first. There is no on-chain rollback.
+<Aside
+  type="danger"
+  title="Funds at risk"
+>
+  Mainnet: transfers are irreversible and affect the specified wallet/pool balance. Testnet: verify the full flow first. There is no on-chain rollback.
 </Aside>
 
 **Behavior**


### PR DESCRIPTION
- [ ] **1. Placeholders not in <ANGLE_CASE> format**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/pools.mdx?plain=1#L31-L236

Placeholders use kebab-case (e.g., `<pool-name>`, `<pool-addr>`, `<amount-ton>`). Rule requires `<ANGLE_CASE>` with descriptive names. Minimal fix: replace with `<POOL_NAME>`, `<POOL_ADDR>`, `<AMOUNT_TON>`, `<VALIDATOR_REWARD_SHARE_PERCENT>`, `<MAX_NOMINATORS_COUNT>`, `<MIN_VALIDATOR_STAKE_TON>`, `<MIN_NOMINATOR_STAKE_TON>`, `<OWNER_ADDRESS>`, and update matching mentions in Behavior bullets.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-5-placeholder-names

---

- [ ] **2. “BOC” capitalization should be “BoC” in prose**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/pools.mdx?plain=1#L58-L221

The abbreviation for Bag of Cells must be “BoC” (not “BOC”) in prose. Minimal fix: change “BOC” → “BoC” while keeping the `.boc` file extension as-is.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-4-ton-specific-examples

---

- [ ] **3. Hyphenated “smart-contract” should be “smart contract”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/pools.mdx?plain=1#L21-L36

Generic concepts must not be capitalized or hyphenated mid‑sentence. Minimal fix: change “smart-contract” → “smart contract”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-2-general-casing-rules

---

- [ ] **4. Truncated addresses lack disclosure and consistent pattern**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/pools.mdx?plain=1#L43-L248

Examples show silently truncated addresses (e.g., `EQC02...fa8`, `EQB1e...6g`) with mixed patterns and `...`. Rule requires stating truncation and using a consistent style (e.g., first 4 / last 4 with an ellipsis: `EQC0…9gA`). Minimal fix: (a) standardize all truncated addresses to first 4 / last 4 using the `…` character, and (b) add a one‑sentence note before the first example: “Addresses in examples are truncated (first 4 / last 4) and are not copyable.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#14-2-units-and-conventions

---

- [ ] **5. Missing safety callouts for commands that move funds**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/pools.mdx?plain=1#L140–158, 160–179, 229–248

Commands that deposit/withdraw funds require a Warning/Caution callout. Minimal fix: add `<Aside type="danger" title="Funds at risk">` under `deposit_to_pool`, `withdraw_from_pool`, and `withdraw_from_single_pool` with: risk (irreversible transfers on mainnet), scope (affects the specified wallet/pool), mitigation/rollback (no on‑chain rollback; verify on testnet first), and an explicit testnet/mainnet label per the example in §11.2.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-1-when-a-safety-callout-is-required; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout

---

- [ ] **6. Use present tense instead of “will” for general behavior**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/pools.mdx?plain=1#L83-L172

Style prefers present tense for general behavior. Minimal fix: “the pool will accept” → “the pool accepts”; “that will execute once the pool cycle allows it” → “that executes once the pool cycle allows it”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-1-voice-and-tense

---

- [ ] **7. Acronym “ADNL” not expanded on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/pools.mdx?plain=1#L130

On first mention, spell out the term and follow with the acronym. Minimal fix: “when the validator ADNL set changes” → “when the validator Abstract Datagram Network Layer (ADNL) set changes”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **8. **6. UI labels styled as code; should be quoted UI text****

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/pools.mdx?plain=1#L22

Table column names are formatted in code font: `Name`, `Status`, `Balance`, `Version`, `Address`. The guide specifies quotation marks for literal UI strings. Minimal fix: use quotes with international style punctuation: “Name”, “Status”, “Balance”, “Version”, and “Address”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **9. **7. Semicolons in list items reduce scanability****

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/pools.mdx?plain=1#L107

Several bullets join independent clauses with semicolons (e.g., lines 21, 107, 172). The guide recommends rare semicolon use; prefer short sentences. Minimal fix: split into two sentences (e.g., “If the pool account is still empty, it signs and broadcasts the deployment message. If it is already active, it logs a warning and exits without changes.”).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **10. **8. Missing comma after introductory “if” clause****

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/pools.mdx?plain=1#L21

“if an account is inactive it falls back …” is missing a comma after the introductory clause. Minimal fix: add the comma: “If an account is inactive, it falls back to the deployment (init) address.” This follows common English grammar for introductory dependent clauses (general knowledge).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **11. Silent truncation of addresses in examples**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/pools.mdx?plain=1#L43

Examples show shortened addresses like “EQC02...fa8”, which violates the ban on silent truncation. Replace truncated IDs with explicit placeholders, e.g., `<POOL_ADDR>`. Apply to lines 43, 135, 157, 179, 204, and 248.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#severity-model-release‑blocking

---

- [ ] **12. Add caution callout for destructive local deletion**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/pools.mdx?plain=1#L46

`delete_pool` removes local artifacts and can cause non‑recoverable local data loss. Add an `<Aside type="caution">` near the command to warn users to back up `.addr`/`.boc` files before deletion and clarify scope (local only).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-1-when-a-safety-callout-is-required, https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#rendering-component

---

- [ ] **13. Placeholders not in ANGLE_CASE and undefined at first use**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/pools.mdx?plain=1#L31

Placeholders use hyphenated/lowercase forms like `<pool-name>`, `<pool-addr>`, and `<amount-ton>`. The style guide requires `<ANGLE_CASE>` placeholders and a definition on first use. Minimal fix: change these to `<POOL_NAME>`, `<POOL_ADDR>`, `<AMOUNT_TON>` (and similar: `<VALIDATOR_REWARD_SHARE_PERCENT>`, `<MAX_NOMINATORS_COUNT>`, `<MIN_VALIDATOR_STAKE_TON>`, `<MIN_NOMINATOR_STAKE_TON>`, `<OWNER_ADDRESS>`), and add a one‑line definition after the first Syntax block where each placeholder first appears. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules