### PR TITLE
fix(deep-links): missing header level for Tonscan Testnet

### DIFF
--- a/ecosystem/wallet-apps/deep-links.mdx
+++ b/ecosystem/wallet-apps/deep-links.mdx
@@ -308,7 +308,7 @@ https://tonscan.org/tx/<lt as int>:<hash as base64url>:<account address>
 https://tonscan.org/tx/63333243000002:rujRhaDI9zx4e_GHLullmsU84RqQsWs4SFangh7_jCk:Ef8zMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzM0vF
 ```
 
-### Testnet
+#### Testnet
 
 ```bash Tonscan Testnet link
 https://testnet.tonscan.org/tx/<lt as int>:<hash as base64url>:<account address>


### PR DESCRIPTION
Towards #307