### PR TITLE
[AI] fix: style-guide.mdx

### DIFF
--- a/contribute/style-guide.mdx
+++ b/contribute/style-guide.mdx
@@ -3,7 +3,9 @@ title: "Documentation style guide"
 sidebarTitle: "Style guide"
 ---
 
-This guide covers the basics: how to structure pages, write examples, and keep docs consistent and safe.
+Structure pages, write runnable examples, and keep docs consistent and safe.
+
+import { Aside } from '/snippets/aside.jsx';
 
 ## Write for the reader
 
@@ -15,8 +17,8 @@ This guide covers the basics: how to structure pages, write examples, and keep d
 
 ## Page types
 
-- Step-by-step guides — for beginners; handhold from zero to first success on one happy path; explain from scratch, define terms, and link out for depth.
-- How-tos — a focused recipe for a specific outcome; assume concepts known and show only what’s needed.
+- Step by step — for beginners; guide from zero to first success on one happy path; explain from scratch, define terms, and link out for depth.
+- How‑to guide — a focused recipe for a specific outcome; assume concepts known and show only what’s needed.
 - Explanation — concepts, architecture, and trade‑offs; clarify why and when, with minimal examples.
 - Reference — exact, complete facts (APIs, CLI, types, errors); stable anchors and minimal prose.
 - Don’t mix types on the same page.
@@ -39,7 +41,7 @@ This guide covers the basics: how to structure pages, write examples, and keep d
 - Make commands copy‑pasteable. Do not include shell prompts like `$` or `>`. Prompts break commands when pasted.
 - Separate command and output. Use two fenced blocks. Mixing them causes copy errors.
 - Use `<ANGLE_CASE>` placeholders in commands and prose and define each on first use (for example, `<RPC_URL>`). In code, use `UPPER_SNAKE` if `< >` clashes with syntax. One clear convention prevents hard‑coded values from slipping in.
-- Tag code fences with a language (`bash`, `json`, `rust`, and so on). This enables correct highlighting and tooling.
+- Tag code fences with a language (for example, `bash`, `json`, `rust`). This enables correct highlighting and tooling.
 - Prefer end‑to‑end examples on testnet by default. Safe defaults encourage trying the steps.
 - Label partial snippets as Not runnable and link to a full example.
 - Do not hard‑wrap long commands. Use soft wrap in the UI or safe continuation if the shell supports it. Hard wraps break execution.
@@ -66,36 +68,31 @@ Add a Caution or Warning when a step moves funds, changes fees or withdrawals, e
 
 Pattern
 
-> Warning — funds at risk
-> Running the next command on mainnet transfers funds irreversibly.
-> Safer first (testnet):
->
-> ```bash
-> jetton transfer --to <ADDR> --amount <AMOUNT> --network testnet
-> ```
->
-> If you must use mainnet: no rollback; on‑chain transfers are final.
+<Aside type="danger" title="Warning — funds at risk">
+Running the next command on mainnet transfers funds irreversibly.
+Safer first (testnet):
+
+```bash
+jetton transfer --to <ADDR> --amount <AMOUNT> --network testnet
+```
+
+If you must use mainnet: no rollback; on‑chain transfers are final.
+</Aside>
+
+`<ADDR>` — recipient address.
+`<AMOUNT>` — amount to transfer.
 
 Default to testnet in task pages. Make destructive flags opt‑in and document mitigations.
 
 ## Necessary disclaimers
 
-Add a Caution or Warning when a page or step:
-
-- Moves funds or changes fee/withdrawal behavior.
-- Exposes, stores, or transmits private keys or mnemonics.
-- Modifies validator configuration, networking, or other consensus‑affecting parameters.
-- Performs chain‑affecting operations (for example, resharding, pruning, halting, replay).
-- Uses destructive flags or commands that delete, rewrite, or lock state (for example, `--purge`, `--force`).
-- Runs on mainnet where actions are irreversible; label the environment and give safer testnet first.
-
-Each safety callout should briefly state the risk, scope, rollback/recovery (if any), and the environment label (testnet vs mainnet).
+See Safety warnings above.
 
 ## Titles and headings
 
 - Use sentence case. Keep headings concise and unique.
 - Use imperatives for tasks (“Deploy a validator”); nouns for concepts (“Validator architecture”). Titles should signal action vs. explanation.
