### PR TITLE
Descriptions for `run_methodX` functions

### DIFF
--- a/languages/func/built-ins.mdx
+++ b/languages/func/built-ins.mdx
@@ -145,7 +145,7 @@ apply(+);   ;; DOES NOT COMPILE
 
 [`touch2`](#touch2)   [`~touch2`](#touch2-2)   [`~dump`](#dump)   [`~strdump`](#strdump)
 
-`run_method0`   `run_method1`   `run_method2`   `run_method3`
+[`run_method0`](#run-method0)   [`run_method1`](#run-method1)   [`run_method2`](#run-method2)   [`run_method3`](#run-method3)
 
 #### `divmod`
 
@@ -529,3 +529,112 @@ Outputs to the debug log the ASCII string encoded in slice `s`. It returns the a
 [Modifying notation](/languages/func/expressions#modifying-notation) can be used on this function.
 
 If the argument `s` is not a slice containing ASCII characters, the debug log will show an error.
+
+#### `run_method0`
+
+```func
+() run_method0 (int method_id)
+```
+
+Executes the 0 argument function with [id](/languages/func/functions#method-id-specifier) `method_id`. The function with id `method_id` must have a signature of the form:
+
+```func
+() some_function()
+```
+
+which receives 0 arguments and returns nothing.
+
+The `run_method0` is useful for dynamically executing methods at run-time.
+For example, receiving the method id to execute in a incoming internal message.
+
+<Aside>
+  Recall that method ids can be explicitly set when declaring functions using the [`method_id` specifier](/languages/func/functions#method-id-specifier):
+
+  ```func
+  () test() method_id(1234)
+  ```
+
+  So that later, it can be invoked as:
+
+  ```func
+  run_method0(1234);   ;; executes function test
+  ```
+</Aside>
+
+<Aside
+  type="danger"
+>
+  The FunC compiler does not check that the function to execute in `run_method0` has the correct number of arguments and
+  that it returns `()`. This is responsibility of the programmer.
+</Aside>
+
+#### `run_method1`
+
+```func
+forall X -> () run_method1 (int method_id, X arg1)
+```
+
+Executes the 1 argument function with [id](/languages/func/functions#method-id-specifier) `method_id`, and passes `arg1` as argument to the function.
+The function with id `method_id` must have a signature of the form:
+
+```func
+() some_function(T a1)
+```
+
+which receives 1 argument and returns nothing. Type `T` must coincide with the type of the argument `arg1` provided in `run_method1`.
+
+For example, under the assumption that `1234` is the id of function `test`, invoking:
+
+```func
+;; The argument "a" is a slice containing the ASCII character 'a'
+run_method1(1234, "a");   
+```
+
+requires that `test` has the signature:
+
+```func
+() test(slice s) 
+```
+
+As with [`run_method0`](#run-method0), function `run_method1` is useful for dynamically executing 1 argument methods at run-time.
+
+<Aside
+  type="danger"
+>
+  The FunC compiler does not check that the function to execute in `run_method1` has the correct number of arguments,
+  that it returns `()`, and that the types of arguments in `run_method1` and the function to execute coincide. This is responsibility of the programmer.
+</Aside>
+
+#### `run_method2`
+
+```func
+forall X, Y -> () run_method2 (int method_id, X arg1, Y arg2)
+```
+
+Executes the 2 argument function with [id](/languages/func/functions#method-id-specifier) `method_id`. The function with id `method_id` must have a signature of the form:
+
+```func
+() some_function(T1 a1, T2 a2)
+```
+
+which receives 2 arguments and returns nothing. Type `T1` must coincide with the type of the argument `arg1` provided in `run_method2`,
+and similarly for type `T2`.
+
+The same observations and warnings apply as with [`run_method1`](#run-method1).
+
+#### `run_method3`
+
+```func
+forall X, Y, Z -> () run_method3 (int method_id, X arg1, Y arg2, Z arg3)
+```
+
+Executes the 3 argument function with [id](/languages/func/functions#method-id-specifier) `method_id`. The function with id `method_id` must have a signature of the form:
+
+```func
+() some_function(T1 a1, T2 a2, T3 a3)
+```
+
+which receives 3 arguments and returns nothing. Type `T1` must coincide with the type of the argument `arg1` provided in `run_method3`,
+and similarly for types `T2` and `T3`.
+
+The same observations and warnings apply as with [`run_method1`](#run-method1).


### PR DESCRIPTION
Closes #1123

I am not sure if I should mention in the docs bug https://github.com/ton-blockchain/ton/issues/1883