### PR TITLE
feat(ci): add workflow to validate size and titles of pull requests, as well as number of linked issues

### DIFF
--- a/.github/workflows/bouncer.yml
+++ b/.github/workflows/bouncer.yml
@@ -211,7 +211,7 @@ jobs:
           script: |
             const maxIssuesAllowed = Number(process.env.MAX_ISSUES_PER_PR ?? '3');
             const body = context.payload.pull_request.body || '';
-            const closePatterns = /\b(?:close[sd]?|fixes|fixed|resolve[sd]?)\s+(?:https?:\/\/github\.com\/|[a-z0-9\-\_\/]*#\d+)/gi;
+            const closePatterns = /\b(?:close[sd]?|fixes|fixed|resolve[sd]?|towards)\s+(?:https?:\/\/github\.com\/|[a-z0-9\-\_\/]*#\d+)/gi;
             const issueCount = [...body.matchAll(closePatterns)].length;
             if (issueCount > maxIssuesAllowed) {
               core.setFailed(`This pull request attempts to close ${issueCount} issues, while the maximum number allowed is ${maxIssuesAllowed}.`);


### PR DESCRIPTION
Closes #1444.

Notice that `pull_request_target` workflows run in the context of the **base** of the pull request, i.e., they use whatever's on the `main` branch. Since this workflow isn't present there, it won't run in this PR.

I've tested this CI with `pull_request` here (worked for maintainers only), and then tested it in my own repo+fork playgrounds, where it worked for all PRs, whether from forks or not.

Finally, notice the JavaScript examples right in the YAML — I cannot move them elsewhere under the premise that there should be **no** checkouts in `pull_request_target` workflows to keep them secure. And no cache use either.

<img width="916" height="185" alt="image" src="https://github.com/user-attachments/assets/480a58be-3919-496d-aac8-6415eaaec4c8" />


It's quite easy to enable JS highlighting there in editors that operate on Tree-sitter, such as Zed or Helix (screenshot is outdated):

<img width="881" height="336" alt="image" src="https://github.com/user-attachments/assets/b27ea98b-3e25-4c9a-90b0-1fd6552a2677" />
