### PR TITLE
[AI] fix: how-to-transfer.mdx

### DIFF
--- a/standard/tokens/jettons/how-to-transfer.mdx
+++ b/standard/tokens/jettons/how-to-transfer.mdx
@@ -114,4 +114,4 @@ async function main() {
 void main();
 ```
 
-JETTON_ADDRESS — jetton master address; RECEIVER_ADDRESS — destination wallet address.
+JETTON\_ADDRESS — jetton master address; RECEIVER\_ADDRESS — destination wallet address.


### PR DESCRIPTION
- [ ] **1. Semicolons in list items; use periods**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-transfer.mdx?plain=1#L10

List items end with semicolons, which the guide discourages. Minimal fix: replace trailing semicolons with periods in both list items.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **2. Avoid first-person “we”; use neutral phrasing**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-transfer.mdx?plain=1#L14

“We present here only the simple comment format.” uses first-person. Minimal fix: “This page shows only the simple comment format.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-1-voice-and-tense

---

- [ ] **3. Remove filler “just” and fix comma splice**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-transfer.mdx?plain=1#L16

“..., and avoid writing code, just follow the guides.” contains filler (“just”) and a comma splice. Minimal fix: “First, you can use web services such as TON MINTER to avoid writing code. Follow the guides.” (Also changes “as” → “such as” for correct idiom; basic grammar per general knowledge.)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **4. Placeholder format must use angle brackets**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-transfer.mdx?plain=1#L27-L29

Placeholders are written as free-form strings. Minimal fix: change to angle-bracket placeholders: `'put your jetton wallet address'` → `'<JETTON_WALLET_ADDR>'`; `'put destination wallet address'` → `'<DESTINATION_ADDR>'`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles

---

- [ ] **5. Don’t encourage pasting secrets; use env var**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-transfer.mdx?plain=1#L61-L66

Hard-coding a mnemonic string invites secrets in examples ([HIGH]). Minimal fix: use an environment variable with a guard, mirroring other pages: `const MNEMONIC = process.env.MNEMONIC; if (!MNEMONIC) throw new Error("Set MNEMONIC to a test mnemonic (testnet)."); const keyPair = await mnemonicToPrivateKey(MNEMONIC.split(" "));` (Replace current `your_mnemonic` lines.)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#severity-model-release-blocking

---

- [ ] **6. Add a Warning callout about funds/keys risk**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-transfer.mdx?plain=1#L5

This how-to sends on-chain messages and may move funds; it lacks a safety callout. Minimal fix: add an `<Aside type="danger" title="Warning — funds at risk">` with scope, rollback, and testnet-first guidance (reuse pattern from `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-mint.mdx?plain=1#L8-L19`).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#19-appendices-a-admonition-levels-and-usage

---

- [ ] **7. Simplify phrasing for clarity**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-transfer.mdx?plain=1#L18

“Below there are two illustrative examples:” is wordy. Minimal fix: “Below are two examples:”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **8. Define placeholders at first use**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-transfer.mdx?plain=1#L20

Placeholders should be defined where introduced. Minimal fix: add one line before the first code block defining `<JETTON_WALLET_ADDR>` as “your jetton wallet address” and `<DESTINATION_ADDR>` as “the destination wallet address.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles

---

- [ ] **9. Make the first snippet runnable or label partial**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-transfer.mdx?plain=1#L78

The first code sample defines `main()` but does not invoke it, unlike the second snippet. Minimal fix: add `void main();` at the end of the first code block to make it copy-pasteable and runnable.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles

---

- [ ] **10. Use descriptive link text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-transfer.mdx?plain=1#L80

Link text “SDK” is vague. Minimal fix: change to “Assets SDK” to match the target and improve accessibility.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-links-and-anchors

---

- [ ] **11. Remove non-actionable filler sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-transfer.mdx?plain=1#L17

“Second, you can use your favorite IDE.” adds no actionable guidance. Minimal fix: remove this sentence.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **12. External TEP link used instead of internal canonical page**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-transfer.mdx?plain=1#L6-L14

This how-to links directly to the TEP for message semantics. Per the docs, internal pages should be linked first, with precise anchors, and TEPs added only as canonical specs when appropriate. Minimal fix: link to `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/API.mdx?plain=1#L12` (`#transfer-message-layout`) and `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/API.mdx?plain=1#L32` (`#forward-payload-formats`) on first mention, and keep the TEP deep link as an additional reference if needed.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references

---

- [ ] **13. Missing colon before a list**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-transfer.mdx?plain=1#L8-L9

“This scheme involves, among other things,” introduces a list but lacks the required colon after a complete clause. Minimal fix: change to “This scheme involves, among other things:”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **14. Inconsistent list item punctuation (phrases end with semicolon/period)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-transfer.mdx?plain=1#L10-L11

These list items are noun phrases and shouldn’t end with terminal punctuation. Minimal fix: remove the trailing semicolon and period so both bullets end with no punctuation.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **15. Acronym not expanded on first use (“IDE”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-transfer.mdx?plain=1#L17

“IDE” appears without definition. Minimal fix: “integrated development environment (IDE)”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **16. Mid-sentence capitalization of “Jetton” (should be lowercase)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-transfer.mdx?plain=1#L6-L17

Use lowercase “jetton” mid-sentence for common nouns. Minimal fix: change “Jetton wallet contracts”, “Jetton transfer message”, and “Jetton wallet” to “jetton wallet contracts”, “jetton transfer message”, and “jetton wallet”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-4-ton-specific-examples

---

- [ ] **17. Defaulting examples to mainnet conflicts with safer defaults**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-transfer.mdx?plain=1#L89-L90

Examples SHOULD default to testnet to reduce risk. Minimal fix: set `const NETWORK = 'testnet';` and add a note or callout on switching to mainnet when ready.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-3-safer-defaults

---

- [ ] **18. Missing placeholder definitions for second snippet**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-transfer.mdx?plain=1#L106-L111

Placeholders `JETTON_ADDRESS` and `RECEIVER_ADDRESS` are not defined near first use. Minimal fix: add brief definitions immediately below the code block (e.g., `JETTON_ADDRESS — jetton master address; RECEIVER_ADDRESS — destination wallet address`).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **19. Acronym not expanded on first use (“SDK”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-transfer.mdx?plain=1#L80-L81

“SDK” appears without definition on this page. Minimal fix: expand on first mention as “software development kit (SDK)”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **20. Placeholder style in code (use UPPER_SNAKE, avoid prose/ellipsis)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-transfer.mdx?plain=1#L27-L61

Placeholders appear as prose strings and include an ellipsis (e.g., 'put your jetton wallet address', 'put destination wallet address', 'put your mnemonic here, ...'). In language code, placeholders should be obvious tokens, not natural‑language sentences or literal ellipses. Minimal fix: use UPPER_SNAKE placeholders, for example: `Address.parse('JETTON_WALLET_ADDRESS')`, `Address.parse('DESTINATION_ADDRESS')`, and read `MNEMONIC` from env (see next item) rather than inlining a string.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-5-placeholder-names; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-5-comments-and-omissions

---

- [ ] **21. Link core term to Glossary on first useful mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-transfer.mdx?plain=1#L6

On first useful mention of a core TON term, link to the Glossary unless the page defines it. Minimal fix: link “jetton” (first mention) to `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/glossary.mdx?plain=1`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-2-what-to-link-and-what-not

---

- [ ] **22. Acronyms not expanded on first mention (TL‑B, SDK, IDE)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-transfer.mdx?plain=1#L8-L80

On first use, spell out the term and follow with the acronym in parentheses. Minimal fixes: “Type Language Binary (TL‑B) scheme”; “Software Development Kit (SDK)”; “integrated development environment (IDE)”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **23. Internal link should be relative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-transfer.mdx?plain=1#L17

Internal links should be relative to avoid coupling to absolute paths. Minimal fix: change `](/standard/tokens/jettons/how-to-find)` → `](./how-to-find)` (or match the repo’s established relative pattern). If the nearby pages consistently use a different internal-link pattern, prefer consistency with that pattern when the guide is silent; otherwise, follow the guide and use relative links.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format

---

- [ ] **24. Use stable permalink for TEP-74 link**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-transfer.mdx?plain=1#L6

The link to the TEP-74 specification points to the moving `master` branch. For normative references, use a versioned or commit permalink to prevent drift. Minimal fix: replace the URL with a GitHub commit permalink to the exact section anchor.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#stable-permalinks

---

- [ ] **25. Use stable permalink for forward_payload-format anchor**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-transfer.mdx?plain=1#L13

The deep link to the `forward_payload-format` section also targets `master`. For precision-critical anchors in standards, link to a specific commit. Minimal fix: update the URL to a commit permalink that preserves the exact anchor.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#stable-permalinks

---

- [ ] **26. Define acronym on first mention: TEP**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-transfer.mdx?plain=1#L6

“TEP 0074” appears without expansion. Define once, then use the acronym. Minimal fix: “TON Enhancement Proposal (TEP) 0074”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#acronyms-and-terms

---

- [ ] **27. Use present tense in code comments**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/how-to-transfer.mdx?plain=1#L43

Comment uses future tense: “will send notification message”. Use present tense for general behavior. Minimal fix: “sends a notification message”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#tone-and-voice