### PR TITLE
fix(foundations/whitepapers/tblkch.pdf): Fix a formula for the number of bytes in the standard cell representation

### DIFF
--- a/foundations/whitepapers/tblkch.mdx
+++ b/foundations/whitepapers/tblkch.mdx
@@ -61,7 +61,7 @@ where $[A]$ equals one when condition $A$ is true, and zero otherwise.
 
 - Finally, $r$ references to other cells follow. Each reference is normally represented by 32 bytes containing the $\text{Sha256}$ hash of the referenced cell, computed as explained below in [1.1.4](#1-1-4-the-sha256-hash-of-a-cell).
 
-In this way, the standard representation $\text{CellRepr}(c)$ of a cell $c$ with $l$ data bits and $r$ references is $2+\lfloor l/8\rfloor+\lceil l/8\rceil+32r$ bytes long.
+In this way, the standard representation $\text{CellRepr}(c)$ of a cell $c$ with $l$ data bits and $r$ references is $2+\lceil l/8\rceil+32r$ bytes long.
 
 ### 1.1.4. The Sha256 hash of a cell
 


### PR DESCRIPTION
Closes #565 