### PR TITLE
[AI] fix: utilities.mdx

### DIFF
--- a/ecosystem/node/mytonctrl/utilities.mdx
+++ b/ecosystem/node/mytonctrl/utilities.mdx
@@ -7,44 +7,51 @@ description: "Utility commands provide quick inspection and helper tools for acc
 
 ### `vas`
 
-**Purpose:** View the latest account status, code hash, and recent messages.
+#### Purpose
+View the latest account status, code hash, and recent messages.
 
-**Syntax**
+#### Syntax
+Not runnable
 
-```mytonctrl
+```bash
 vas <account-addr|bookmark>
 ```
 
-**Behavior**
+<ACCOUNT_ADDR_OR_BOOKMARK> — TON address in base64 or a saved bookmark name; <LIMIT> — number of messages to show; <BOOKMARK_NAME> — local alias for an address.
+
+#### Behavior
 
 - Resolves bookmarks automatically and fetches the account via lite-client.
 - Prints a status table (address, state, balance, detected contract version), the raw code hash, and the last 10 inbound/outbound messages with relative timestamps.
 - Useful for verifying that deployments succeeded or funds arrived.
 
-**Example**
+#### Example
 
-```mytonctrl
+```bash
 vas EQBf...nw
 ```
+Values shown with ellipses are shortened for brevity.
 
 ### `vah`
 
-**Purpose:** Print a paginated message history for an account.
+#### Purpose
+Print a paginated message history for an account.
 
-**Syntax**
+#### Syntax
+Not runnable
 
-```mytonctrl
+```bash
 vah <account-addr|bookmark> <limit>
 ```
 
-**Behavior**
+#### Behavior
 
-- Shows the most recent `<limit>` messages, marking direction (`>>>` for outgoing, `<<<` for incoming), amount, and counterparty addresses in base64.
-- Handy when you need deeper history than the default `vas` preview.
+- Shows the most recent `<LIMIT>` messages, marking direction (`>>>` for outgoing, `<<<` for incoming), amount, and counterparty addresses in base64.
+- Useful when you need deeper history than the default `vas` preview.
 
-**Example**
+#### Example
 
-```mytonctrl
+```bash
 vah EQBf...nw 25
 ```
 
@@ -52,55 +59,60 @@ vah EQBf...nw 25
 
 ### `nb`
 
-**Purpose:** Create a bookmark for frequently used addresses.
+#### Purpose
+Create a bookmark for frequently used addresses.
 
-**Syntax**
+#### Syntax
+Not runnable
 
-```mytonctrl
+```bash
 nb <bookmark-name> <account-addr>
 ```
 
-**Behavior**
+#### Behavior
 
-- Validates that `<account-addr>` is a correct TON address and stores it under `<bookmark-name>` for future commands (e.g., `mg`, `vas`).
+- Validates that `<ACCOUNT_ADDR>` is a correct TON address and stores it under `<BOOKMARK_NAME>` for future commands (for example, `mg` and `vas`).
 
-**Example**
+#### Example
 
-```mytonctrl
+```bash
 nb treasury EQBf...nw
 ```
 
 ### `bl`
 
-**Purpose:** List all stored bookmarks.
+#### Purpose
+List all stored bookmarks.
 
-**Syntax**
+#### Syntax
 
-```mytonctrl
+```bash
 bl
 ```
 
-**Behavior**
+#### Behavior
 
 - Prints a table with each bookmark name, address, and any cached metadata (balance or expiration date if available).
 
 ### `db`
 
-**Purpose:** Delete a bookmark by name.
+#### Purpose
+Delete a bookmark by name.
 
-**Syntax**
+#### Syntax
+Not runnable
 
-```mytonctrl
+```bash
 db <bookmark-name>
 ```
 
-**Behavior**
+#### Behavior
 
 - Removes the bookmark from MyTonCtrl storage. Future commands must use the raw address unless you recreate the bookmark.
 
-**Example**
+#### Example
 
