### PR TITLE
fix: AI review for PR 1028

### DIFF
--- a/languages/func/built-ins.mdx
+++ b/languages/func/built-ins.mdx
@@ -178,7 +178,7 @@ In FunC, the value `null` belongs to the TVM type `Null`, which represents the a
 
 #### `touch` and `~touch`
 
-`touch` pushes a variable to the top of the stack. `~touch` is identical to `touch`, but it is adapted for use in [modifying syntax](/languages/func/functions#modifying-methods).
+`touch` pushes a variable to the top of the stack. `~touch` is identical to `touch`, but it is adapted for use in [modifying notation](/languages/func/expressions#modifying-notation).
 
 #### `at`
 

--- a/languages/func/functions.mdx
+++ b/languages/func/functions.mdx
@@ -120,7 +120,7 @@ In FunC, function specifiers modify the behavior of functions. There are three t
 1. Either `inline` or `inline_ref`, but not both
 1. `method_id`
 
-One, multiple, or none can be used in a function declaration. However, they must appear in the order of the above list, e.g., `impure` must come before `inline` and `method_id, `inline\_ref`must come before`method\_id\`, etc.
+One, multiple, or none can be used in a function declaration. However, they must appear in the order of the above list, e.g., `impure` must come before `inline` and `method_id`, `inline_ref` must come before `method_id`, etc.
 
 ### `impure` specifier
 


### PR DESCRIPTION
A follow-up to #1028: fixed a broken link and an improper use of inline code.