### PR TITLE
chore(ci): decrease the amount of scripting in `bouncer.yml` and stop posting messages on new pushes

### DIFF
--- a/.github/workflows/bouncer.yml
+++ b/.github/workflows/bouncer.yml
@@ -127,7 +127,6 @@ jobs:
 
   enforce-better-descriptions:
     name: "Title and description"
-    if: github.event.action == 'opened' || github.event.action == 'edited'
     runs-on: ubuntu-latest
     steps:
       # pr title check
@@ -137,7 +136,8 @@ jobs:
         with:
           script: |
             const title = context.payload.pull_request.title;
-            const pattern = /^(revert: )?(feat|fix|chore|refactor|test)(?:\/(feat|fix|chore|refactor|test))?!?(\(.+?\))?!?: [a-z].{1,200}/;
+            const types = 'feat|fix|chore|refactor|test';
+            const pattern = new RegExp(`^(revert: )?(${types})(?:\\/(${types}))?!?(\\([^\\)]+\\))?!?: [a-zA-Z].{1,200}`);
             const matches = title.match(pattern) !== null;
             if (!matches) {
               core.setFailed([


### PR DESCRIPTION
Closes #1497.

Stopped posting messages on new pushes in the PR — they are in the workflow outputs now. This significantly reduced the JS code used in the workflow, to the point where it's not really a win even if we manage to extract it elsewhere.

Also made the wording of workflow outputs be a bit smoother ­— no more "until then your PR is doomed and you're failure" type stuff. It's now more chill and explanatory, but still concise.