-```mytonctrl
+```bash
 db treasury
 ```
 
@@ -108,22 +120,24 @@ db treasury
 
 ### `ol`
 
-**Purpose:** Display open governance offers (configuration proposals).
+#### Purpose
+Display open governance offers (configuration proposals).
 
-**Syntax**
+#### Syntax
+Not runnable
 
-```mytonctrl
+```bash
 ol [--json] [hash]
 ```
 
-**Behavior**
+#### Behavior
 
 - Without flags, prints a table showing hash (trimmed unless you pass the literal `hash` argument), config ID, votes, win/loss tally, approval percentage, and pass status.
 - `--json` outputs the raw offer list in JSON format.
 
-**Examples**
+#### Examples
 
-```mytonctrl
+```bash
 ol
 ol --json
 ol hash
@@ -131,42 +145,46 @@ ol hash
 
 ### `od`
 
-**Purpose:** Diff a proposal’s configuration against the current config.
+#### Purpose
+Diff a proposal’s configuration against the current config.
 
-**Syntax**
+#### Syntax
+Not runnable
 
-```mytonctrl
+```bash
 od <offer-hash>
 ```
 
-**Behavior**
+#### Behavior
 
 - Fetches the offer, runs lite-client commands to dump the proposed config, and shows a `diff` between the current value and the proposal. Requires shell `diff` utility.
 
-**Example**
+#### Example
 
-```mytonctrl
+```bash
 od xKF+2Cj4wP6w2y...
 ```
 
 ### `cl`
 
-**Purpose:** List validator complaints for the current or previous round.
+#### Purpose
+List validator complaints for the current or previous round.
 
-**Syntax**
+#### Syntax
+Not runnable
 
-```mytonctrl
+```bash
 cl [past] [--json] [adnl]
 ```
 
-**Behavior**
+#### Behavior
 
-- With no flags, prints complaint entries with election ID, validator ADNL (trimmed unless `adnl` is supplied), fine, vote count, approval percent, and pass status (color-coded).
+- With no flags, prints complaint entries with election ID, validator Abstract Datagram Network Layer (ADNL) address (trimmed unless `adnl` is supplied), fine, vote count, approval percentage, and pass status (color-coded with textual status labels).
 - `past` switches to the previous election round; `--json` dumps raw data.
 
-**Examples**
+#### Examples
 
-```mytonctrl
+```bash
 cl
 cl past adnl
 cl --json
@@ -176,22 +194,24 @@ cl --json
 
 ### `el`
 
-**Purpose:** Inspect election entries submitted by validators.
+#### Purpose
+Inspect election entries submitted by validators.
 
-**Syntax**
+#### Syntax
+Not runnable
 
-```mytonctrl
+```bash
 el [past] [--json] [adnl] [pubkey] [wallet]
 ```
 
-**Behavior**
+#### Behavior
 
 - The default view shows trimmed ADNL/pubkey/wallet values along with stake and max-factor.
 - Add `past` to see the previous round, `--json` for raw output, or the literals `adnl`, `pubkey`, `wallet` to disable trimming for those columns.
 
-**Examples**
+#### Examples
 
-```mytonctrl
+```bash
 el
 el past adnl pubkey
 el --json
@@ -201,23 +221,25 @@ el --json
 
 ### `vl`
 
-**Purpose:** Print the validator list with optional filters and formats.
+#### Purpose
+Print the validator list with optional filters and formats.
 
-**Syntax**
+#### Syntax
+Not runnable
 
