### PR TITLE
[AI] fix: types.mdx

### DIFF
--- a/language/func/types.mdx
+++ b/language/func/types.mdx
@@ -28,14 +28,15 @@ Each of these types occupies a single stack entry in the TVM stack.
 
 FunC does not have a dedicated boolean type.
 Instead, booleans are represented as integers:
+
 - `false` is `0`, `true` is `-1` (a 257-bit integer with all bits set to 1).
 - Logical operations use bitwise operators.
 - In conditional checks, any nonzero integer is treated as `true`.
 
 ### Null values
 
-In FunC, the `null` value of the TVM type `Null` represents the absence of a value for a given atomic type. 
-Any atomic type variable can have `null` to indicate absence of a value. 
+In FunC, the `null` value of the TVM type `Null` represents the absence of a value for a given atomic type.
+Any atomic type variable can have `null` to indicate absence of a value.
 
 For functions:
 
@@ -51,6 +52,7 @@ FunC supports type inference. The hole types `_` and `var` serve as placeholders
 For example, in the declaration:
 
 Not runnable
+
 ```func
 var x = 2;
 ```
@@ -61,11 +63,13 @@ and both sides of the assignment must have matching types.
 As another example, in the following function declaration (see [Function declarations](/language/func/functions#function-declaration) for more details):
 
 Not runnable
+
 ```func
 _ someFunction(int a) {
   return a + 1;
 }
 ```
+
 the type checker infers that `_` must have type `int`, since the type of the returned expression `a + 1` is `int`.
 
 ## Composite types
@@ -75,16 +79,19 @@ Types can be combined to form more complex structures.
 ### Functional type
 
 A functional type is written in the form `A → B`, where:
+
 - `A` is the input type, which is called the domain.
 - `B` is the output type, which is called the codomain.
 
 #### Example
+
 The type `int → cell` represents a function that:
+
 - Takes an integer as input.
 - Returns a TVM cell as output.
 
-As in functional programming, it is possible to declare functional types which have in their domain and codomain other functional types. 
-For example, `(int → int) → int` is a function with domain `int → int` and codomain `int`. 
+As in functional programming, it is possible to declare functional types which have in their domain and codomain other functional types.
+For example, `(int → int) → int` is a function with domain `int → int` and codomain `int`.
 Similarly, `int → (int → int)` is a function with domain `int` and codomain `int → int`.
 
 ### Tensor types
@@ -93,6 +100,7 @@ Tensor types represent ordered collections of values and are written in the form
 These types occupy multiple TVM stack entries, unlike atomic types, which use a single entry.
 
 #### Example
+
 If a function `foo` has the type `int → (int, int)`,
 it takes one integer as input and returns a pair of integers as output.
 A call to this function may look like: `(int a, int b) = foo(42);`.
@@ -102,25 +110,28 @@ Internally, the function consumes one stack entry and produces two.
 For instance, the following code **will not compile**:
 
 Not runnable
+
 ```func
 (int a, int b, int c) = (2, (3, 9));
 ```
+
 Since FunC strictly enforces type consistency, these structures cannot be mixed.
 
 <Aside type="note">
-
-A type of the form `(A)` is considered the same type as `A` by the type checker.
-
+  A type of the form `(A)` is considered the same type as `A` by the type checker.
 </Aside>
 
 #### Unit type ()
+
 The unit type `()` is used to indicate that:
+
 - A function does not return a value.
 - A function takes no arguments.
 
 The unit type `()` has a single value, also written as `()`, occupying **zero stack** entries.
 
 #### Examples
+
 - `print_int` has the type `int → ()`, meaning it takes an integer but returns nothing.
 - `random` has the type `() → int`, meaning it takes no arguments but returns an integer.
 
@@ -129,13 +140,14 @@ The unit type `()` has a single value, also written as `()`, occupying **zero st
 Tuple types in FunC are written in the form `[A, B, ...]` and represent TVM tuples with a fixed length and known component types at compile time.
 
 For example, `[int, cell]` defines a tuple with exactly two elements:
+
 - The first element is an integer.
 - The second element is a cell.
 
 The type `[]` represents an empty tuple with a unique value—the empty tuple itself.
 
 <Aside type="note">
-Unlike the unit type `()`, an empty tuple `[]` occupies one stack entry.
+  Unlike the unit type `()`, an empty tuple `[]` occupies one stack entry.
 </Aside>
 
 ## Polymorphism with type variables
@@ -144,14 +156,15 @@ FunC features a custom type system with support for polymorphic functions.
 For example, consider the following function:
 
 Not runnable
+
 ```func
 forall X -> (X, X) duplicate(X value) {
   return (value, value);
 }
 ```
 
-Here, `X` is a type variable that allows the function to operate on values of any type. Type variables are declared after `forall` and before `->`. 
-The function receives a value of type `X`, and duplicates this value to return a value of type `(X, X)`. 
+Here, `X` is a type variable that allows the function to operate on values of any type. Type variables are declared after `forall` and before `->`.
+The function receives a value of type `X`, and duplicates this value to return a value of type `(X, X)`.
 
 For example,
 
@@ -159,10 +172,8 @@ For example,
 - Calling `duplicate([])` produces two copies of an empty tuple: `([], [])`.
 
 <Aside type="note">
-
-Type variables in polymorphic functions cannot be instantiated with tensor types. 
-There is only one exception: the tensor type `(a)`, where `a` is not a tensor type itself, since the compiler treats `(a)` as if it was `a`.
-
+  Type variables in polymorphic functions cannot be instantiated with tensor types.
+  There is only one exception: the tensor type `(a)`, where `a` is not a tensor type itself, since the compiler treats `(a)` as if it was `a`.
 </Aside>
 
 For more details, see the [Polymorphism with forall](/language/func/functions#polymorphism-with-forall) section.
@@ -176,5 +187,5 @@ FunC does not support defining custom types beyond the type constructions descri
 Every value in FunC occupies a certain number of stack entries.
 If this number is consistent for all values of a given type, it is called the **type width**.
 
-For example, all [atomic types](#atomic-types) have a type width of 1, because all their values occupy a single stack entry. 
+For example, all [atomic types](#atomic-types) have a type width of 1, because all their values occupy a single stack entry.
 The tensor type `(int, int)` has type width 2, because all its values occupy 2 stack entries.


### PR DESCRIPTION
- [ ] **1. Expand acronym TVM on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/types.mdx?plain=1#L15

"TVM" appears without expansion. Per the guide, spell out the term on first mention, then use the acronym. Minimal fix: change "TVM cell type" to "TON Virtual Machine (TVM) cell type" at the first occurrence on this page.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **2. Expand acronym TON on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/types.mdx?plain=1#L15

"TON" appears without expansion in "TON Blockchain". Per the guide, expand the term on first mention. Minimal fix: "The Open Network (TON) Blockchain" at the first occurrence on this page. If expansion is intentionally omitted across nearby pages, note an exception; otherwise keep consistent with the rule.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **3. Avoid bold-only labels; use structure instead**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/types.mdx?plain=1#L79-L120

Standalone bold labels ("**Example:**" and "**Examples**") are used as pseudo-headings. The guide discourages bolding entire sentences/paragraphs and recommends using headings or callouts for structure. Minimal fix: convert these to proper subheadings (e.g., "#### Example" / "#### Examples") or make the label plain text (no bold) followed by the content.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#emphasis-bold-and-italics

---

- [ ] **4. Missing space before inline code**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/types.mdx?plain=1#L113

There is no space before the inline code in "unit type`()`". Minimal fix: add a space so it reads "unit type `()`". This follows general Markdown readability and matches spacing used elsewhere on the page (e.g., "type `[]`"). This relies on general Markdown conventions.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#8-2-structure-for-scanning

---

- [ ] **5. Code fence closing marker has leading space**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/types.mdx?plain=1#L104

The closing code fence has a leading space, which can break rendering in some Markdown engines. Minimal fix: remove the leading space so the fence is exactly "```". This relies on general Markdown syntax rules.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **6. Grammar: "before of `->`" → "before `->`"**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/types.mdx?plain=1#L147

The phrase "before of `->`" is ungrammatical. Minimal fix: "before `->`" (or "before the `->`").
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **7. Article usage in domain/codomain definitions**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/types.mdx?plain=1#L76-L77

"which is called domain/codomain" is missing the definite article and reads awkwardly. Minimal fix: "which is called the domain" and "which is called the codomain". This improves clarity and aligns with plain, precise wording.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **8. Avoid mixing "->" and "→" for function types; standardize**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/types.mdx?plain=1#L75-L162; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/functions.mdx?plain=1#L23-L50

This page uses ASCII "->" for function types, while the related Functions page predominantly uses the Unicode arrow "→" (e.g., in Return type examples). To maintain terminology and symbol consistency, standardize on one form across pages. Minimal fix (local to this page): replace "->" with "→" in type signatures to match the Functions page.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **9. Inline code spans include conjunction in token list**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/types.mdx?plain=1#L99

The inline code shows "`(2, 3, and 9)`", which includes the word "and" inside a code span. Minimal fix: move the conjunction outside code and present tokens cleanly, e.g., "three stack entries 2, 3, and 9" or use a single code span for the tuple literal "`(2, 3, 9)`". This keeps code styling for tokens only and improves readability. This relies on general code formatting conventions.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#8-2-structure-for-scanning

---

- [ ] **10. Capitalization after code block**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/types.mdx?plain=1#L105

Sentence begins with lowercase "since" after a code block. Minimal fix: capitalize to "Since FunC strictly enforces type consistency, …" for standard sentence casing.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **11. Throat‑clearing phrasing before a list**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/types.mdx?plain=1#L40-L44

"Since any atomic type allows `null`, it is important to be aware of the following regarding functions:" is wordy/hedging. Minimal fix: shorten to a direct lead-in, e.g., "For functions:" or "Note:" followed by the bullets.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **12. Improve phrasing: "Like in functional programming"**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/types.mdx?plain=1#L84

"Like in functional programming" is informal. Minimal fix: "As in functional programming" for clearer, standard phrasing.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **13. Remove unnecessary bold emphasis in body text**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/types.mdx?plain=1#L138

"FunC features a **custom type system**…" uses bold for emphasis in running text without necessity. Minimal fix: remove bold styling around "custom type system".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#emphasis-bold-and-italics

---

- [ ] **14. Terminology consistency: "slot" vs "stack entry"**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/types.mdx?plain=1#L25

This page says "single slot in the TVM stack" while elsewhere (e.g., https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/functions.mdx?plain=1#L392) the term "stack entry" is used. Minimal fix: change to "single stack entry" for consistency across pages.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **15. List punctuation consistency**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/types.mdx?plain=1#L115-L116

The two bullets under the unit type lack terminal periods, while adjacent lists on this page use periods. The guide is silent on mandatory list punctuation; for consistency, add periods to these items to match earlier bullet lists on this page.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#8-2-structure-for-scanning

---

- [ ] **16. Generic concept capitalized mid-sentence (Blockchain)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/types.mdx?plain=1#L15

Generic concepts must not be capitalized mid-sentence. Change “TON Blockchain” to “TON blockchain”. Keep proper nouns capitalized (TON) only.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#general-casing-rules

---

- [ ] **17. Bold formatting wraps a code token and missing space**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/types.mdx?plain=1#L113

Bold must not be used to style tokens; also a space is missing before the code. Change “**Special case: unit type`()`**” to “**Special case: unit type** `()`”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#emphasis-bold-and-italics

---

- [ ] **18. Aside components missing explicit type**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/types.mdx?plain=1#L107-L160

For consistent rendering, set an explicit supported `type` on `<Aside>`. Minimal fix: change `<Aside>` to `<Aside type="note">` in both occurrences.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#admonition-levels-and-usage

---

- [ ] **19. Awkward construction (“considered by the type checker as the same type”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/types.mdx?plain=1#L109-L110

Tighten phrasing. Change “considered by the type checker as the same type as `A`” to “considered the same type as `A` by the type checker.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#plain-precise-wording

---

- [ ] **20. Inline “Note:” label should use an Aside**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/types.mdx?plain=1#L134

Render callouts with the `<Aside>` component for consistency. Minimal fix: replace the inline “Note:” with an MDX Aside using `type="note"` wrapping the sentence.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#admonition-levels-and-usage

---

- [ ] **21. Partial code snippets lack “Not runnable” label**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/types.mdx?plain=1#L53-L145

Focused excerpts that are not complete programs should be labeled as partial. Minimal fix: add a preceding line “Not runnable” above each illustrative `func` code block on this page.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **22. Prefer glossary link on first useful mention of core terms**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/types.mdx?plain=1#L15-L25

On first useful mention, link core TON terms to the Glossary. Minimal fix: link the first mentions of “The Open Network (TON)” and “TON Virtual Machine (TVM)” to the Glossary entries if available (e.g., `/ton/glossary`).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#what-to-link-and-what-not

---

- [ ] **23. Redundant wording (“Logical operations are performed using bitwise operations.”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/types.mdx?plain=1#L32

Avoid redundancy. Minimal fix: “Logical operations use bitwise operators.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#plain-precise-wording

---

- [ ] **24. Wordy construction (“is able to infer”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/types.mdx?plain=1#L67

Prefer the direct verb. Change “the type checker is able to infer that …” to “the type checker infers that …”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#plain-precise-wording

---

- [ ] **25. Hedge wording: “could also accept” → “may accept”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/types.mdx?plain=1#L43

Use precise, non-hedging phrasing and keep parallel structure with the preceding bullet (“may return”). Replace “Functions that expect an atomic type as input could also accept `null`.” with “Functions that expect an atomic type as input may accept `null`.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **26. Timeless phrasing: remove “At the moment,”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/types.mdx?plain=1#L157-L158

Avoid time-relative wording. Replace “At the moment, type variables in polymorphic functions cannot be instantiated with tensor types.” with “Type variables in polymorphic functions cannot be instantiated with tensor types.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17.2-timelessness

---

- [ ] **27. Timeless phrasing: remove “Currently,”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/types.mdx?plain=1#L166

Avoid time-relative wording. Replace “Currently, FunC does not support defining custom types beyond the type constructions described above.” with “FunC does not support defining custom types beyond the type constructions described above.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17.2-timelessness

---

- [ ] **28. Frontmatter boolean: use unquoted boolean for `noindex`**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/types.mdx?plain=1#L4

Frontmatter should use `noindex: true` (boolean), not a quoted string. Change `noindex: "true"` to `noindex: true`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16.2-navigation-labels. General knowledge: YAML booleans should be unquoted to be parsed as booleans.

---

- [ ] **29. Bold used as pseudo-heading and missing space before code**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/types.mdx?plain=1#L113

The full-line bold label “Special case: unit type`()`” uses bold to simulate a heading and lacks a space before the code span. Use a proper heading and correct spacing. Minimal fix: replace with a subheading, e.g., `#### Unit type ()`, and add the missing space between “type” and `()`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis