### PR TITLE
[AI] fix: built-ins.mdx

### DIFF
--- a/language/func/built-ins.mdx
+++ b/language/func/built-ins.mdx
@@ -1,7 +1,7 @@
 ---
-title: "FunC reserved words and built-ins"
-sidebarTitle: "Reserved words and built-ins"
-noindex: "true"
+title: "FunC reserved keywords and built-ins"
+sidebarTitle: "Reserved keywords and built-ins"
+noindex: true
 ---
 
 import { Aside } from '/snippets/aside.jsx';
@@ -64,13 +64,11 @@ FunC reserves the following symbols and words. These cannot be used as identifie
 
 ## Built-ins
 
-This section covers extra language constructs that are not part of the core but are still important for functionality.
-Although they could be implemented in [stdlib.fc](/language/func/stdlib),
-keeping them as built-in features allows the FunC optimizer to work more efficiently.
+Built-ins are language constructs outside the core that the optimizer handles efficiently. Although they could be implemented in [the standard library](stdlib), keeping them built-in enables better optimization.
 
 In addition, FunC does not allow the built-in names in this section to be used as identifiers.
 However, there is an exception: [built-ins with non-symbolic names](#built-ins-with-non-symbolic-names) 
-*can* be used as identifiers for local variables.
+_can_ be used as identifiers for local variables.
 
 ### Built-ins with symbolic names
 
@@ -120,9 +118,7 @@ However, there is an exception: [built-ins with non-symbolic names](#built-ins-w
 
 `run_method0` &emsp; `run_method1` &emsp; `run_method2` &emsp; `run_method3`
 
-<Aside type="danger">
-   The description of each of these built-ins must be specified, together with an example of usage.
-</Aside>
+
 
 #### `throw`
 
@@ -153,11 +149,11 @@ The first argument is a parameter of any type, the second argument defines the e
 Parameterized version of `throw_unless`.
 The first argument is a parameter of any type, the second argument defines the error code, and the third argument is the condition.
 
-#### `~dump`
+#### `~dump` {#dump}
 
 `~dump` outputs a variable to the debug log.
 
-#### `~strdump`
+#### `~strdump` {#strdump}
 
 `~strdump` outputs a string to the debug log.
 
@@ -182,15 +178,12 @@ It uses a 513-bit intermediate result to prevent overflow if the final result fi
 
 `null?` checks if the given argument is `null`. In FunC, the value `null` belongs to the TVM type `Null`, which represents the absence of a value for certain atomic types. 
 See [null values](/language/func/types#null-values) for details.
+ 
 
 #### `touch` and `~touch`
 
-`touch` pushes a variable to the top of the stack. `~touch` is identical to `touch`, but it is adapted for use in [modifying syntax](/language/func/functions#modifying-methods). 
-
-<Aside type="danger">
-   Link for modifying syntax is missing.
-</Aside>
+`touch` pushes a variable to the top of the stack. `~touch` is identical to `touch`, but it is adapted for use in [modifying methods](functions#modifying-functions). 
 
 #### `at` 
 
-Function `at` returns the value of a tuple element at the specified position.
+The function `at` returns the value of a tuple element at the specified position.


### PR DESCRIPTION
- [ ] **1. Inconsistent terminology: “Reserved keywords” vs page title “reserved words”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/built-ins.mdx?plain=1#L2

The frontmatter uses “Reserved words” (title/sidebar), but the H2 heading reads “Reserved keywords”. For terminology discipline, use one term consistently on the page. Minimal fix: change `## Reserved keywords` to `## Reserved words` to match the title/sidebar. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **2. Italics delimiter uses asterisks instead of underscores**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/built-ins.mdx?plain=1#L73

The phrase `*can* be used as identifiers` uses `*...*`. House rule requires `_..._` for italics. Minimal fix: replace `*can*` with `_can_`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#6-2-quotation-marks-and-emphasis

---

- [ ] **3. Broken self-links to “~dump” and “~strdump” anchors**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/built-ins.mdx?plain=1#L119

List links point to `#dump` and `#strdump`, but the headings are ``#### `~dump` `` (line 156) and ``#### `~strdump` `` (line 160). These anchors are unlikely to resolve as `#dump`/`#strdump` without explicit IDs. Minimal fix: add explicit IDs to the headings: ``#### `~dump` {#dump}`` and ``#### `~strdump` {#strdump}``, keeping the list links unchanged. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format

---

- [ ] **4. Incorrect anchor and editorial aside for “modifying syntax”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/built-ins.mdx?plain=1#L188

The link uses `/language/func/functions#modifying-methods`, but the target page’s section is “Modifying functions” (`#modifying-functions`) in `https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/functions.mdx?plain=1#L166`. Also, an inline `<Aside type="danger">Link for modifying syntax is missing.</Aside>` is an internal editorial note that leaks to readers. Minimal fixes: (a) update the link to `functions#modifying-functions` (relative, correct anchor), and (b) remove the editorial Aside. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format; https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#8-2-structure-for-scanning

---

- [ ] **5. Use relative internal links instead of absolute paths**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/built-ins.mdx?plain=1#L68

Internal links use absolute site paths (e.g., `[stdlib.fc](/language/func/stdlib)`, `[null values](/language/func/types#null-values)`). Prefer relative links for stability. Minimal fixes: change to `[stdlib.fc](stdlib)` and `[null values](types#null-values)`. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-3-link-targets-and-format

---

- [ ] **6. Editorial Aside about missing built-in descriptions appears to readers**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/built-ins.mdx?plain=1#L123

`<Aside type="danger">The description of each of these built-ins must be specified, together with an example of usage.</Aside>` is an internal TODO that does not help the reader and adds noise. Minimal fix: remove this Aside (or convert it into actionable content with real descriptions/examples, which requires domain input). Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#8-2-structure-for-scanning

---

- [ ] **7. Possible inconsistency in `throw_arg` arity vs description (needs confirmation)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/built-ins.mdx?plain=1#L143

Text says `throw_arg` is “unconditional” but then lists three arguments including a “condition”. Cross-doc example shows `throw_arg(-1, 100)` with two arguments (https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/statements.mdx?plain=1#L351-L364). Minimal fix (requires domain confirmation): correct the `throw_arg` description to match the actual signature and behavior (likely two arguments) or clarify parameters explicitly. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-4-avoid-circularity-and-drift (single source of truth) and style-of-issues “Truthfulness and internal consistency” per integrator instructions

---

- [ ] **8. Throat-clearing opener (meta introduction)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/built-ins.mdx?plain=1#L67

"This section covers extra language constructs…" describes the section instead of delivering the information. Minimal fix: replace with a direct, answer-first sentence (e.g., "Built-ins are language constructs outside the core that the optimizer handles efficiently. Although they could be implemented in the standard library, keeping them built-in enables better optimization."). Keep concise and factual.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-7-avoid-tautology-pleonasm-throat-clearing-and-circular-references

---

- [ ] **9. Grammar: missing article in sentence**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/built-ins.mdx?plain=1#L196

"Function `at` returns…" should be "The function `at` returns…" for standard English usage. Minimal fix: add "The" at the beginning. This follows basic English grammar (general knowledge) and improves readability.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#17-4-proofread

---

- [ ] **10. Frontmatter boolean quoted as string**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/built-ins.mdx?plain=1#L4

`noindex: "true"` uses a quoted string instead of a boolean. Frontmatter guidance shows `noindex: true`; booleans in YAML frontmatter should be unquoted (general knowledge). Minimal fix: change to `noindex: true`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#16-2-navigation-labels

---

- [ ] **11. Terminology consistency: “modifying syntax” phrasing**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/built-ins.mdx?plain=1#L188

Text says "adapted for use in modifying syntax," but the canonical term on the referenced page is "Modifying functions" and it describes "modifying methods" usage. Minimal fix: change phrase to "modifying methods" and link to `functions#modifying-functions`.
Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms

---

- [ ] **12. Link text should be descriptive (“stdlib.fc”)**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/built-ins.mdx?plain=1#L68

Link text “stdlib.fc” is terse/file‑centric; the guide requires descriptive link text. Minimal fix: change to “standard library” while keeping the same target page. Example: “Although they could be implemented in [the standard library](/language/func/stdlib), …”. Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#12-1-link-text

---

- [ ] **13. Title/sidebar use “reserved words” vs. “reserved keywords”**

https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/built-ins.mdx?plain=1#L2

The frontmatter `title` and `sidebarTitle` use “reserved words,” while the page H2 is “Reserved keywords,” and other docs use “reserved keyword” (see https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/language/func/literals.mdx?plain=1#L26). The guide has no glossary entry for this term; prefer the dominant usage across docs. Minimal fix: change `title` to “FunC reserved keywords and built-ins” and `sidebarTitle` to “Reserved keywords and built-ins.” Rule: https://github.com/tact-lang/mintlify-ton-docs/blob/53b6c23461988d04871b01bac537f21fbd21f860/contribute/style-guide-extended.mdx?plain=1#5-3-acronyms-and-terms