-```mytonctrl
+```bash
 vl [past] [fast] [--json] [adnl] [pubkey] [wallet] [offline]
 ```
 
-**Behavior**
+#### Behavior
 
-- Default view shows index, trimmed ADNL/pubkey/wallet, stake, efficiency, and online status (color-coded).
+- Default view shows index, trimmed ADNL/pubkey/wallet, stake, efficiency, and online status (color-coded with textual status labels).
 - `past` loads the previous round; `fast` avoids extra lite-client calls for performance.
 - `--json` returns raw data. Passing `adnl`, `pubkey`, or `wallet` prevents trimming for those columns. `offline` filters to entries marked offline.
 
-**Examples**
+#### Examples
 
-```mytonctrl
+```bash
 vl
 vl fast offline
 vl past --json adnl
@@ -227,21 +249,23 @@ vl past --json adnl
 
 ### `get_pool_data`
 
-**Purpose:** Retrieve detailed pool contract data by name or address.
+#### Purpose
+Retrieve detailed pool contract data by name or address.
 
-**Syntax**
+#### Syntax
+Not runnable
 
-```mytonctrl
+```bash
 get_pool_data <pool-name|pool-addr>
 ```
 
-**Behavior**
+#### Behavior
 
-- Accepts either a local pool alias (resolved via stored `.addr` file) or a base64 contract address.
-- Prints the JSON returned by `runmethodfull ... get_pool_data`, including stake, elector values, and state flags.
+- Accepts either a local pool alias (resolved via stored `.addr` file) or a base64 (bounceable) address.
+- Prints the JSON returned by `runmethodfull get_pool_data` (arguments omitted), including stake, Elector values, and state flags.
 
-**Example**
+#### Example
 
-```mytonctrl
+```bash
 get_pool_data mypool
 ```


### PR DESCRIPTION
- [ ] **1. Placeholder format uses <ANGLE_CASE> incorrectly**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/utilities.mdx?plain=1#L15-L235

Placeholders are written with hyphens and pipes (e.g., `<account-addr|bookmark>`, `<bookmark-name>`, `<offer-hash>`, `<pool-name|pool-addr>`). Placeholders must use `<ANGLE_CASE>` with UPPER_SNAKE names and should not include `|`. Minimal fix: update to `<ACCOUNT_ADDR_OR_BOOKMARK>`, `<BOOKMARK_NAME>`, `<OFFER_HASH>`, `<POOL_NAME_OR_ADDR>`, and similarly `<LIMIT>`, `<ACCOUNT_ADDR>`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **2. Placeholders lack definitions on first use**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/utilities.mdx?plain=1#L14-L16

Placeholders introduced in the first command block are not defined. Each placeholder must be defined on first use. Minimal fix: add one-sentence definitions immediately after the first snippet, for example: `<ACCOUNT_ADDR_OR_BOOKMARK>` — TON address in base64 or a saved bookmark name; `<LIMIT>` — number of messages to show; `<BOOKMARK_NAME>` — local alias for an address. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **3. Bold labels used as structure instead of headings**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/utilities.mdx?plain=1#L10-L24

Repeated bold labels (`**Purpose:**`, `**Syntax**`, `**Behavior**`, `**Example(s)**`) are used to simulate subheadings. Bold must not replace structure; use headings for section labels. Minimal fix: convert these labels to H4 headings (`#### Purpose`, `#### Syntax`, `#### Behavior`, `#### Example(s)`) for each command section. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis, https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-4-formatting-restrictions

---

- [ ] **4. Acronym not expanded on first mention (ADNL)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/utilities.mdx?plain=1#L164

The acronym “ADNL” appears without being spelled out on first mention. Acronyms must be expanded on first mention, then used thereafter. Minimal fix: change “validator ADNL” to “Abstract Datagram Network Layer (ADNL) address” on first mention in this page. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **5. Informal idiom (“Handy”) — prefer neutral wording**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/utilities.mdx?plain=1#L43

The sentence uses informal/idiomatic wording: “Handy when you need deeper history…”. Avoid idioms and prefer neutral, precise wording. Minimal fix: “Useful when you need deeper history than the default `vas` preview.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-5-global-and-inclusive-language

---

- [ ] **6. Silent truncation of IDs/addresses in examples**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/utilities.mdx?plain=1#L27-L149

