### PR TITLE
[AI] fix: index.mdx

### DIFF
--- a/ecosystem/ton-connect/index.mdx
+++ b/ecosystem/ton-connect/index.mdx
@@ -3,35 +3,35 @@ title: "TON Connect overview"
 sidebarTitle: "Overview"
 ---
 
-To integrate with TON, the standard wallet connection protocol is used — TON Connect. It is similar to WalletConnect on Ethereum, but made specifically for TON and covers basic integration aspects. For deeper integrations, it's common to utilize various supplementary SDKs and APIs.
+To integrate with TON, the standard wallet connection protocol is used — TON Connect. It is similar to WalletConnect on Ethereum, but made specifically for TON and covers basic integration aspects. For deeper integrations, it's common to use various supplementary SDKs and APIs.
 
 <img
   className="block dark:hidden"
   src="/resources/images/ton-connect/basic-schema.svg"
-  alt="Basic communication schema of TON Connect"
+  alt="TON Connect communication diagram"
 />
 
 <img
   className="hidden dark:block"
   src="/resources/images/ton-connect/basic-schema-dark.svg"
-  alt="Basic communication schema of TON Connect"
+  alt="TON Connect communication diagram"
 />
 
 ## About TON Connect
 
 <video autoPlay muted loop className="w-full rounded-xl" src="/resources/videos/TonConnect.mp4">
-  Your browser does not support the \<video> tag.
+  Your browser does not support the <video> tag.
 </video>
 
 TON Connect enables secure communication between wallets and decentralized applications, allowing users to authorize transactions while maintaining control of their private keys.
 
-Currently, TON Connect supports over 30 wallets and connects to hundreds of major applications across the TON ecosystem. As the mandatory connection protocol for all Telegram Mini Apps, it serves as the gateway to TON's entire ecosystem of applications and services.
+TON Connect supports many wallets and is widely used across the TON ecosystem. TON Connect is the connection protocol for Telegram Mini Apps.
 
-Think of it as the essential infrastructure that your institutional clients will need to access any TON-based services — from DeFi protocols to gaming applications to payment systems.
+It provides a standard way for wallets and decentralized applications to connect across services such as DeFi, gaming, and payments.
 
