### PR TITLE
fix(walletkit): pass optional payload BoC as a Base64-encoded string

### DIFF
--- a/ecosystem/ton-connect/walletkit/web/toncoin.mdx
+++ b/ecosystem/ton-connect/walletkit/web/toncoin.mdx
@@ -280,7 +280,7 @@ Transactions can be created directly from the wallet service (not from dApps) an
 This example should be modified according to the wallet service's logic:
 
 ```ts title="TypeScript"
-import { type TONTransferRequest } from '@ton/walletkit';
+import type { TONTransferRequest, Base64String } from '@ton/walletkit';
 
 async function sendToncoin(
   // Sender's TON `walletId` as a string
@@ -292,7 +292,7 @@ async function sendToncoin(
   // Optional comment string
   comment?: string,
   // Optional payload body as a BoC in Base64-encoded string
-  payload?: string,
+  payload?: Base64String,
 ) {
   if (comment && payload) {
     console.error('Cannot attach both a comment or a payload body');
@@ -309,7 +309,8 @@ async function sendToncoin(
     recipientAddress: recipientAddress,
     transferAmount: nanoAmount.toString(),
     // Optional comment OR payload, not both
-    ...(comment && { comment: comment }),
+    ...(comment && { comment }),
+    ...(payload && { payload }),
   }
 
   // Build transaction content


### PR DESCRIPTION
Closes #1770