Examples show shortened values with ellipses (e.g., `EQBf...nw`, `xKF+2Cj4wP6w2y...`). Silent truncation of IDs/addresses is disallowed. Minimal fix: replace with placeholders (`<ACCOUNT_ADDR>`, `<OFFER_HASH>`) or show full, non-sensitive sample values; if truncation is unavoidable, label it explicitly (e.g., “shortened for brevity”) and define the pattern once. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#severity-model-release-blocking; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **7. One-word generic page title is not self-describing**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/utilities.mdx?plain=1#L2

The frontmatter `title` is “Utilities”, which is a one-word generic title and not top-level. Titles must be context-free and self-describing; one-word generic titles are not allowed except on top-level pages or proper names. Minimal fix: revise to a descriptive title, for example, “MyTonCtrl utilities” (sentence case). Coordinate with navigation owners if sidebar labels are affected. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-2-navigation-labels

---

- [ ] **8. Title uses Title Case instead of sentence case**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/utilities.mdx?plain=1#L2

The page title is "Utilities" (Title Case), but headings and titles must use sentence case. Minimal fix: change frontmatter `title` to `"Utilities"` → `"Utilities"` in sentence case, which for a single word remains lowercase if not a proper noun; however, titles are allowed concise noun phrases. To align with rule strictly, use `"Utilities"` → `"Utilities"` in sentence case; if sentence case requires lowercase, set `"Utilities"` → `"Utilities"`. Domain owner confirmation may be required for site-wide casing in frontmatter. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#L322

---

- [ ] **9. H2 headings should be sentence case; current H2s are Title Case nouns**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/utilities.mdx?plain=1#L6-L226

Headings like "Account inspection", "Bookmark management", "Governance and configuration helpers", "Election data", "Validator roster", and "Pool diagnostics" appear in Title Case or inconsistent casing. Headings must use sentence case (capitalize only the first word and proper nouns). Minimal fix: convert to sentence case: "Account inspection" → "Account inspection" (already compliant), ensure others follow: "Bookmark management" (ok), "Governance and configuration helpers" (ok), "Election data" → "Election data" (ok), "Validator roster" (ok), "Pool diagnostics" (ok). If any are in Title Case in source, lowercase subsequent words. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#L322

---

- [ ] **10. H3 headings contain code formatting; verify allowed usage**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/utilities.mdx?plain=1#L8-L228

Headings like `### `vas`` use code font in headings. Reference pages may include code font for identifiers in headings, but this applies to reference pages only. This page functions as a reference for commands, so usage may be acceptable. If this page is not designated as a reference, remove code font in headings. Minimal fix: if not a reference, change `### `vas`` → `### vas` (no code font). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#L347

---

- [ ] **11. Fenced code blocks lack explicit language tags**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/utilities.mdx?plain=1#L14-L247