-For technical architecture details: [TON Connect protocol specification on GitHub](https://github.com/ton-blockchain/ton-connect).
+For technical architecture details, see the TON Connect protocol specification on GitHub: [TON Connect protocol specification on GitHub](https://github.com/ton-blockchain/ton-connect).
 
-## Are you building a web3 app?
+## Web3 apps
 
 Explore the demo apps made with React.
 
@@ -50,7 +50,7 @@ Explore the demo apps made with React.
   />
 </Columns>
 
-Proceed with integration and usage recipes.
+Integration and usage recipes.
 
 <Columns cols={2}>
   <Card
@@ -60,12 +60,12 @@ Proceed with integration and usage recipes.
   />
   <Card
     icon="wrench"
-    title="Common usage examples"
+    title="Common use cases"
     href="/guidebook/dapp#usage"
   />
 </Columns>
 
-Skim the related reference pages.
+Related reference pages.
 
 <Columns cols={2}>
   <Card
@@ -90,7 +90,7 @@ Skim the related reference pages.
   </Card>
 </Columns>
 
-## Are you building a web3 wallet?
+## Web3 wallets
 
 Follow the step-by-step guide.
 
@@ -100,7 +100,7 @@ Follow the step-by-step guide.
   href="/guidebook/wallet">
 </Card>
 
-Or skim the related reference pages.
+Related reference pages.
 
 <Columns cols={2}>
   <Card
@@ -120,7 +120,7 @@ Or skim the related reference pages.
   </Card>
 </Columns>
 
-For more, see the TON Connect articles from Google Docs.
+More TON Connect articles.
 
 <Columns cols={3}>
   <Card
@@ -142,7 +142,7 @@ For more, see the TON Connect articles from Google Docs.
 
 ## Complete integration recipes
 
-Comprehensive guides that walk you through complete integration scenarios, covering everything from initial setup to production deployment. Each recipe includes code examples, best practices, and troubleshooting tips.
+Guides for end-to-end integration, from setup to deployment. Each recipe includes code examples, best practices, and troubleshooting.
 
 <Columns cols={1}>
   <Card
@@ -154,7 +154,7 @@ Comprehensive guides that walk you through complete integration scenarios, cover
 
 ## Curated guides and tutorials from the community
 
-Tutorials and guides created by the TON community to help developers integrate TON into their applications. They provide practical, real-world examples and alternative approaches to common integration challenges.
+Community tutorials with practical examples and alternative approaches to common integration tasks.
 
 <Columns cols={1}>
   <Card
@@ -166,7 +166,7 @@ Tutorials and guides created by the TON community to help developers integrate T
 
 ## Join the community
 
-If you have questions about integrating TON into your project, need help troubleshooting issues, or want to discuss best practices with other developers, join our community channels.
+Join the community channels for integration help and best practices.
 
 <Columns cols={2}>
   <Card
@@ -187,4 +187,4 @@ If you have questions about integrating TON into your project, need help trouble
 
 - [Technical specification of the TON Connect protocol (GitHub)](https://github.com/ton-blockchain/ton-connect)
 - [Official list of wallets that support TON Connect (GitHub)](https://github.com/ton-blockchain/wallets-list)
-- [HTTP bridge for TON Connect](https://github.com/ton-connect/bridge)
+- [TON Connect HTTP bridge (GitHub)](https://github.com/ton-connect/bridge)


### PR DESCRIPTION
- [ ] **1. Frontmatter title not in sentence case**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L2

The page title uses Title Case (“Mintless Jetton”) but headings/titles must use sentence case and generic concepts like “jetton” are lowercase mid‑sentence. Minimal fix: change `title: "Mintless Jetton"` to `title: "Mintless jetton"`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#71-case-and-form; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#132-general-casing-rules

---

- [ ] **2. Generic term “jetton” capitalized in prose**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L13-L21

Mid‑sentence “Jettons/Jetton” are capitalized (“Mintless Jettons”, “standard Jetton”), but generic concepts must be lowercase. Minimal fix: “Mintless jettons”, “standard jetton”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#132-general-casing-rules; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#134-ton‑specific-examples

---

- [ ] **3. Throat‑clearing sentence in the opener**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L17

“In this article we will explore how…” is throat‑clearing. Minimal fix: remove the sentence or rewrite to direct voice, e.g., “Learn how mintless jettons work and how to use them.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#57-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **4. Redundant “Introduction” heading alongside “Overview”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L7-L19

Avoid generic, duplicate headings; keep section headings unique and meaningful. Minimal fix: remove the “## Introduction” heading and keep “## Overview” as the first H2.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#73-uniqueness-and-linkability

---

- [ ] **5. Headings use Title Case instead of sentence case**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L39-L181

Examples: “Merkle Tree Foundation”, “Data Structures”, “Cryptographic Proof Validation”, “State Transitions”, “Off‑chain Infrastructure”, “Merkle Tree Generation”, “Proof Serving”, “Supporting mintless jettons in DApps (DEX/Lending platforms)”. Minimal fix: convert to sentence case, e.g., “Merkle tree foundation”, “Data structures”, “Cryptographic proof validation”, “State transitions”, “Off‑chain infrastructure”, “Merkle tree generation”, “Proof serving”, “Supporting mintless jettons in dApps (DEX and lending platforms)”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#71-case-and-form

---

- [ ] **6. Fenced code blocks missing language tags and “Not runnable” label**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L122-L132

Two illustrative state examples are fenced without a language tag and are partial (not runnable). Minimal fix: add a short label line “Not runnable” above each block and use a language tag like `text` for the fences (e.g., “Not runnable” + ```text).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#438-fenced-code-blocks; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#102-partial-snippets

---

- [ ] **7. Validation steps are not structured as a proper ordered list**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L98–116

The numbered items (“1. Merkle Proof Verification”, “2. Timestamp Validation”, etc.) are plain paragraphs, not an ordered list. Minimal fix: convert to an actual ordered list using `1.` for each item with sub‑bullets underneath, or promote each to a subheading.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#64-lists

---

- [ ] **8. GitHub link includes a tracking/tab parameter**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L13

The link has `?tab=readme-ov-file`. Clean URLs must not include tracking/view parameters. Minimal fix: remove the query string: `https://github.com/ton-community/mintless-jetton`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#125-external-references

---

- [ ] **9. TEP links point to moving “master” branch (use stable permalinks)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L21-L191–192

Normative references should use versioned or permanent URLs; linking to `master` is a moving target. Minimal fix: change to a commit SHA permalink for the exact section, or link an internal canonical page if available.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#125-external-references

---

- [ ] **10. Inconsistent “off‑chain” vs “offchain” usage**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L25-L191

Prose mixes “off‑chain” and “offchain”. Prefer one form consistently; in prose use “off‑chain” and keep “offchain” only where required by URLs. Minimal fix: change link texts/phrases to “off‑chain” in prose.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#131-term-bank-canonical-source; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#717-prefer-stable-terminology

---

- [ ] **11. Inconsistent capitalization of “custom payload API”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L164-L169

The same term appears as “custom payload API” and “Custom Payload API”. Generic terms must not be capitalized mid‑sentence. Minimal fix: use “custom payload API” consistently.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#132-general-casing-rules

---

- [ ] **12. Code identifiers not formatted as code in prose**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L65-L83

Identifiers like AirdropItem and MerkleProof should be in code font. Minimal fix: wrap them with backticks: `AirdropItem`, `MerkleProof`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#63-code-styling; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#132-general-casing-rules

---

- [ ] **13. Grammar: agreement and possessives in data‑structure description**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L51-L65

Issues: “Airdrop HashMap represent…” (subject‑verb agreement) and “users airdrop information” (missing possessive). Minimal fix: “Airdrop HashMap represents how we store users’ airdrop information.” Also add articles in line 65: “where the key is a 267‑bit internal TON account address and the value is an `AirdropItem` structure.” (General knowledge: basic English grammar.)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles-reader-first-answer-first

---

- [ ] **14. Inconsistent casing for “dApps” in heading and prose**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L181-L183–185

The page uses “DApps” while elsewhere in the docs “dApps” is prevalent (e.g., https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/walletkit/native-web.mdx?plain=1#L74-L90). Minimal fix: use “dApps” consistently in heading and body.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#131-term-bank-canonical-source; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#717-prefer-stable-terminology

---

- [ ] **15. Marketing adjective in technical section (“innovative”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L13

Pages must not use marketing language in technical sections. Minimal fix: remove “innovative”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles-reader-first-answer-first

---

- [ ] **16. Define placeholders on first use (`<root_hash>`, `<airdrop_amount>`)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L126-L134

Placeholders must be defined on first use. Minimal fix: after the first state block, add short definitions, e.g., “`<root_hash>` — 256‑bit Merkle root hash; `<airdrop_amount>` — the claimed jetton amount.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#101-general-rules

---

- [ ] **17. List structure after lead‑in: convert paragraphs to bullets**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L162–175

After the lead‑in “Wallets can achieve this by:”, items must be bullets. Minimal fix: make “Integrating with the off‑chain API …” and “Using a custom API:” top‑level bullets, with their current sub‑steps nested under each.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#64-lists

---

- [ ] **18. Acronyms not expanded on first use (DApps, DEX)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L181–185

Spell out on first mention. Minimal fix: change to "decentralized applications (DApps)" in the heading and expand DEX in body (e.g., "decentralized exchanges (DEXs)"). Keep acronyms thereafter.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#53-acronyms-and-terms

---

- [ ] **19. Product naming/casing consistency: “TonAPI or Ton Center API”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L183; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/mytonctrl/installer.mdx?plain=1#L138; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/rpc/get-api-key.mdx?plain=1#L1–4

Align with project usage for product names. Minimal fix: "TON API or TON Center API" (matches usage elsewhere). If "TonAPI" is the official brand, confirm in the term bank and standardize accordingly.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#132-general-casing-rules

---

- [ ] **20. External link policy: personal gist should be labeled as background**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L189

Prefer authoritative sources; personal posts may be linked only as background. Minimal fix: append “(background)” to the link label or move under a "Background" note.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#125-external-references

---

- [ ] **21. Prefer “use” over “utilizing”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L30

Plain wording is required. Minimal fix: "By using Merkle trees, mintless jettons store a single hash…"
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording

---

- [ ] **22. Inconsistent capitalization (“merkle hash”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L71

Use consistent casing for Merkle terms. Minimal fix: "Merkle hash" (capitalize "Merkle" consistently with earlier uses).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17.4-proofread

---

- [ ] **23. Internal‑first link in See also (metadata standard)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L192

Prefer internal docs when available. Minimal fix: change "Jetton metadata standard" to link to `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/metadata.mdx?plain=1`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12.2-what-to-link-and-what-not

---

- [ ] **24. Inconsistent capitalization: “TON Blockchain”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L21

Use consistent terminology; elsewhere the docs use “TON blockchain” (lowercase “blockchain”). Minimal fix: change “TON Blockchain” → “TON blockchain”. Supporting usage: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/node/overview.mdx?plain=1 (multiple occurrences of “TON blockchain”).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **25. Missing article and inconsistent casing in contract reference**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L67

“For Jetton Master contract, standard storage is extended…” is missing the article and uses inconsistent casing. Minimal fix: “For the jetton master contract, standard storage is extended with `merkle_hash` …”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **26. Numbered list items should end with periods (full sentences)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L144–147

Each item is a full sentence but lacks terminal punctuation. Minimal fix: add a period at the end of each item in the “Merkle Tree Generation” list.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **27. Remove filler “Note that …” and fix number agreement**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L25

“Note that” is filler, and “mintless jetton” should be plural in this context. Minimal fix: “To use mintless jettons to the full extent, you need off‑chain infrastructure.” (Relies on general English style; keeps content unchanged.)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **28. List items under “Merkle tree foundation” lack terminal periods**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L43–45

These bullets are full sentences but lack periods. Minimal fix: add periods at the end of each list item for consistency within the list.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **29. “Cryptographic proof validation” bullets lack terminal periods**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L100–103,106–107,111,115–116

Bullets are full sentences but lack periods. Minimal fix: add a period at the end of each sentence-style bullet to be consistent within the list.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **30. Ambiguous slash in heading and inconsistent “dApp(s)” casing**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L181-L183

Heading uses “DApps (DEX/Lending platforms)”. Slashes create ambiguity similar to “and/or”, and "DApps" casing is inconsistent with prevalent "dApps" usage in this repo (e.g., https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/ton-connect/index.mdx?plain=1). Minimal fixes: (a) Change to “dApps (DEX and lending platforms)”; (b) use “dApps” consistently in body text (l183).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references; consistency with nearby pages

---

- [ ] **31. Avoid “leverage” as a verb**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L37

"Mintless jettons leverage Merkle trees" should avoid "leverage" as a verb. Minimal fix: "Mintless jettons use Merkle trees".
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#b-banned-and-preferred-terms

---

- [ ] **32. Full-sentence bullets under “Using a custom API” lack periods**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L173–175

These items are imperative sentences but lack terminal periods, and earlier bullets in the same section use periods. Minimal fix: add periods to each item for consistency.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **33. Heading not in sentence case: “Overview”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L19

Headings must use sentence case. Minimal fix: change to "## Overview" is already sentence case; alternatively, if keeping, no action needed. If retaining, ignore this item. Domain owner decision: confirm whether to keep both "Introduction" and "Overview". Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles

---

- [ ] **34. Ordered list must use `1.` for each item**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L98–115

Validation steps are numbered 1., 2., 3., 4. The style requires using `1.` for all items and letting MDX auto‑number. Minimal fix: change the list item markers at lines 104, 109, and 113 to `1.`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#ordered-lists-must-use-1

---

- [ ] **35. Imperative lead-ins for lists**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/jettons/mintless/overview.mdx?plain=1#L164-L171

Colons should follow a complete clause, and procedures prefer imperatives. Minimal fixes: change "Integrating with the off-chain API…:" to "Integrate with the off-chain API…:", and "Using a custom API:" to "Use a custom API:". Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles