### PR TITLE
chore: update link of `royalty-distributor` in nft 2.0

### DIFF
--- a/standard/tokens/nft/nft-2.0.mdx
+++ b/standard/tokens/nft/nft-2.0.mdx
@@ -218,7 +218,7 @@ fun onInternalMessage(in: InMessage) {
 }
 ```
 
-For a reference implementation of royalty distribution logic, see the [open-source royalty distributor contract](https://github.com/ton-community/royalty-distributor) on GitHub.
+For a reference implementation of royalty distribution logic, see the [open-source royalty distributor contract](https://github.com/ton-org/royalty-distributor) on GitHub.
 
 ## Ecosystem products requirements
 


### PR DESCRIPTION
closes https://github.com/ton-org/docs/issues/1517