### PR TITLE
[AI] fix: how-works.mdx

### DIFF
--- a/standard/tokens/nft/how-works.mdx
+++ b/standard/tokens/nft/how-works.mdx
@@ -10,14 +10,18 @@ In The Open Network (TON), there is a collection smart contract and a separate s
 Each NFT knows its collection, its index, and its item-specific part of the [metadata](/standard/tokens/metadata). The initial owner is assigned by the collection.
 
 ## NFT deployment
+
 The collection deploys NFT items with the initial owner and the item-specific metadata.
 
 ![NFT deployment](/standard/tokens/nft/pictures/nftDeploy.jpg)
 
 ## Verify that an NFT belongs to a collection
+
 ### High-level check
+
 You can do it with a single request:
 Not runnable
+
 ```ts
 const itemAddress = "EQD3LzasMd4GAmhIEkCQ4k6LnziTqNZ6VPtRfeZKHu0Fmkho";
 const collectionAddress = "EQCOtGTvX-RNSaiUavmqNcDeblB3-TloZpvYuyGOdFnfy-1N";
@@ -40,9 +44,11 @@ console.error(error);
 ```
 
 ### Low-level check
+
 First read the NFT item index. If the collection, for that index, returns the same NFT item address, the item belongs to the collection.
 
 Not runnable
+
 ```ts
 const itemAddress = "EQD3LzasMd4GAmhIEkCQ4k6LnziTqNZ6VPtRfeZKHu0Fmkho";
   const collectionAddress = "EQCOtGTvX-RNSaiUavmqNcDeblB3-TloZpvYuyGOdFnfy-1N";
@@ -125,12 +131,14 @@ const itemAddress = "EQD3LzasMd4GAmhIEkCQ4k6LnziTqNZ6VPtRfeZKHu0Fmkho";
   }
 ```
 
-
 ## Get full metadata for an NFT
+
 ### High-level check
+
 [Open metadata endpoint in playground](/ecosystem/rpc/ton-center-v3/accounts/get-account-metadata?playground=open)
 
 ### Low-level check
+
 Metadata is split into two parts: one part is stored on the item, another on the collection. Merge them.
 
 To get metadata for an NFT of a particular index, first fetch the NFT item address from the collection, then read the item metadata, then combine it with the collection metadata to get the final result.
@@ -140,24 +148,26 @@ To get metadata for an NFT of a particular index, first fetch the NFT item addre
 ## NFT transfer
 
 Not runnable
+
 ```text title="Signature"
 transfer(query_id, new_owner, response_destination, custom_payload, forward_amount, forward_payload)
 ```
 
 ### Transfer parameters
 
-| Parameter | Purpose | Value |
-| --- | --- | --- |
-| `query_id` | Request identifier | Any number (e.g., timestamp or counter), usually 0 |
-| `new_owner` | Address that should receive ownership | New owner address |
-| `response_destination` | Where to send confirmation and excess | Address to receive confirmation and excess |
-| `custom_payload` | Custom information passed to the NFT | Not used in standard NFTs; can be used by protocols |
-| `forward_amount` | Amount to forward to the new owner with a notification | 0 if no notification; >0 to send notification |
-| `forward_payload` | Message for the new owner | Any payload; leave empty if not required |
+| Parameter              | Purpose                                                | Value                                               |
+| ---------------------- | ------------------------------------------------------ | --------------------------------------------------- |
+| `query_id`             | Request identifier                                     | Any number (e.g., timestamp or counter), usually 0  |
+| `new_owner`            | Address that should receive ownership                  | New owner address                                   |
+| `response_destination` | Where to send confirmation and excess                  | Address to receive confirmation and excess          |
+| `custom_payload`       | Custom information passed to the NFT                   | Not used in standard NFTs; can be used by protocols |
+| `forward_amount`       | Amount to forward to the new owner with a notification | 0 if no notification; >0 to send notification       |
+| `forward_payload`      | Message for the new owner                              | Any payload; leave empty if not required            |
 
 The NFT updates its owner field and now belongs to the new owner.
 
 ### Optional notifications
