### PR TITLE
feat/fix(whitepaper): convert ton latex to web whitepaper v2

### DIFF
--- a/foundations/whitepapers/ton.mdx
+++ b/foundations/whitepapers/ton.mdx
@@ -1528,7 +1528,7 @@ When any node wants to look up the value of a key $K$, it first creates a set $S
 
 If the value of some key $K$ is to be set, the same procedure is run for $s'\geq s$, with $\text{Find\_Node}$ queries instead of $\text{Find\_Value}$, to find $s$ nearest nodes to $K$. Afterwards, $\text{Store}$ queries are sent to all of them.
 
-There are some less important details in the implementation of a Kademlia-like DHT (for example, any node should look up $s$ nearest nodes to itself, say, once every hour, and re-publish all stored keys to them by means of $\text{STORE}$ queries). We will ignore them for the time being.
+There are some less important details in the implementation of a Kademlia-like DHT (for example, any node should look up $s$ nearest nodes to itself, say, once every hour, and re-publish all stored keys to them by means of $\text{Store}$ queries). We will ignore them for the time being.
 
 #### 3.2.8. Booting a Kademlia node
 


### PR DESCRIPTION
Converted the Ton whitepaper from the original LaTeX source ([ton.tex](https://github.com/ton-blockchain/ton/blob/master/doc/ton.tex)) to Markdown.
This version replaces the earlier PDF-based conversion.

This closes #115 
### **Known differences (to be fixed in future releases):**

* Blackboard bold (`\mathbb{}`) fixes ([[#1066](https://github.com/ton-org/docs/issues/1066)](https://github.com/ton-org/docs/issues/1066))
* Italic formatting consistency — deciding when to use `\mathit{}` vs Markdown italics ([[#1068](https://github.com/ton-org/docs/issues/1068)](https://github.com/ton-org/docs/issues/1068))
* Render issues for formulas on small screens in the web whitepaper  (scroll visibility and overflow) ([[#1069](https://github.com/ton-org/docs/issues/1069)](https://github.com/ton-org/docs/issues/1069))
