### PR TITLE
fix(landing): remove unnecessary focus from sections

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -328,7 +328,7 @@ export const JourneyStep = ({ title, icon, iconType, href, cta, children }) => {
     </Journey>
     <div className="text-left sm:text-center">
       <p className="mt-4 text-pretty text-base sm:text-lg prose prose-gray dark:prose-invert">
-        Looking for something else? Search documentation <kbd>Ctrl&nbsp;+&nbsp;K</kbd> and ask AI right there,
+        Looking for something else? Search documentation with <kbd>Ctrl&nbsp;+&nbsp;K</kbd> and ask AI right there,
         or open the assistant panel by pressing <kbd>Ctrl&nbsp;+&nbsp;I</kbd>. If nothing was found, <a href="#community" className="font-normal text-base sm:text-lg">ask the community</a> of TON developers, builders and enthusiasts.
       </p>
     </div>


### PR DESCRIPTION
Closes #892. A Safari-compatible fix, keeping `tabindex` intact and only disabling the visible focus outline.