+
 To send a notification to the new owner from the NFT, set a positive `forward_amount`.
 If you want to receive the excess (all remaining TON), set `response_destination` accordingly.
 
@@ -179,6 +189,7 @@ sequenceDiagram
 ```
 
 ## NFT sale
+
 Often a sale contract is created. First, the sale contract becomes the owner; upon successful purchase, it transfers the NFT to the buyer.
 
 ```mermaid
@@ -198,8 +209,10 @@ sequenceDiagram
 ```
 
 See also:
+
 - [NFT overview](/standard/tokens/nft/overview)
 - NFT Standard [TEP-62](https://github.com/ton-blockchain/TEPs/blob/1fbc23cac69723c53251f686ec90d81bf0e83443/text/0062-nft-standard.md)
 
 ## Best practices
+
 - Metadata referenced by each link should be permanent. If you need to change it, send a transaction that updates the reference.


### PR DESCRIPTION
- [ ] **1. Title uses title case; must be sentence case**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/how-works.mdx?plain=1#L2

The page title "NFT: How it Works" uses title case. Headings and titles must use sentence case (capitalize only the first word and proper nouns). Minimal fix: change to `title: "NFT: How it works"`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form

---

- [ ] **2. Sidebar title uses title case; should mirror sentence case**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/how-works.mdx?plain=1#L3

The `sidebarTitle` "How it Works" uses title case. Headings must use sentence case; sidebar labels should mirror in‑page headings. Minimal fix: change to `sidebarTitle: "How it works"`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-2-navigation-labels

---

- [ ] **3. Intro sentence is a run‑on and link text is non‑descriptive**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/how-works.mdx?plain=1#L6

The sentence joins two independent clauses without clear punctuation and uses the vague link text "why". Minimal fix: split and use descriptive link text: "…— each item is its own contract. See [contract sharding](/techniques/contract-sharding)."
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-1-commas-colons-semicolons; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text

---

- [ ] **4. Image alt text is not descriptive/cased consistently**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/how-works.mdx?plain=1#L8

Alt text "overview nft" is not descriptive and miscases the acronym. Minimal fix: change to `![NFT overview](...)`. Similarly, prefer clearer phrasing for other images (e.g., line 15 → `![NFT deployment](...)`, line 136 → `![NFT metadata](...)`).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#15-2-structure-and-tables

---

- [ ] **5. Task heading should be imperative, not a question**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/how-works.mdx?plain=1#L17

"How to verify an NFT belongs to a collection?" is a question. Task/procedure headings must start with an imperative verb. Minimal fix: "Verify that an NFT belongs to a collection" (no question mark).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form

---

- [ ] **6. Vague subheadings "High level" / "Low level" reduce navigability**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/how-works.mdx?plain=1#L18

"High level" and "Low level" do not make sense out of context and repeat later (lines 41, 128, 131). Minimal fix: make them descriptive, for example: "High‑level check" and "Low‑level check" (or "Check with API" / "Check on‑chain"). Keep sentence case.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-3-uniqueness-and-linkability

---

- [ ] **7. Code fence info string includes extraneous token (```ts TypeScript)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/how-works.mdx?plain=1#L20

The code block info string contains two tokens (`ts TypeScript`), which is non‑standard and can break highlighting/tooling. Minimal fix: use a single language identifier: start the fence with ```` ```ts ````; if a title is needed, use `title="TypeScript"` metadata.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-general-rules

---

- [ ] **8. Low‑level snippet likely non‑runnable; label as Partial snippet**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/how-works.mdx?plain=1#L44

The low‑level TypeScript snippet references `Cell`, `Address`, and `Buffer` without imports/context and is unlikely to be runnable as shown. Partial snippets must be labeled. Minimal fix: add a line above the fence: `Not runnable`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **9. Subheading capitalization: sentence case for "Transfer parameters"**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/how-works.mdx?plain=1#L144

Headings must use sentence case with the first word capitalized. Minimal fix: change `### transfer parameters` to `### Transfer parameters`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-1-case-and-form

---

- [ ] **10. Ambiguous subheading "Optional"; make it descriptive**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/how-works.mdx?plain=1#L157

