### PR TITLE
feat(ci): add `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+      timezone: "Etc/UTC"
+    versioning-strategy: increase
+    allow:
+      - dependency-name: "cspell"
+      - dependency-name: "husky"
+      - dependency-name: "mint"
+    ignore:
+      - dependency-name: "remark*"
+      - dependency-name: "unified*"
+      - dependency-name: "unist*"
+      - dependency-name: "string*"


### PR DESCRIPTION
Closes #1485

After this is merged, someone with sufficient permissions should enable Dependabot for this repository:

<img width="955" height="391" alt="image" src="https://github.com/user-attachments/assets/364ec231-9cb7-41cc-b130-310e104588ef" />