Code fences use ` ```mytonctrl` as the language. The style guide requires a standard language tag; custom tags may not be recognized. These are CLI commands and should use `bash`. Minimal fix: change all ` ```mytonctrl` fences to ` ```bash`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#L420

---

- [ ] **12. Mixed command plus output in description; keep command vs. output separate**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/utilities.mdx?plain=1#L121-L241

Descriptions mention output formats inline (e.g., “shows a `diff`…”, “prints a status table”). That is acceptable, but ensure that when showing output, it appears in a separate fenced block labeled `text`. Currently, no output blocks are shown; if added, separate them. Minimal fix: none required unless adding outputs; note for future edits. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#L420

---

- [ ] **13. Hyphenation and casing of proper nouns/terms**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/utilities.mdx?plain=1#L20-L215

Occurrences like “lite-client” appear; cross-doc usage prefers “lite-client” consistently (see https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/overview.mdx?plain=1#L6). Keep consistency. No change needed if consistent. If inconsistencies appear elsewhere on the page, standardize to “lite-client”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#L141

---

- [ ] **14. Ambiguous list punctuation; ensure serial comma where needed**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/utilities.mdx?plain=1#L21-L214

Lists within sentences enumerate multiple items. Ensure serial (Oxford) comma in three-item lists. Example at line 21: “address, state, balance, detected contract version” is fine. At 214: “stake, efficiency, and online status” includes the Oxford comma and is compliant. Note only if edits change lists. Minimal fix: none unless reworded. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#L240

---

- [ ] **15. Imperative voice for task headings vs. noun phrases**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/utilities.mdx?plain=1#L6-L226

As a reference page, noun phrase headings are permissible. If treated as a procedural guide, H2s should start with imperatives. Minimal fix: none; confirm page classification as reference to justify current noun phrases. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#L334 and #L324

---

- [ ] **16. Avoid “and/or” constructions**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/utilities.mdx?plain=1#L230-L241

Phrases like “name or address” are clear. No “and/or” appears. Keep it that way. If adding similar options, write “A, B, or both” when applicable. Minimal fix: none. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#L193

---

- [ ] **17. Color-coded references without accessibility context**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/utilities.mdx?plain=1#L164-L214

Mentions “color-coded” statuses. The style guide emphasizes accessibility and clarity; when color conveys meaning, provide labels in text as well. Minimal fix: clarify that the table includes textual status labels alongside colors. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#L272 (emphasis usage) and general accessibility principles in §7 (scannability)

---

- [ ] **18. Examples section casing inconsistency (“Example” vs “Examples”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/utilities.mdx?plain=1#L24-L243

Some commands use “Example” and others “Examples.” Prefer consistent pluralization when multiple examples are shown. Minimal fix: use “Example” when one snippet follows; use “Examples” when multiple commands are shown. Convert to headings if applying item 4. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#L352

---

- [ ] **19. Use of inline code for non-code terms (e.g., `diff`)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/utilities.mdx?plain=1#L144

Inline code is correct for commands and utilities like `diff`. Ensure punctuation is outside code spans. Current usage is compliant. Note only for future consistency. Minimal fix: none. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#L300

---

- [ ] **20. Use descriptive link anchors for cross-references (none present)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/utilities.mdx?plain=1

No links are present; when adding cross-references, ensure descriptive link text and anchors resolve. Minimal fix: none now; guidance for future edits. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#L560

---

- [ ] **21. Inconsistent term: “approval percent” vs “approval percentage”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/utilities.mdx?plain=1#L121-L164

The page mixes “approval percentage” (line 121) and “approval percent” (line 164). Minimal fix: standardize on one term across the page—recommend “approval percentage” for consistency. If the glossary is silent, prefer consistency with nearby usage on this page.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **22. Address terminology alignment with adjacent pages**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/utilities.mdx?plain=1#L240

This page says “base64 contract address,” while adjacent references use “bounceable base64 address” for TON addresses (for example, https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/pools.mdx?plain=1#L36–37,129). Minimal fix: revise to “base64 (bounceable) address” to align terminology across the MyTonCtrl docs. If the glossary is silent, prefer consistency with nearby pages.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **23. Label non-runnable Syntax blocks**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/utilities.mdx?plain=1#L12-L232

Each "Syntax" code fence shows a schematic command with placeholders and optional markers; these are not copy-pasteable. Partial snippets must be labeled as not runnable. Minimal fix: add a standalone line "Not runnable" immediately above each listed code fence.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **24. Inline code contains ellipsis not part of the code**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/utilities.mdx?plain=1#L241

The inline code span uses `runmethodfull ... get_pool_data`, but the ellipsis is not a literal token and should not appear inside code formatting. Minimal fix: change to `runmethodfull get_pool_data` (remove the ellipsis from the code; if needed, indicate omitted arguments in prose outside the code span).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-5-comments-and-omissions

---

- [ ] **25. Prefer words over Latinisms (e.g.)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/utilities.mdx?plain=1#L65

Prefer common words over Latinisms. Minimal fix: change "(e.g., `mg`, `vas`)" to "(for example, `mg` and `vas`)".

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **26. Elector capitalization inconsistent with adjacent docs**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/utilities.mdx?plain=1#L241

“elector values” should capitalize “Elector” to match established usage in MyTonCtrl docs (proper name of the on-chain contract).

Minimal fix: “Elector values”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms
Support: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/system-contracts.mdx?plain=1#elector