-- Don’t style headings, except when an identifier needs code font.
+- Don’t style headings; on Reference pages only, identifiers may use code font.
 - Use clear section labels such as Verify, Troubleshoot, and See also.
 
 ## Link to details, don’t duplicate
@@ -109,14 +106,14 @@ Each safety callout should briefly state the risk, scope, rollback/recovery (if 
 ## Terminology and names
 
 - Use the project term bank for canonical spellings, casing, and preferred terms. One vocabulary prevents drift.
-  Examples: TON, jetton, smart contract, BoC (bag of cells), AccountChain, ShardChain, WorkChain, MasterChain, BaseChain.
+  Examples: TON, jetton, smart contract, bag of cells (BoC), accountchain, shardchain, workchain, masterchain, basechain.
 - Prefer allowlist and denylist over whitelist and blacklist. These are clearer and inclusive.
 - Use mainnet and testnet as common nouns. Use TON Mainnet and TON Testnet for the proper names. This distinguishes the generic type from the named network.
 
 ## Files, front matter, labels
 
 - Filenames use `kebab-case.md` or `kebab-case.mdx` (for example, `validator-setup.mdx`). This is readable and consistent across platforms.
-- Optional front matter can declare `doc_type`, `audience`, and `status` (experimental or deprecated). If deprecated, add an Important callout with the replacement and timeline.
+- Use only site‑supported front matter metadata. Communicate status at the top of the page with an <Aside> (for example, `title="Deprecated"` or `title="Experimental"`).
 - Keep sidebar labels short (2–4 words) and mirror in‑page headings.
 
 ## Accessibility


### PR DESCRIPTION
- [ ] **1. Blockquote used for warning callout instead of Aside**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide.mdx?plain=1#L69

The “Pattern” section renders a warning as a Markdown blockquote with embedded code. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.6-blockquotes and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#11.2-how-to-write-the-callout. Minimal fix: replace the blockquote with the `<Aside>` component using supported types (map Warning → `type="danger"`) and a `title`, for example:

import { Aside } from '/snippets/aside.jsx';

<Aside type="danger" title="Warning — funds at risk">
Running the next command on mainnet transfers funds irreversibly.
Safer first (testnet):

```bash
jetton transfer --to <ADDR> --amount <AMOUNT> --network testnet
```

If you must use mainnet: no rollback; on‑chain transfers are final.
</Aside>

— This aligns with allowed admonition types and avoids using `>` for callouts. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#a-admonition-levels-and-usage.

---

- [ ] **2. Undefined placeholders in safety example (`<ADDR>`, `<AMOUNT>`)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide.mdx?plain=1#L73

The safety example introduces `<ADDR>` and `<AMOUNT>` without defining them. Undefined placeholders are a high‑severity hazard, and placeholders must be defined at first use. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#severity-model-release-blocking and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles. Minimal fix: immediately after the example, add two one‑line definitions, for example:

`<ADDR>` — recipient address.
`<AMOUNT>` — amount to transfer.

(General knowledge: defining placeholders reduces copy/paste mistakes.)

---

- [ ] **3. Chain names use CamelCase; should be lowercase mid‑sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide.mdx?plain=1#L112

The examples list “AccountChain, ShardChain, WorkChain, MasterChain, BaseChain”. Mid‑sentence forms must be lowercase (accountchain, shardchain, workchain, masterchain, basechain); CamelCase forms are disallowed. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#13.6-banned-and-preferred-terms. Minimal fix: update the examples line to: “TON, jetton, smart contract, BoC (bag of cells), accountchain, shardchain, workchain, masterchain, basechain.”

---

- [ ] **4. Frontmatter guidance recommends unsupported custom keys**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide.mdx?plain=1#L119

The text says “Optional front matter can declare `doc_type`, `audience`, and `status`…”. The extended guide prohibits introducing custom frontmatter keys for internal taxonomy (e.g., `doc_type`, `audience`, custom `status`); use only site‑supported metadata and express status via an `<Aside>` in content. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-file-navigation-and-frontmatter-conventions and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#a-admonition-levels-and-usage. Minimal fix: remove the recommendation to set `doc_type`, `audience`, and `status` in frontmatter; instead, note that status should be communicated at the top of the page with an `<Aside>` (e.g., `title="Deprecated"` or `title="Experimental"`).

---

- [ ] **5. Intro sentence is throat-clearing; replace with reader-focused directive**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide.mdx?plain=1#L6

The opening line is meta (“This guide covers the basics: …”), which is throat-clearing and delays value delivery. Replace with an imperative, reader-focused line, or remove. Minimal fix: “Structure pages, write runnable examples, and keep docs consistent and safe.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **6. Acronym expansion order reversed (“BoC (bag of cells)”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide.mdx?plain=1#L112

On first mention, spell out the term followed by the acronym. Minimal fix: change “BoC (bag of cells)” to “bag of cells (BoC)”.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms

---

- [ ] **7. Open-ended “and so on” in list; prefer “for example” and stop**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide.mdx?plain=1#L42

The bullet “Tag code fences with a language (`bash`, `json`, `rust`, and so on).” uses an open-ended phrase equivalent to “etc.” In procedures/lists, avoid open-ended endings; either complete the list or use “for example” and stop. Minimal fix: “Tag code fences with a language (for example, `bash`, `json`, `rust`).” General knowledge: “and so on” functions like “etc.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **8. Idiomatic “handhold” phrasing; use a neutral verb**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide.mdx?plain=1#L18

“handhold from zero to first success” is a colloquial idiom; avoid idioms and prefer neutral, precise language. Minimal fix: “guide from zero to first success.”

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.5-global-and-inclusive-language

---

- [ ] **9. Safety guidance duplicated across two sections; consolidate**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide.mdx?plain=1#L63

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide.mdx?plain=1#L81

“Safety warnings” and “Necessary disclaimers” restate the same triggers and requirements for safety callouts. Avoid duplicating facts; keep a single canonical home. Minimal fix: merge “Necessary disclaimers” into “Safety warnings” (or reference the earlier section) to prevent drift.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12.5-avoid-circularity-and-drift

---

- [ ] **10. Undefined and non-descriptive placeholders in warning example**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide.mdx?plain=1#L74

The command uses `<ADDR>` and `<AMOUNT>` without definitions and with non-descriptive names. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#433-101-general-rules (placeholders must be defined on first use) and Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#645-135-placeholder-names (use descriptive `<ANGLE_CASE>` names) apply. Minimal fix: rename to `<WALLET_ADDR>` and `<AMOUNT_TON>`, and add one-line definitions immediately below the callout (for example, “`<WALLET_ADDR>` — destination wallet address; `<AMOUNT_TON>` — amount to transfer in TON”).

---

- [ ] **11. Doc type names inconsistent with canonical forms**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide.mdx?plain=1#L18

“Step-by-step guides” and “How-tos” diverge from the canonical doc type names. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#66-3-documentation-framework-content-types and Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#72-31-what-each-type-means-and-looks-like define the types as “Step by step,” “How‑to guide,” “Explanation,” and “Reference.” Minimal fix: change list items to “Step by step — …” and “How‑to guide — …” (keep “Explanation” and “Reference” as-is).

---

- [ ] **12. Code font in headings should be restricted to Reference pages**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide.mdx?plain=1#L98

The guideline “Don’t style headings, except when an identifier needs code font” is too broad. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#347-71-case-and-form allows code font in headings only on Reference pages. Minimal fix: revise the bullet to: “Don’t style headings; on Reference pages only, identifiers may use code font.”