### PR TITLE
feat(get-support): add link to ton monorepo

### DIFF
--- a/get-support.mdx
+++ b/get-support.mdx
@@ -40,7 +40,6 @@ Miscellaneous:
 - [TON Security Bug Bounty bot in Telegram](https://t.me/ton_bugs_bot) - send general blockchain security reports to this Telegram bot.
 - [HackenProof](https://hackenproof.com/programs/ton) - websites, web apps, and Telegram mini-apps operated by TON Foundation.
 
-
 ## GitHub repository
 
 - [Main TON monorepo](https://github.com/ton-blockchain/ton) - source code for the node and validator, lite-client, tonlib, FunC compiler, and related tools.


### PR DESCRIPTION
closes https://github.com/ton-org/docs/issues/1598 

also removed the section of TON Hubs 