### PR TITLE
[AI] fix: create-mini-app.mdx

### DIFF
--- a/ecosystem/tma/create-mini-app.mdx
+++ b/ecosystem/tma/create-mini-app.mdx
@@ -29,12 +29,12 @@ your application by sequentially prompting for the following information:
 
 ## Choose preferred technologies
 
-#### TMA SDKs
+### TMA SDKs
 
 - [@telegram-apps/sdk](https://www.npmjs.com/package/@telegram-apps/sdk)  – A TypeScript library for communication with Telegram Mini Apps
 - [@twa-dev/sdk](https://www.npmjs.com/package/@twa-dev/sdk) – This package allows you to work with the SDK as an npm package
 
-#### Frameworks
+### Frameworks
 
 - [React.js template](https://github.com/Telegram-Mini-Apps/reactjs-template)
 - [Next.js template](https://github.com/Telegram-Mini-Apps/nextjs-template)


### PR DESCRIPTION
- [ ] **1. Title does not follow How‑to pattern**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/create-mini-app.mdx?plain=1#L2

The page is a procedural How‑to but the frontmatter `title` is not in the required “How to …” form. Minimal fix: set `title: "How to create a Mini App with the CLI"` and add `sidebarTitle: "Create a Mini App with the CLI"` per the pattern. If a different task name is canonical, use that phrasing in sentence case. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#how-to-frontmatter-pattern (see “How‑to frontmatter pattern” in §16.1) and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#headings-and-titles (task headings must be imperative/sentence case).

---

- [ ] **2. Acronym “TMA” used before definition**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/create-mini-app.mdx?plain=1#L34

The heading “TMA SDKs” uses the acronym before it is defined on this page. Minimal fix: define on first mention in the body (“Telegram Mini Apps (TMA)”) or adjust the first occurrence to include the expansion; for example, in line 9 change to “Telegram Mini Apps (TMA) platform”. After defining once, later uses of “TMA” are fine. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#acronyms-and-terms (§5.3).

---

- [ ] **3. Acronym “CLI” not expanded on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/create-mini-app.mdx?plain=1#L8

“is a CLI tool” introduces “CLI” without expansion. Minimal fix: “is a command-line interface (CLI) tool…”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#acronyms-and-terms (§5.3).

---

- [ ] **4. Acronym “SDK” not expanded on first mention**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/create-mini-app.mdx?plain=1#L34

The first in-page use of “SDK” is in a heading. Minimal fix: make the heading “TMA software development kits (SDKs)” or add a brief parenthetical in the heading: “TMA SDKs (software development kits)”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#acronyms-and-terms (§5.3).

---

- [ ] **5. Code fence metadata malformed; language tag inconsistent with nearby pages**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/create-mini-app.mdx?plain=1#L16

Fence is “```bash npm icon="npm"” which includes an extra token after the language identifier. Minimal fix: use a single language identifier with the attribute, consistent with nearby pages, e.g., “```sh icon="npm"”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#code-and-command-examples (§10.1: fenced code blocks must specify a language). For the choice of `sh`, this follows nearby pages for consistency (https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/telegram-ui/overview.mdx?plain=1#L9).

---

- [ ] **6. Package name mismatch between description and command (needs confirmation)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/create-mini-app.mdx?plain=1#L17

The intro names `@telegram-apps/create-mini-app` (https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/create-mini-app.mdx?plain=1#L8), but the command uses `npx @telegram-apps/telegram-apps-tools@latest`. One of these is likely incorrect. Minimal fix (requires domain decision): either change the command to `npx @telegram-apps/create-mini-app@latest` to match the description, or update the intro to name the package actually invoked. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#goals-and-principles (Single source of truth; avoid conflicting duplicates) and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#code-and-command-examples (§10.1: examples must be precise and copy‑pasteable).

---

- [ ] **7. Procedural heading uses gerund; should be imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/create-mini-app.mdx?plain=1#L20

Heading “Creating a new application” uses a gerund. Minimal fix: “Create a new application”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#headings-and-titles (§7: task headings must start with an imperative verb; avoid gerunds).

---

- [ ] **8. Step heading is a noun phrase; should be imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/create-mini-app.mdx?plain=1#L25

Heading “Project directory name” is a label, not an action. Minimal fix: “Set the project directory name”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#headings-and-titles (§7: task headings must start with an imperative verb).

---

- [ ] **9. Step heading “Preferred technologies” should be imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/create-mini-app.mdx?plain=1#L32

Use an imperative action for task steps. Minimal fix: “Choose preferred technologies”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#headings-and-titles (§7: task headings must start with an imperative verb).

---

- [ ] **10. Step heading “Git remote repository URL” should be imperative; body uses lowercase “git”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/create-mini-app.mdx?plain=1#L44

Use an imperative action for the step, and capitalize the proper noun “Git” in the body. Minimal fix: change heading to “Enter the Git remote repository URL” and in lines 46–47 use “Git” (capital G) in both occurrences. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#headings-and-titles (§7: task headings must start with an imperative verb). For “Git” capitalization, this follows general technical writing conventions for proper nouns.

---

- [ ] **11. List formatting: stray tab/marker and unformatted literal default value**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/create-mini-app.mdx?plain=1#L29

The list item begins with “-\t**Default**: mini-app” (tab after `-`) and the literal default `mini-app` is not in code font. The explanatory sentence is split onto a separate paragraph. Minimal fix: “- **Default**: `mini-app`. The script creates a subfolder with this name in the current directory.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#lists (§6.4: list mechanics) and https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#code-styling (§6.3: literals must use code formatting).

---

- [ ] **12. Terminology inconsistency: “mini application” vs. “Mini App”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/create-mini-app.mdx?plain=1#L9

Use the canonical term consistently. Nearby pages use “Mini App(s)” (https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/overview.mdx?plain=1#L5). Minimal fix: replace “mini application” with “Mini App”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#acronyms-and-terms (§5.3: follow the project term bank/prevailing usage across docs).

---

- [ ] **13. Procedural section “Usage” should be imperative**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/create-mini-app.mdx?plain=1#L12

Task/procedure headings should be imperative. Minimal fix: “Run the CLI” (or “Use the CLI”) in sentence case. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#headings-and-titles (§7: task headings must start with an imperative verb).

---

- [ ] **14. Avoid “above” reference in procedures**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/create-mini-app.mdx?plain=1#L22

“The above command executes a script …” uses a relative “above” reference. Minimal fix: “The command runs a script that …”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.7-avoid-tautology-pleonasm-throat-clearing-and-circular-references (avoid “as mentioned above/below”; link or restate precisely).

---

- [ ] **15. Plural wording mismatch: only one command shown**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/create-mini-app.mdx?plain=1#L14

The text says “use one of the following scripts depending on your package manager,” but only a single command is shown. Minimal fix: change to “Run the following command:”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.2-plain-precise-wording (prefer precise wording; avoid ambiguity). If additional package managers are intended, this item needs a domain decision to add them.

---

- [ ] **16. Marketing phrasing in SDK description**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/create-mini-app.mdx?plain=1#L35

“A TypeScript library for seamless communication …” uses promotional wording (“seamless”). Minimal fix: “A TypeScript library for communication with Telegram Mini Apps.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#1.-goals-and-principles-reader-first-answer-first (technical sections MUST NOT contain marketing language).

---

- [ ] **17. List punctuation: sentence fragments should omit periods**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/create-mini-app.mdx?plain=1#L35

Bulleted descriptions under “TMA SDKs” are fragments ending with periods, while the frameworks list omits terminal punctuation. Minimal fix: remove terminal periods from the SDK bullets to match the rule for fragments. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6.4-lists (if items are not full sentences, omit terminal punctuation consistently).

---

- [ ] **18. Passive/future phrasing; prefer active present**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/create-mini-app.mdx?plain=1#L46

“This value will be used to connect …” uses future passive. Minimal fix: “The tool uses this value to connect the project to your remote Git repository.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.1-voice-tense-and-person (use active voice and present tense for instructions).

---

- [ ] **19. Terminology consistency: “folder” → “directory”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/ecosystem/tma/create-mini-app.mdx?plain=1#L27

The heading and surrounding text use “directory,” but this line says “folder.” Minimal fix: “Enter the name of the directory where the project files will be located.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5.3-acronyms-and-terms (follow canonical terminology; avoid introducing synonyms for the same concept).