Headings must make sense out of context. "Optional" alone is vague. Minimal fix: rename to a descriptive label such as `### Optional notifications` (reflects the content about `forward_amount` and `response_destination`).
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-3-uniqueness-and-linkability

---

- [ ] **11. Link text should be more specific than "Playground link for metadata"**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/how-works.mdx?plain=1#L129

Link text must be descriptive. Minimal fix: e.g., "Open get‑account‑metadata in playground" or "Open metadata endpoint in playground" linking to the same target.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text

---

- [ ] **12. Acronyms not expanded on first use (TON, NFT)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/how-works.mdx?plain=1#L6

On first mention, spell out the term and follow with the acronym. Minimal fix: "In The Open Network (TON), there is … for every non-fungible token (NFT) item …".

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **13. Signature block uses unsupported fence token and is unlabeled**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/how-works.mdx?plain=1#L140-L142

The block uses "```ts wrap" (unsupported) and shows a non-runnable signature. Minimal fix: add "Not runnable" above the block and switch to ```text title="Signature" or use ```ts only if the snippet is valid TypeScript.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-runnable-snippets

---

- [ ] **14. Ambiguous "we"; prefer direct instructions**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/how-works.mdx?plain=1#L132

"We need to merge them." uses ambiguous "we". Prefer direct second person or imperative. Minimal fix: "Merge them." or "You need to merge them." (keep concise and active).

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#4-voice-and-tone

---

- [ ] **15. Use placeholders for hard-coded addresses (optional improvement)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/how-works.mdx?plain=1#L21-L46

Examples should avoid hard-coded values where readers might copy/paste. Use neutral placeholders in code and define them on first use. Minimal fix: replace sample addresses with placeholders like `ITEM_ADDRESS` and `COLLECTION_ADDRESS`, and add brief definitions after the block.

Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-1-runnable-snippets

---

- [ ] **16. H2 not in imperative: “How to get full metadata of an NFT”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/how-works.mdx?plain=1#L127

Procedure headings must use the imperative and sentence case. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#7-headings-and-titles. Minimal fix: change to “Get full metadata for an NFT”.

---

- [ ] **17. Ambiguous slash (“confirmation/excess”) in table cell**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/how-works.mdx?plain=1#L150

Avoid ambiguous constructions like “and/or”; prefer clear wording. The slash here reads as “and/or”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#57-avoid-tautology-pleonasm-throat-clearing-and-circular-references. Minimal fix: change to “Address to receive confirmation and excess”.

---

- [ ] **18. External TEP link without internal canonical link alongside**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/how-works.mdx?plain=1#L186–189

Prefer internal docs first; when linking a TEP, also include the internal explanation page. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#125-external-references and #123-avoid-circularity-and-drift. Minimal fix: add an internal link alongside the TEP, e.g., “See also: [NFT overview](/standard/tokens/nft/overview)”, keeping the precise TEP link as the canonical spec.

---

- [ ] **19. Partial TypeScript snippets missing "Not runnable" label**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/how-works.mdx?plain=1#L20–39,44–124

Both TypeScript examples are not runnable as-is (e.g., rely on top-level `await`/unimported symbols). Partial snippets must be labeled explicitly. Minimal fix: add a line "Not runnable" above each block.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#10-2-partial-snippets

---

- [ ] **20. “See more” label deviates from standard “See also”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/how-works.mdx?plain=1

The concluding section uses “See more:” rather than the conventional “See also”. Use clear, standard section labels to aid scanning. Minimal fix: rename to “See also”.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#titles-and-headings

---

- [ ] **21. Compound adjectives in headings lack hyphens**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/how-works.mdx?plain=1

Headings “### High level” and “### Low level” use compound adjectives without hyphens. Hyphenate compound modifiers for clarity. Minimal fixes: “### High‑level” and “### Low‑level”. This relies on general English grammar for compound modifiers.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#titles-and-headings

---

- [ ] **22. Empty section: “## Best practices” has no content**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/standard/tokens/nft/how-works.mdx?plain=1

The page ends with “## Best practices” without any content. Empty headings harm structure and scannability. Minimal fix: remove the empty section or add concise, relevant content.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1-goals-and-principles (scannability) and #7-headings-and-titles (structure clarity)