### PR TITLE
Update contract-getters.mdx

### DIFF
--- a/languages/tolk/features/contract-getters.mdx
+++ b/languages/tolk/features/contract-getters.mdx
@@ -44,7 +44,7 @@ struct JettonWalletDataReply {
     jettonWalletCode: cell
 }
 
-get fun get_wallet_data(): JettonWalletDataReply {
+get fun walletData(): JettonWalletDataReply {
     val storage = lazy WalletStorage.load();
 
     return {
@@ -65,7 +65,7 @@ Use [`lazy` loading](/languages/tolk/features/lazy-loading) for [contract storag
 Get methods can accept parameters. Parameters use the same syntax as regular functions:
 
 ```tolk
-get fun get_wallet_address(ownerAddress: address): address {
+get fun walletAddress(ownerAddress: address): address {
     // ...
 }
 ```


### PR DESCRIPTION
Just a couple of lines above, it says that camelCase should be used for getter names.