### PR TITLE
[AI] fix: address-formats.mdx

### DIFF
--- a/ton/addresses/address-formats.mdx
+++ b/ton/addresses/address-formats.mdx
@@ -46,7 +46,10 @@ intended recipient through wallet applications (for instance, [Tonkeeper](https:
 The user-friendly address format is a secure, base64-encoded (or base64url-encoded) wrapper around the raw format. It adds metadata
 flags and a checksum to prevent common errors and provide greater control over message routing.
 
-<Aside type="danger" title="Warning">
+<Aside
+  type="danger"
+  title="Warning"
+>
   This format applies only to addresses described by the `addr_std` TL-B scheme. See [General information](./addresses-general-info).
 </Aside>
 


### PR DESCRIPTION
- [ ] **1. Unordered list items end with punctuation**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L8

List items are fragments, but they end with a semicolon and a period. Minimal fix: remove terminal punctuation so the bullets read “- **raw**” and “- **user-friendly**”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **2. Opening phrasing and grammar (“Accordingly to… there exist…”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L5

Use plain wording and correct preposition: “According to … there are …”. Minimal fix: “According to TEP 0002, there are two internal address formats on the TON Blockchain:”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **3. Comma splice and awkward sentence about equivalence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L11

Sentence joins independent clauses with a comma and reads awkwardly. Minimal fix: “However, these representations are equivalent: they refer to the same address but look very different.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **4. Misspelling and external link where internal exists**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L13

“adresses” is misspelled and the link points to an external Mintlify preview while an internal page exists. Minimal fix: “To see how wallets and other applications use these formats, see the [Addresses workflow](/ecosystem/wallet-apps/addresses-workflow) page.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text

---

- [ ] **5. “existent workchains” → “existing workchains”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L23

Prefer common word forms. Minimal fix: “In existing workchains, …”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **6. Masterchain/basechain casing**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L26

Uses “MasterChain” and “BaseChain”. Per term bank, these are common nouns and must be lowercase mid‑sentence. Minimal fix: “masterchain” and “basechain”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-4-ton-specific-examples

---

- [ ] **7. mainnet/testnet capitalization (generic usage)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L39

“Testnet” and “Mainnet” are capitalized as proper nouns but used generically. Minimal fix: use lowercase “testnet” and “mainnet” here and throughout this page (also lines 59, 79–82, 90–93).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13-3-hyphenation-and-abbreviations

---

- [ ] **8. Admonition component must be <Aside> (not <Warning>)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L51

Callouts must use the unified Aside component with a supported type. Minimal fix: replace with `<Aside type="note">…</Aside>` and keep content unchanged.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#a-admonition-levels-and-usage

---

- [ ] **9. Admonition sentence: link text and comma splice**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L51

Link text “general info” is non‑descriptive and casing doesn’t match the target title; the sentence uses a comma splice. Minimal fix: “This format applies only to addresses described by the `addr_std` TL‑B scheme. See [General information](/ton/addresses/addresses-general-info).”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons

---

- [ ] **10. Endianness link should use a stable general reference**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L61

Links to a blog post for a general concept. Prefer Wikipedia for general, non‑TON topics. Minimal fix: link to https://en.wikipedia.org/wiki/Endianness.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references

---

- [ ] **11. Throat‑clearing phrase “As we can see,”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L77

Remove throat‑clearing. Minimal fix: “There are four handling variants:”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **12. Variant bullets end with semicolons**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L79

Bulleted items are full sentences but end with semicolons. Minimal fix: end each with a period.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **13. Tone: remove “so‑called”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L96

Avoid hedging/tone words. Minimal fix: “The same encoding is used for the armored versions of [public keys](/techniques/security) and [ADNL addresses](/ton/network).”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **14. Plural and hyphenation (“OS” and “double‑click”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L110

Use standard American English mechanics. Minimal fix: “Most OSes do not allow you to select an address with a double‑click because of the `_`, `-`, `/`, `+` Base64 symbols.” (General English mechanics applied.)
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-6-spelling-and-contractions

---

- [ ] **15. Summary subject–verb agreement**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L114

Fix agreement: “Raw format … lacks safety features.” and “User‑friendly format … includes flags and a checksum.”
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **16. Prefer internal reference over TEP in opening sentence (or add internal alongside)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L5

Prefer internal docs by default; include the TEP only as a supplemental spec link when needed. Minimal fix: add a link to [General information](/ton/addresses/addresses-general-info) in addition to the TEP, or replace the TEP link with the internal page.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references

---

- [ ] **17. Awkward phrasing: “For user‑friendly format forms selection”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L104

Use plain wording. Minimal fix: “When choosing the user‑friendly form:” or “For user‑friendly form selection:”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording

---

- [ ] **18. Use stable permalink for code link (CRC16)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L62

When linking to specific source files that must remain reproducible, use a stable commit permalink instead of a moving `main` branch. Minimal fix: pin the `crc16.kt` link to a specific commit in `ton-kotlin`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references

---

- [ ] **19. Acronym not defined on first use (“OS”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L110

Spell out on first mention, then use the acronym. Minimal fix: “Most operating systems (OS) do not allow …”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **20. “existent workchains” and WorkChain casing**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L23-L25

Use “existing” instead of “existent”, and standardize the term to “WorkChain” (proper-cased) to match usage elsewhere (e.g., https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/addresses-general-info.mdx?plain=1#L41). Minimal fix: “In existing WorkChains, …”; “identifying the WorkChain.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17.4 Proofread

---

- [ ] **21. Ordered list items punctuated as full sentences**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L59-L62

The items are sentence fragments (labels with definitions) but end with periods. For non‑sentence list items, omit terminal punctuation. Minimal fix: remove the trailing periods on items 1–4. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.1 Commas, colons, semicolons

---

- [ ] **22. Internal links should be relative, not absolute**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L52-L121

Change absolute paths to relative ones, for example: `/ton/addresses/addresses-general-info` → `./addresses-general-info`; `/techniques/security` → `../../techniques/security`; `/ton/network` → `../network`; `/ton/statuses` → `../statuses`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-3-links-and-anchors

---

- [ ] **23. Use stable permalinks for external GitHub references**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L5-L62

Avoid linking to moving branches (“master”/“main”). Link TEP 0002 and `crc16.kt` via a commit permalink (or replace `CRC16-CCITT` with an authoritative spec or Wikipedia when precision is informational). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-5-external-references

---

- [ ] **24. List item punctuation and casing in handling variants**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L79-L82

Each item is a full sentence but starts lowercase and ends with a semicolon. Capitalize the first word and end with periods (or convert to non-sentential fragments without terminal punctuation). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-4-lists

---

- [ ] **25. Define acronyms on first use: UI, OS**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L108-L110

Spell out on first mention: “user interface (UI)” and “operating systems (OS)”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **26. Remove filler “In fact,”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L48

Avoid throat‑clearing; start with the fact directly. Minimal fix: drop “In fact,”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **27. Fix awkward phrasing and emphasis in format selection guidance**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L104

Phrasing is awkward, and italics over‑emphasize repeated terms. Minimal fix: “When selecting the user‑friendly format, use bounceable addresses for user smart contracts … and non‑bounceable addresses for wallets …” (remove italics). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-2-plain-precise-wording; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#emphasis-bold-and-italics

---

- [ ] **28. Avoid “etc.” in lists; make the example explicit**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L121

Replace open‑ended “etc.” with a concrete example phrased as “such as …” or end the sentence without it. Minimal fix: “how addresses evolve (such as active and frozen).” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **29. Admonitions must use <Aside>, not <Warning>/<Note>**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L51-L53

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ton/addresses/address-formats.mdx?plain=1#L95-L98

House style requires the `<Aside>` component with an allowed `type`. Minimal fix: replace `<Warning>…</Warning>` with `<Aside type="danger" title="Warning">…</Aside>` and replace `<Note>…</Note>` with `<Aside type="note">…</Aside>`.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11-2-how-to-write-the-callout; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#a-admonition-levels-and-usage