### PR TITLE
chore: set the `canonical` url

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -584,6 +584,11 @@
       "description": "Maybe you were looking for one of these pages below?"
     }
   },
+  "seo": {
+    "metatags": {
+      "canonical": "https://docs.ton.org"
+    }
+  },
   "redirects": [
     {
       "source": "/v3/concepts/dive-into-ton/introduction",


### PR DESCRIPTION
Closes #1325. Well, image cache did get updated already, but just to be sure, and for a better SEO, it's good to have a canonical URL set up right.