### PR TITLE
fix: typo in `bouncer.yml`

### DIFF
--- a/.github/workflows/bouncer.yml
+++ b/.github/workflows/bouncer.yml
@@ -60,7 +60,7 @@ jobs:
               per_page: 100,
             });
             const filtered = files.filter((f) =>
-              f.match(/\.mdx?$/) !== null &&
+              f.filename.match(/\.mdx?$/) !== null &&
               !f.filename.startsWith('tvm/instructions.mdx') &&
               !f.filename.startsWith('snippets'),
             );


### PR DESCRIPTION
Towards #1263 (a follow-up)