### PR TITLE
fix: change `hipo.fi` to `hipo.finance`

### DIFF
--- a/ecosystem/staking/overview.mdx
+++ b/ecosystem/staking/overview.mdx
@@ -54,7 +54,7 @@ Liquid staking protocols tokenize staked positions, enabling stakers to receive 
 - Withdrawal: 36-72 hours cooldown
 - Centralized validation
 
-[**Hipo**](https://hipo.fi):
+[**Hipo**](https://hipo.finance):
 
 - Minimum stake: Varies
 - Liquid token: hTON


### PR DESCRIPTION
hipo.fi is for sale now. Current site is hipo.finance

Closes #1795.